### PR TITLE
fix: wait 300ms if necessary when initialize sender instance

### DIFF
--- a/examples/react/src/contexts/WalletSelectorContext.tsx
+++ b/examples/react/src/contexts/WalletSelectorContext.tsx
@@ -46,41 +46,39 @@ export const WalletSelectorContextProvider: React.FC = ({ children }) => {
   };
 
   useEffect(() => {
-    setTimeout(() => {
-      NearWalletSelector.init({
-        network: "testnet",
-        contractId: "guest-book.testnet",
-        wallets: [
-          setupNearWallet(),
-          setupSender(),
-          setupLedger(),
-          setupMathWallet(),
-          setupWalletConnect({
-            projectId: "c4f79cc...",
-            metadata: {
-              name: "NEAR Wallet Selector",
-              description: "Example dApp used by NEAR Wallet Selector",
-              url: "https://github.com/near/wallet-selector",
-              icons: ["https://avatars.githubusercontent.com/u/37784886"],
-            },
-          }),
-        ],
-      })
-        .then((instance) => {
-          return instance.getAccounts().then(async (newAccounts) => {
-            syncAccountState(localStorage.getItem("accountId"), newAccounts);
+    NearWalletSelector.init({
+      network: "testnet",
+      contractId: "guest-book.testnet",
+      wallets: [
+        setupNearWallet(),
+        setupSender(),
+        setupLedger(),
+        setupMathWallet(),
+        setupWalletConnect({
+          projectId: "c4f79cc...",
+          metadata: {
+            name: "NEAR Wallet Selector",
+            description: "Example dApp used by NEAR Wallet Selector",
+            url: "https://github.com/near/wallet-selector",
+            icons: ["https://avatars.githubusercontent.com/u/37784886"],
+          },
+        }),
+      ],
+    })
+      .then((instance) => {
+        return instance.getAccounts().then(async (newAccounts) => {
+          syncAccountState(localStorage.getItem("accountId"), newAccounts);
 
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore-next-line
-            window.selector = instance;
-            setSelector(instance);
-          });
-        })
-        .catch((err) => {
-          console.error(err);
-          alert("Failed to initialise wallet selector");
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore-next-line
+          window.selector = instance;
+          setSelector(instance);
         });
-    }, 500);
+      })
+      .catch((err) => {
+        console.error(err);
+        alert("Failed to initialise wallet selector");
+      });
   }, []);
 
   useEffect(() => {

--- a/examples/react/src/contexts/WalletSelectorContext.tsx
+++ b/examples/react/src/contexts/WalletSelectorContext.tsx
@@ -46,39 +46,41 @@ export const WalletSelectorContextProvider: React.FC = ({ children }) => {
   };
 
   useEffect(() => {
-    NearWalletSelector.init({
-      network: "testnet",
-      contractId: "guest-book.testnet",
-      wallets: [
-        setupNearWallet(),
-        setupSender(),
-        setupLedger(),
-        setupMathWallet(),
-        setupWalletConnect({
-          projectId: "c4f79cc...",
-          metadata: {
-            name: "NEAR Wallet Selector",
-            description: "Example dApp used by NEAR Wallet Selector",
-            url: "https://github.com/near/wallet-selector",
-            icons: ["https://avatars.githubusercontent.com/u/37784886"],
-          },
-        }),
-      ],
-    })
-      .then((instance) => {
-        return instance.getAccounts().then(async (newAccounts) => {
-          syncAccountState(localStorage.getItem("accountId"), newAccounts);
-
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore-next-line
-          window.selector = instance;
-          setSelector(instance);
-        });
+    setTimeout(() => {
+      NearWalletSelector.init({
+        network: "testnet",
+        contractId: "guest-book.testnet",
+        wallets: [
+          setupNearWallet(),
+          setupSender(),
+          setupLedger(),
+          setupMathWallet(),
+          setupWalletConnect({
+            projectId: "c4f79cc...",
+            metadata: {
+              name: "NEAR Wallet Selector",
+              description: "Example dApp used by NEAR Wallet Selector",
+              url: "https://github.com/near/wallet-selector",
+              icons: ["https://avatars.githubusercontent.com/u/37784886"],
+            },
+          }),
+        ],
       })
-      .catch((err) => {
-        console.error(err);
-        alert("Failed to initialise wallet selector");
-      });
+        .then((instance) => {
+          return instance.getAccounts().then(async (newAccounts) => {
+            syncAccountState(localStorage.getItem("accountId"), newAccounts);
+
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore-next-line
+            window.selector = instance;
+            setSelector(instance);
+          });
+        })
+        .catch((err) => {
+          console.error(err);
+          alert("Failed to initialise wallet selector");
+        });
+    }, 500);
   }, []);
 
   useEffect(() => {

--- a/packages/sender/src/lib/sender.ts
+++ b/packages/sender/src/lib/sender.ts
@@ -105,6 +105,7 @@ export function setupSender({
           throw new Error("Wallet not installed");
         }
 
+        // Add extra wait to ensure `window.near.isSignedIn()` login status is updated from background
         await wait(INJECTED_WALLET_LOADING_MS);
 
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/packages/sender/src/lib/sender.ts
+++ b/packages/sender/src/lib/sender.ts
@@ -10,6 +10,12 @@ import {
 
 import { InjectedSender } from "./injected-sender";
 
+const INJECTED_WALLET_LOADING_MS = 300;
+
+const wait = (ms: number) => {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+};
+
 declare global {
   interface Window {
     near: InjectedSender | undefined;
@@ -98,6 +104,8 @@ export function setupSender({
         if (!(await isInstalled())) {
           throw new Error("Wallet not installed");
         }
+
+        await wait(INJECTED_WALLET_LOADING_MS);
 
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         wallet = window.near!;


### PR DESCRIPTION
# Description

Make wallet-selector work with Sender v0.2.3. 

The issue is that, when using Sender, `window.near.isSignedIn()` is  `false` when you refresh the page (which will be `true` after a while, e.g. 300ms). We also noticed the similar issue in MetaMask that `window.ethereum.isConnected()`  is `false` when the page is reloaded, which will become `true` within 1s. This seems to be a limitation of Chrome extension since the extension needs to update the data from background.

<!-- REMOVE ALL THE TEMPLATE BELOW IF THE PR IS A RELEASE -->


# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change. This type of change is the main reason for the PR.
<!-- CHECKLIST_TYPE: ONE -->
- [x] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->

# Breaking changes
<!-- CHECKLIST_TYPE: ONE -->
<!-- SPECIFY BREAKING CHANGES AS A ONE-LINER -->
- [ ] BREAKING CHANGE - SPECIFY: _______
- [x] NO BREAKING CHANGE - this PR doesn't contain any breaking changes and it's backwards compatible
<!-- /CHECKLIST_TYPE -->
