### PR TITLE
feat: #164 Support for Multiple Transactions (NEAR Wallet & Sender)

### DIFF
--- a/examples/angular/src/app/components/content/content.component.html
+++ b/examples/angular/src/app/components/content/content.component.html
@@ -2,6 +2,9 @@
   <div>
     <button (click)="signOut()">Log out</button>
     <button (click)="switchProvider()">Switch Provider</button>
+    <button (click)="onSendMultipleTransactions()">
+      Send Multiple Transactions
+    </button>
     <button *ngIf="accounts.length > 1" (click)="switchAccount()">
       Switch Account
     </button>

--- a/examples/angular/src/app/components/content/content.component.ts
+++ b/examples/angular/src/app/components/content/content.component.ts
@@ -10,10 +10,9 @@ import { Message } from "../../interfaces/message";
 import { Sumbitted } from "../form/form.component";
 import { Account } from "../../interfaces/account";
 
-const { parseNearAmount } = utils.format;
-
 const SUGGESTED_DONATION = "0";
-const BOATLOAD_OF_GAS = parseNearAmount("0.00000000003");
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+const BOATLOAD_OF_GAS = utils.format.parseNearAmount("0.00000000003")!;
 
 @Component({
   selector: "near-wallet-selector-content",
@@ -110,6 +109,44 @@ export class ContentComponent implements OnInit, OnDestroy {
     });
   }
 
+  onSendMultipleTransactions() {
+    this.selector.signAndSendTransactions({
+      transactions: [
+        {
+          // Deploy your own version of https://github.com/near-examples/rust-counter using Gitpod to get a valid receiverId.
+          receiverId: "dev-1648806797290-14624341764914",
+          actions: [
+            {
+              type: "FunctionCall",
+              params: {
+                methodName: "increment",
+                args: {},
+                gas: BOATLOAD_OF_GAS,
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                deposit: utils.format.parseNearAmount("0")!,
+              },
+            },
+          ],
+        },
+        {
+          receiverId: this.selector.getContractId(),
+          actions: [
+            {
+              type: "FunctionCall",
+              params: {
+                methodName: "addMessage",
+                args: { text: "Hello World!" },
+                gas: BOATLOAD_OF_GAS,
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                deposit: utils.format.parseNearAmount("0")!,
+              },
+            },
+          ],
+        },
+      ],
+    });
+  }
+
   syncAccountState(
     currentAccountId: string | null,
     newAccounts: Array<AccountInfo>
@@ -167,9 +204,8 @@ export class ContentComponent implements OnInit, OnDestroy {
               methodName: "addMessage",
               args: { text: message.value },
               gas: BOATLOAD_OF_GAS as string,
-              deposit: utils.format.parseNearAmount(
-                donation.value || "0"
-              ) as string,
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+              deposit: utils.format.parseNearAmount(donation.value || "0")!,
             },
           },
         ],

--- a/examples/react/src/components/Content.tsx
+++ b/examples/react/src/components/Content.tsx
@@ -99,6 +99,42 @@ const Content: React.FC = () => {
     alert("Switched account to " + nextAccountId);
   };
 
+  const handleSendMultipleTransactions = () => {
+    selector.signAndSendTransactions({
+      transactions: [
+        {
+          // Deploy your own version of https://github.com/near-examples/rust-counter using Gitpod to get a valid receiverId.
+          receiverId: "dev-1648806797290-14624341764914",
+          actions: [
+            {
+              type: "FunctionCall",
+              params: {
+                methodName: "increment",
+                args: {},
+                gas: BOATLOAD_OF_GAS,
+                deposit: utils.format.parseNearAmount("0")!,
+              },
+            },
+          ],
+        },
+        {
+          receiverId: selector.getContractId(),
+          actions: [
+            {
+              type: "FunctionCall",
+              params: {
+                methodName: "addMessage",
+                args: { text: "Hello World!" },
+                gas: BOATLOAD_OF_GAS,
+                deposit: utils.format.parseNearAmount("0")!,
+              },
+            },
+          ],
+        },
+      ],
+    });
+  };
+
   const handleSubmit = useCallback(
     (e: SubmitEvent) => {
       e.preventDefault();
@@ -180,6 +216,9 @@ const Content: React.FC = () => {
       <div>
         <button onClick={handleSignOut}>Log out</button>
         <button onClick={handleSwitchProvider}>Switch Provider</button>
+        <button onClick={handleSendMultipleTransactions}>
+          Send Multiple Transactions
+        </button>
         {accounts.length > 1 && (
           <button onClick={handleSwitchAccount}>Switch Account</button>
         )}

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -296,7 +296,7 @@ console.log(contractId); // "guest-book.testnet"
 
 **Returns**
 
-- `Promise<object>`: More details on this can be found [here](https://docs.near.org/docs/api/rpc/transactions#send-transaction-await).
+- `Promise<void | object>`: Browser wallets won't return the transaction outcome as they may need to redirect for signing. More details on this can be found [here](https://docs.near.org/docs/api/rpc/transactions#send-transaction-await).
 
 **Description**
 
@@ -387,6 +387,47 @@ await selector.signAndSendTransaction({
       gas: "30000000000000",
       deposit: "10000000000000000000000",
     }
+  }]
+});
+```
+
+### `.signAndSendTransactions(params)`
+
+**Parameters**
+
+- `params` (`object`)
+  - `transactions` (`Array<Transaction>`)
+    - `signerId` (`string?`): Account ID used to sign the transaction. Defaults to the first account.
+    - `receiverId` (`string`): Account ID to receive the transaction.
+    - `actions` (`Array<Action>`)
+      - `type` (`string`): Action type. See above for available values.
+      - `params` (`object?`): Parameters for the Action (if applicable).
+
+**Returns**
+
+- `Promise<void | Array<object>>`: Browser wallets won't return the transaction outcomes as they may need to redirect for signing. More details on this can be found [here](https://docs.near.org/docs/api/rpc/transactions#send-transaction-await).
+
+**Description**
+
+Signs one or more transactions before sending to the network. The user must be signed in to call this method as there's at least charges for gas spent.
+
+Note: Sender Wallet only supports `"FunctionCall"` action types right now. If you wish to use other NEAR Actions in your dApp, it's recommended to remove this wallet in your configuration.
+
+**Example**
+
+```ts
+await selector.signAndSendTransactions({
+  transactions: [{
+    receiverId: "guest-book.testnet",
+    actions: [{
+      type: "FunctionCall",
+      params: {
+        methodName: "addMessage",
+        args: { text: "Hello World!" },
+        gas: "30000000000000",
+        deposit: "10000000000000000000000",
+      }
+    }]
   }]
 });
 ```

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,7 @@ export {
   HardwareWallet,
   BridgeWallet,
   AccountInfo,
+  Transaction,
   Action,
   ActionType,
   CreateAccountAction,

--- a/packages/core/src/lib/Optional.ts
+++ b/packages/core/src/lib/Optional.ts
@@ -1,0 +1,1 @@
+export type Optional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;

--- a/packages/core/src/lib/wallet/index.ts
+++ b/packages/core/src/lib/wallet/index.ts
@@ -1,2 +1,3 @@
 export * from "./wallet";
+export * from "./transactions";
 export * from "./actions";

--- a/packages/core/src/lib/wallet/transactions.ts
+++ b/packages/core/src/lib/wallet/transactions.ts
@@ -1,0 +1,7 @@
+import { Action } from "./actions";
+
+export interface Transaction {
+  signerId: string;
+  receiverId: string;
+  actions: Array<Action>;
+}

--- a/packages/core/src/lib/wallet/wallet.ts
+++ b/packages/core/src/lib/wallet/wallet.ts
@@ -1,7 +1,8 @@
-import { FinalExecutionOutcome } from "near-api-js/lib/providers";
+import { providers } from "near-api-js";
 
 import { updateState } from "../state";
 import { Provider, Logger, PersistentStorage, Emitter } from "../services";
+import { Transaction } from "./transactions";
 import { Action } from "./actions";
 import { Options } from "../Options";
 import { NetworkConfiguration } from "../network";
@@ -15,6 +16,14 @@ export interface SignAndSendTransactionParams {
   signerId: string;
   receiverId: string;
   actions: Array<Action>;
+}
+
+export interface SignAndSendTransactionsParams {
+  transactions: Array<Transaction>;
+}
+
+export interface SignAndSendTransactionsResponse {
+  results: Array<providers.FinalExecutionOutcome>;
 }
 
 export interface AccountInfo {
@@ -56,7 +65,12 @@ interface BaseWallet {
   // Signs a list of actions before sending them via an RPC endpoint.
   signAndSendTransaction(
     params: SignAndSendTransactionParams
-  ): Promise<FinalExecutionOutcome>;
+  ): Promise<providers.FinalExecutionOutcome>;
+
+  // Sings a list of transactions before sending them via an RPC endpoint.
+  signAndSendTransactions(
+    params: SignAndSendTransactionsParams
+  ): Promise<SignAndSendTransactionsResponse>;
 }
 
 export interface BrowserWallet extends BaseWallet {

--- a/packages/core/src/lib/wallet/wallet.ts
+++ b/packages/core/src/lib/wallet/wallet.ts
@@ -1,11 +1,10 @@
-import { providers } from "near-api-js";
-
 import { updateState } from "../state";
 import { Provider, Logger, PersistentStorage, Emitter } from "../services";
 import { Transaction } from "./transactions";
 import { Action } from "./actions";
 import { Options } from "../Options";
 import { NetworkConfiguration } from "../network";
+import { providers } from "near-api-js";
 
 export interface HardwareWalletSignInParams {
   accountId: string;
@@ -32,7 +31,7 @@ export type WalletEvents = {
   accountsChanged: { accounts: Array<AccountInfo> };
 };
 
-interface BaseWallet {
+interface BaseWallet<ExecutionOutcome = providers.FinalExecutionOutcome> {
   id: string;
   name: string;
   description: string | null;
@@ -61,13 +60,15 @@ interface BaseWallet {
   // Signs a list of actions before sending them via an RPC endpoint.
   signAndSendTransaction(
     params: SignAndSendTransactionParams
-  ): Promise<providers.FinalExecutionOutcome>;
+  ): Promise<ExecutionOutcome>;
 
   // Sings a list of transactions before sending them via an RPC endpoint.
-  signAndSendTransactions(params: SignAndSendTransactionsParams): Promise<void>;
+  signAndSendTransactions(
+    params: SignAndSendTransactionsParams
+  ): Promise<ExecutionOutcome extends void ? void : Array<ExecutionOutcome>>;
 }
 
-export interface BrowserWallet extends BaseWallet {
+export interface BrowserWallet extends BaseWallet<void> {
   type: "browser";
 }
 

--- a/packages/core/src/lib/wallet/wallet.ts
+++ b/packages/core/src/lib/wallet/wallet.ts
@@ -64,9 +64,7 @@ interface BaseWallet {
   ): Promise<providers.FinalExecutionOutcome>;
 
   // Sings a list of transactions before sending them via an RPC endpoint.
-  signAndSendTransactions(
-    params: SignAndSendTransactionsParams
-  ): Promise<Array<providers.FinalExecutionOutcome>>;
+  signAndSendTransactions(params: SignAndSendTransactionsParams): Promise<void>;
 }
 
 export interface BrowserWallet extends BaseWallet {

--- a/packages/core/src/lib/wallet/wallet.ts
+++ b/packages/core/src/lib/wallet/wallet.ts
@@ -22,10 +22,6 @@ export interface SignAndSendTransactionsParams {
   transactions: Array<Transaction>;
 }
 
-export interface SignAndSendTransactionsResponse {
-  results: Array<providers.FinalExecutionOutcome>;
-}
-
 export interface AccountInfo {
   accountId: string;
 }
@@ -70,7 +66,7 @@ interface BaseWallet {
   // Sings a list of transactions before sending them via an RPC endpoint.
   signAndSendTransactions(
     params: SignAndSendTransactionsParams
-  ): Promise<SignAndSendTransactionsResponse>;
+  ): Promise<Array<providers.FinalExecutionOutcome>>;
 }
 
 export interface BrowserWallet extends BaseWallet {

--- a/packages/ledger-wallet/src/lib/ledger-wallet.ts
+++ b/packages/ledger-wallet/src/lib/ledger-wallet.ts
@@ -276,6 +276,10 @@ export function setupLedgerWallet({
 
         return provider.sendTransaction(signedTx);
       },
+
+      async signAndSendTransactions() {
+        throw new Error("Not implemented");
+      },
     };
   };
 }

--- a/packages/math-wallet/src/lib/math-wallet.ts
+++ b/packages/math-wallet/src/lib/math-wallet.ts
@@ -195,6 +195,10 @@ export function setupMathWallet({
 
         return provider.sendTransaction(signedTx);
       },
+
+      async signAndSendTransactions() {
+        throw new Error("Not implemented");
+      },
     };
   };
 }

--- a/packages/near-wallet/src/lib/near-wallet.ts
+++ b/packages/near-wallet/src/lib/near-wallet.ts
@@ -187,7 +187,6 @@ export function setupNearWallet({
       async signAndSendTransactions({ transactions }) {
         logger.log("NearWallet:signAndSendTransactions", { transactions });
 
-        // near-api-js doesn't have this method declared in TypeScript.
         return wallet
           .requestSignTransactions({
             transactions: await transformTransactions(transactions),

--- a/packages/near-wallet/src/lib/near-wallet.ts
+++ b/packages/near-wallet/src/lib/near-wallet.ts
@@ -187,11 +187,12 @@ export function setupNearWallet({
       async signAndSendTransactions({ transactions }) {
         logger.log("NearWallet:signAndSendTransactions", { transactions });
 
-        // @ts-ignore
         // near-api-js doesn't have this method declared in TypeScript.
-        return account["requestSignTransactions"]({
-          transactions: transformTransactions(transactions),
-        });
+        return wallet
+          .requestSignTransactions({
+            transactions: await transformTransactions(transactions),
+          })
+          .then(() => []);
       },
     };
   };

--- a/packages/near-wallet/src/lib/near-wallet.ts
+++ b/packages/near-wallet/src/lib/near-wallet.ts
@@ -177,10 +177,12 @@ export function setupNearWallet({
 
         const account = wallet.account();
 
-        // near-api-js marks this method as protected.
         return account["signAndSendTransaction"]({
           receiverId,
           actions: transformActions(actions),
+        }).then(() => {
+          // Suppress response since transactions with deposits won't actually
+          // return FinalExecutionOutcome.
         });
       },
 

--- a/packages/near-wallet/src/lib/near-wallet.ts
+++ b/packages/near-wallet/src/lib/near-wallet.ts
@@ -187,11 +187,9 @@ export function setupNearWallet({
       async signAndSendTransactions({ transactions }) {
         logger.log("NearWallet:signAndSendTransactions", { transactions });
 
-        return wallet
-          .requestSignTransactions({
-            transactions: await transformTransactions(transactions),
-          })
-          .then(() => []);
+        return wallet.requestSignTransactions({
+          transactions: await transformTransactions(transactions),
+        });
       },
     };
   };

--- a/packages/sender-wallet/src/lib/injected-sender-wallet.ts
+++ b/packages/sender-wallet/src/lib/injected-sender-wallet.ts
@@ -77,6 +77,15 @@ export interface SignAndSendTransactionResponse {
   type: "sender-wallet-extensionResult";
 }
 
+export interface SignAndSendTransactionsResponse {
+  actionType: "DAPP/DAPP_POPUP_RESPONSE";
+  method: "signAndSendTransactions";
+  notificationId: number;
+  error?: string;
+  response?: Array<FinalExecutionOutcome>;
+  type: "sender-wallet-extensionResult";
+}
+
 export interface Transaction {
   receiverId: string;
   actions: Array<Action>;
@@ -111,8 +120,7 @@ export interface InjectedSenderWallet {
   signAndSendTransaction: (
     params: SignAndSendTransactionParams
   ) => Promise<SignAndSendTransactionResponse>;
-  // TODO: Determine return type.
   requestSignTransactions: (
     params: RequestSignTransactionsParams
-  ) => Promise<unknown>;
+  ) => Promise<SignAndSendTransactionsResponse>;
 }

--- a/packages/sender-wallet/src/lib/sender-wallet.ts
+++ b/packages/sender-wallet/src/lib/sender-wallet.ts
@@ -233,6 +233,8 @@ export function setupSenderWallet({
             if (!res.response?.length) {
               throw new Error("Invalid response");
             }
+
+            return res.response;
           });
       },
     };

--- a/packages/sender-wallet/src/lib/sender-wallet.ts
+++ b/packages/sender-wallet/src/lib/sender-wallet.ts
@@ -1,6 +1,7 @@
 import isMobile from "is-mobile";
 import {
   Action,
+  Transaction,
   FunctionCallAction,
   InjectedWallet,
   WalletModule,
@@ -67,6 +68,15 @@ export function setupSenderWallet({
       }
 
       return actions.map((x) => x.params);
+    };
+
+    const transformTransactions = (transactions: Array<Transaction>) => {
+      return transactions.map((transaction) => {
+        return {
+          receiverId: transaction.receiverId,
+          actions: transformActions(transaction.actions),
+        };
+      });
     };
 
     return {
@@ -207,8 +217,25 @@ export function setupSenderWallet({
           });
       },
 
-      async signAndSendTransactions() {
-        throw new Error("Not implemented");
+      async signAndSendTransactions({ transactions }) {
+        logger.log("SenderWallet:signAndSendTransactions", { transactions });
+
+        return wallet
+          .requestSignTransactions({
+            transactions: transformTransactions(transactions),
+          })
+          .then((res) => {
+            if (res.error) {
+              throw new Error(res.error);
+            }
+
+            // Shouldn't happen but avoids inconsistent responses.
+            if (!res.response?.length) {
+              throw new Error("Invalid response");
+            }
+
+            return res.response;
+          });
       },
     };
   };

--- a/packages/sender-wallet/src/lib/sender-wallet.ts
+++ b/packages/sender-wallet/src/lib/sender-wallet.ts
@@ -233,8 +233,6 @@ export function setupSenderWallet({
             if (!res.response?.length) {
               throw new Error("Invalid response");
             }
-
-            return res.response;
           });
       },
     };

--- a/packages/sender-wallet/src/lib/sender-wallet.ts
+++ b/packages/sender-wallet/src/lib/sender-wallet.ts
@@ -206,6 +206,10 @@ export function setupSenderWallet({
             return res.response[0];
           });
       },
+
+      async signAndSendTransactions() {
+        throw new Error("Not implemented");
+      },
     };
   };
 }

--- a/packages/wallet-connect/src/lib/wallet-connect.ts
+++ b/packages/wallet-connect/src/lib/wallet-connect.ts
@@ -200,6 +200,10 @@ export function setupWalletConnect({
           },
         });
       },
+
+      async signAndSendTransactions() {
+        throw new Error("Not implemented");
+      },
     };
   };
 }


### PR DESCRIPTION
# Description

- Added support for `signAndSendTransactions` for NEAR Wallet and Sender.
- Modified other wallets to throw an error for now.
- Exposed a serialisable version of `Transaction` (similar to `Action`).
- Added a `Optional` type helper to make properties on an interface optional in a similar approach you see with helpers like `Pick` and `Omit`.
- Updated examples to include a simple demo.
- Corrected interfaces for signing methods on `BrowserWallet`.

Closes #164

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change. This type of change is the main reason for the PR.
<!-- CHECKLIST_TYPE: ONE -->
- [ ] FIX - a PR of this type patches a bug.
- [x] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->

# Breaking changes
<!-- CHECKLIST_TYPE: ONE -->
<!-- SPECIFY BREAKING CHANGES AS A ONE-LINER -->
- [ ] BREAKING CHANGE - SPECIFY: _______
- [x] NO BREAKING CHANGE - this PR doesn't contain any breaking changes and it's backwards compatible
<!-- /CHECKLIST_TYPE -->
