### PR TITLE
feat: [SQAC-103] Support for Ad Hoc Smart Contract Calls

### DIFF
--- a/packages/near-wallet-selector/README.md
+++ b/packages/near-wallet-selector/README.md
@@ -289,6 +289,7 @@ console.log(contractId); // "guest-book.testnet"
 
 - `params` (`object`)
   - `signerId` (`string?`): Account ID used to sign the transaction. Defaults to the first account.
+  - `receiverId` (`string?`): Account ID to receive the transaction. Defaults to `contractId` defined in `.init`.
   - `actions` (`Array<Action>`)
     - `type` (`string`): Action type. See below for available values.
     - `params` (`object?`): Parameters for the Action (if applicable).

--- a/packages/near-wallet-selector/src/core/NearWalletSelector.tsx
+++ b/packages/near-wallet-selector/src/core/NearWalletSelector.tsx
@@ -14,6 +14,7 @@ import { NetworkConfiguration, resolveNetwork } from "../network";
 
 interface SignAndSendTransactionParams {
   signerId?: string;
+  receiverId?: string;
   actions: Array<Action>;
 }
 
@@ -107,6 +108,7 @@ export default class NearWalletSelector {
 
   async signAndSendTransaction({
     signerId,
+    receiverId,
     actions,
   }: SignAndSendTransactionParams) {
     const wallet = this.controller.getSelectedWallet();
@@ -126,7 +128,7 @@ export default class NearWalletSelector {
 
     return wallet.signAndSendTransaction({
       signerId: signerId || accounts[0].accountId,
-      receiverId: this.getContractId(),
+      receiverId: receiverId || this.getContractId(),
       actions,
     });
   }


### PR DESCRIPTION
# Description

Added support for passing a `receiverId` to `signAndSendTransaction`.

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change. This type of change is the main reason for the PR.
<!-- CHECKLIST_TYPE: ONE -->
- [ ] FIX - a PR of this type patches a bug.
- [x] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->

# Breaking changes
<!-- CHECKLIST_TYPE: ONE -->
<!-- SPECIFY BREAKING CHANGES AS A ONE-LINER -->
- [ ] BREAKING CHANGE - SPECIFY: _______
- [x] NO BREAKING CHANGE - this PR doesn't contain any breaking changes and it's backwards compatible
<!-- /CHECKLIST_TYPE -->
