### PR TITLE
fix: Fixed bug where error was not shown when connecting with ledger

### DIFF
--- a/packages/core/src/lib/modal/Modal.tsx
+++ b/packages/core/src/lib/modal/Modal.tsx
@@ -50,6 +50,10 @@ const Modal: React.FC<ModalProps> = ({ options, network, wallets }) => {
     };
   }, []);
 
+  useEffect(() => {
+    resetState();
+  }, [state.showModal]);
+
   const resetState = () => {
     setWalletInfoVisible(false);
     setLedgerError("");
@@ -67,8 +71,6 @@ const Modal: React.FC<ModalProps> = ({ options, network, wallets }) => {
       ...prevState,
       showModal: false,
     }));
-
-    resetState();
   };
 
   const handleDismissOutsideClick = (e: MouseEvent) => {
@@ -114,9 +116,10 @@ const Modal: React.FC<ModalProps> = ({ options, network, wallets }) => {
         accountId: ledgerAccountId,
         derivationPath: ledgerDerivationPath,
       })
-      .catch((err) => setLedgerError(`Error: ${err.message}`));
-
-    resetState();
+      .catch((err) => {
+        setLedgerError(`Error: ${err.message}`);
+        setIsLoading(false);
+      });
   };
 
   return (
@@ -194,6 +197,7 @@ const Modal: React.FC<ModalProps> = ({ options, network, wallets }) => {
               <div className="account-id">
                 <input
                   type="text"
+                  className={ledgerError ? "input-error" : ""}
                   placeholder="Account ID"
                   autoFocus={true}
                   value={ledgerAccountId}


### PR DESCRIPTION
# Description
If you want to connect using the Ledger Wallet and you type in an account id that is not registered with the public key an error will not be shown. There will not be any UI changes or messages to inform you that something went wrong.

This is happening because after we update the `ledgerError` state variable we also reset the state using the `resetState` method.

Now the `resetState` method will only be called when `state.showModal` changes using the `useEffect` hook.

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change. This type of change is the main reason for the PR.
<!-- CHECKLIST_TYPE: ONE -->
- [x] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->

# Breaking changes
<!-- CHECKLIST_TYPE: ONE -->
<!-- SPECIFY BREAKING CHANGES AS A ONE-LINER -->
- [ ] BREAKING CHANGE - SPECIFY: _______
- [x] NO BREAKING CHANGE - this PR doesn't contain any breaking changes and it's backwards compatible
<!-- /CHECKLIST_TYPE -->
