### PR TITLE
#164 Add Support for Batch Transactions

### DIFF
--- a/src/core/Contract.ts
+++ b/src/core/Contract.ts
@@ -3,7 +3,10 @@ import ProviderService, {
 } from "../services/provider/ProviderService";
 import WalletController from "../controllers/WalletController";
 import { Options } from "./NearWalletSelector";
-import { SignAndSendTransactionParams } from "../wallets/Wallet";
+import {
+  SignAndSendTransactionParams,
+  SignAndSendTransactionsParams,
+} from "../wallets/Wallet";
 
 class Contract {
   private readonly options: Options;
@@ -46,6 +49,18 @@ class Contract {
       receiverId: this.options.contract.accountId,
       actions,
     });
+  }
+
+  async signAndSendTransactions({
+    transactions,
+  }: SignAndSendTransactionsParams) {
+    const wallet = this.controller.getSelectedWallet();
+
+    if (!wallet) {
+      throw new Error("Wallet not selected!");
+    }
+
+    return wallet.signAndSendTransactions({ transactions });
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,27 @@
 import NearWalletSelector from "./core/NearWalletSelector";
 
+export { Options } from "./core/NearWalletSelector";
+
+export {
+  Wallet,
+  WalletType,
+  BrowserWallet,
+  InjectedWallet,
+  HardwareWallet,
+  AccountInfo,
+} from "./wallets/Wallet";
+
+export {
+  Action,
+  ActionType,
+  CreateAccountAction,
+  DeployContractAction,
+  FunctionCallAction,
+  TransferAction,
+  StakeAction,
+  AddKeyAction,
+  DeleteKeyAction,
+  DeleteAccountAction,
+} from "./wallets/actions";
+
 export default NearWalletSelector;

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,4 +24,6 @@ export {
   DeleteAccountAction,
 } from "./wallets/actions";
 
+export { Transaction } from "./wallets/transactions";
+
 export default NearWalletSelector;

--- a/src/wallets/Wallet.ts
+++ b/src/wallets/Wallet.ts
@@ -1,6 +1,7 @@
 import { Options } from "../core/NearWalletSelector";
 import ProviderService from "../services/provider/ProviderService";
 import { Emitter } from "../utils/EventsHandler";
+import { Transaction } from "./transactions";
 import { Action } from "./actions";
 
 export interface WalletOptions {
@@ -12,6 +13,10 @@ export interface WalletOptions {
 export interface SignAndSendTransactionParams {
   receiverId: string;
   actions: Array<Action>;
+}
+
+export interface SignAndSendTransactionsParams {
+  transactions: Array<Transaction>;
 }
 
 export interface AccountInfo {
@@ -57,6 +62,12 @@ interface BaseWallet {
   // Signs a list of actions before sending them via an RPC endpoint.
   signAndSendTransaction(
     params: SignAndSendTransactionParams
+  ): Promise<unknown>;
+
+  // TODO: Determine standardised response.
+  // Signs a list of transactions before sending them via an RPC endpoint.
+  signAndSendTransactions(
+    params: SignAndSendTransactionsParams
   ): Promise<unknown>;
 }
 

--- a/src/wallets/actions.ts
+++ b/src/wallets/actions.ts
@@ -80,6 +80,8 @@ export type Action =
   | DeleteKeyAction
   | DeleteAccountAction;
 
+export type ActionType = Action["type"];
+
 const getAccessKey = (permission: AddKeyPermission) => {
   if (permission === "FullAccess") {
     return transactions.fullAccessKey();

--- a/src/wallets/browser/NearWallet.ts
+++ b/src/wallets/browser/NearWallet.ts
@@ -5,6 +5,7 @@ import { Options } from "../../core/NearWalletSelector";
 import { Emitter } from "../../utils/EventsHandler";
 import { logger } from "../../services/logging.service";
 import { transformActions } from "../actions";
+import { transformTransactions } from "../transactions";
 import { setSelectedWalletId } from "../helpers";
 import { LOCAL_STORAGE_SELECTED_WALLET_ID } from "../../constants";
 import { nearWalletIcon } from "../icons";
@@ -13,6 +14,7 @@ import {
   BrowserWallet,
   BrowserWalletType,
   SignAndSendTransactionParams,
+  SignAndSendTransactionsParams,
   WalletOptions,
 } from "../Wallet";
 
@@ -120,6 +122,20 @@ class NearWallet implements BrowserWallet {
     return account.signAndSendTransaction({
       receiverId,
       actions: transformActions(actions),
+    });
+  };
+
+  signAndSendTransactions = ({
+    transactions,
+  }: SignAndSendTransactionsParams) => {
+    logger.log("NearWallet:signAndSendTransactions", { transactions });
+
+    const account = this.wallet.account();
+
+    // @ts-ignore
+    // near-api-js doesn't have this method declared in TypeScript.
+    return account.requestSignTransactions({
+      transactions: transformTransactions(transactions),
     });
   };
 }

--- a/src/wallets/hardware/LedgerWallet.ts
+++ b/src/wallets/hardware/LedgerWallet.ts
@@ -292,6 +292,14 @@ class LedgerWallet implements HardwareWallet {
       return JSON.parse(Buffer.from(successValue, "base64").toString());
     });
   };
+
+  // TODO: Not entirely sure how we should implement this. Is it simply a case of sequentially
+  //  calling provider.sendTransaction? If so, this seems to completely miss the point of
+  //  transactions (from a classic database mental modal)? I would expect this method be to
+  //  used to ensure atomicity.
+  signAndSendTransactions = async () => {
+    throw new Error("Not implemented");
+  };
 }
 
 export default LedgerWallet;

--- a/src/wallets/injected/SenderWallet.ts
+++ b/src/wallets/injected/SenderWallet.ts
@@ -16,8 +16,10 @@ import {
   InjectedWallet,
   InjectedWalletType,
   SignAndSendTransactionParams,
+  SignAndSendTransactionsParams,
   WalletOptions,
 } from "../Wallet";
+import { Transaction } from "../transactions";
 
 declare global {
   interface Window {
@@ -186,7 +188,16 @@ class SenderWallet implements InjectedWallet {
       );
     }
 
-    return actions.map((x) => x.params);
+    return actions.map((action) => action.params);
+  };
+
+  private transformTransactions = (transactions: Array<Transaction>) => {
+    return transactions.map((transaction) => {
+      return {
+        receiverId: transaction.receiverId,
+        actions: this.transformActions(transaction.actions),
+      };
+    });
   };
 
   signAndSendTransaction = async ({
@@ -207,6 +218,17 @@ class SenderWallet implements InjectedWallet {
 
         return res;
       });
+  };
+
+  // TODO: Assuming a similar response to signAndSendTransaction. Might need to add similar error handling.
+  signAndSendTransactions = async ({
+    transactions,
+  }: SignAndSendTransactionsParams) => {
+    logger.log("SenderWallet:signAndSendTransactions", { transactions });
+
+    return this.wallet.requestSignTransactions({
+      transactions: this.transformTransactions(transactions),
+    });
   };
 }
 

--- a/src/wallets/transactions.ts
+++ b/src/wallets/transactions.ts
@@ -1,0 +1,29 @@
+import * as nearApi from "near-api-js";
+import { Action, transformActions } from "./actions";
+
+export interface Transaction {
+  signerId: string;
+  publicKey: string;
+  receiverId: string;
+  nonce: number;
+  actions: Array<Action>;
+  blockHash: Uint8Array;
+}
+
+export const transformTransactions = (transactions: Array<Transaction>) => {
+  const { utils } = nearApi;
+
+  return transactions.map((transaction) => {
+    const { signerId, publicKey, receiverId } = transaction;
+    const { nonce, actions, blockHash } = transaction;
+
+    return nearApi.transactions.createTransaction(
+      signerId,
+      utils.PublicKey.from(publicKey),
+      receiverId,
+      nonce,
+      transformActions(actions),
+      blockHash
+    );
+  });
+};


### PR DESCRIPTION
## This PR Includes

- Added support for `signAndSendTransactions` NEAR Wallet & Sender Wallet.

## Notes

- I'm struggling to understand how we might implement this for Ledger Wallet.
  - The `near-api-js` docs seem to [confuse Transactions with Actions](https://docs.near.org/docs/api/naj-cookbook#batch-transactions).
  - There's [no dedicated RPC method for multiple transactions](https://near.github.io/near-api-js/classes/providers_json_rpc_provider.jsonrpcprovider.html#sendtransaction). Surely it would defeat the purpose of batch transactions if we simply call `sendTransaction` sequentially - we would lack atomicity.
- [Sender Wallet only supports `receiverId` and `actions` for Transactions](https://docs.senderwallet.io/guide/sending-transactions#sign-and-send-multiple-transactions) compared to NEAR Wallet. There's again (like `signAndSendTransaction`) the limitation of only `FunctionCall` Actions too.
- NEAR Wallet [doesn't define `requestSignTransactions` in TypeScript](https://github.com/near/near-api-js/blob/7ea21f330af1a00543b1ae655761a98820f6a368/src/wallet-account.ts#L280) although it's documented [here](https://near.github.io/near-api-js/classes/walletaccount.walletconnection.html#requestsigntransactions).
- The tests in `near-api-js` [only demonstrate a single transaction](https://github.com/near/near-api-js/blob/c73eb80c5a6b5fb4f5e8105fc02db2d8e8c01a1d/test/wallet-account.test.js#L163) which makes me think this feature is a bit of an edge case, especially when the docs only demonstrate multiple Actions too.

## Work Remaining

- [ ] Test NEAR Wallet.
- [ ] Test Sender Wallet.
- [ ] Update README with new method.