### PR TITLE
fix: Patch Sign In Bug with Sender

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,6 @@ const selector = await NearWalletSelector.init({
 });
 ```
 
-## Known Issues
-
-At the time of writing, there is an issue with Sender where the signed in state is lost when navigating back to a dApp you had previously signed in to - this includes browser refreshes.
-
 ## Contributing
 
 Contributors may find the [`examples`](./examples) directory useful as it provides a quick and consistent way to manually test new changes and/or bug fixes.

--- a/packages/core/src/lib/modal/Modal.styles.ts
+++ b/packages/core/src/lib/modal/Modal.styles.ts
@@ -110,6 +110,7 @@ export default `
   border-radius: 8px;
   border: 1px solid var(--dark-gray-op-30);
   display: flex;
+  text-align: center;
 }
 
 .Modal-option-list li div {


### PR DESCRIPTION
# Description

- Added workaround for Sender to maintain the signed in state when refreshing the browser or navigating back to the dApp. Once the bug has been fixed in the extension, we need to remove this patch.

# Notes

- Based on changes from #235 to avoid merge conflicts.

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change. This type of change is the main reason for the PR.
<!-- CHECKLIST_TYPE: ONE -->
- [x] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->

# Breaking changes
<!-- CHECKLIST_TYPE: ONE -->
<!-- SPECIFY BREAKING CHANGES AS A ONE-LINER -->
- [ ] BREAKING CHANGE - SPECIFY: _______
- [x] NO BREAKING CHANGE - this PR doesn't contain any breaking changes and it's backwards compatible
<!-- /CHECKLIST_TYPE -->
