### PR TITLE
fix: [SQAC-101] Fix NEAR Wallet walletUrl Resolution

### DIFF
--- a/packages/near-wallet-selector/src/wallets/browser/NearWallet.ts
+++ b/packages/near-wallet-selector/src/wallets/browser/NearWallet.ts
@@ -28,12 +28,17 @@ function setupNearWallet({
         return walletUrl;
       }
 
-      if (typeof options.network === "string") {
-        return `https://wallet.${options.network}.near.org`;
+      switch (network.networkId) {
+        case "mainnet":
+          return "https://wallet.near.org";
+        case "testnet":
+          return "https://wallet.testnet.near.org";
+        case "betanet":
+          return "https://wallet.betanet.near.org";
+        default:
+          // TODO: Throw once wallets are separate packages.
+          return "https://wallet.testnet.near.org";
       }
-
-      // TODO: Throw once wallets are separate packages.
-      return undefined;
     };
 
     return {


### PR DESCRIPTION
# Description

Refactored `getWalletUrl` logic. We now default to testnet for unknown `networkId` values. As the TODO states, this will become an error case once we've migrated NEAR Wallet to its own package.

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change. This type of change is the main reason for the PR.
<!-- CHECKLIST_TYPE: ONE -->
- [x] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->

# Breaking changes
<!-- CHECKLIST_TYPE: ONE -->
<!-- SPECIFY BREAKING CHANGES AS A ONE-LINER -->
- [ ] BREAKING CHANGE - SPECIFY: _______
- [x] NO BREAKING CHANGE - this PR doesn't contain any breaking changes and it's backwards compatible
<!-- /CHECKLIST_TYPE -->
