### PR TITLE
fix: SQAC-122 Improve Sender Error when requestSignIn Fails

### DIFF
--- a/packages/sender/src/lib/injected-sender.ts
+++ b/packages/sender/src/lib/injected-sender.ts
@@ -13,7 +13,9 @@ interface AccessKey {
 
 export interface RequestSignInResponse {
   accessKey: AccessKey;
-  error: string;
+  error: {
+    type: string;
+  };
   notificationId: number;
   type: "sender-wallet-result";
 }

--- a/packages/sender/src/lib/injected-sender.ts
+++ b/packages/sender/src/lib/injected-sender.ts
@@ -13,9 +13,11 @@ interface AccessKey {
 
 export interface RequestSignInResponse {
   accessKey: AccessKey;
-  error: {
-    type: string;
-  };
+  error:
+    | string
+    | {
+        type: string;
+      };
   notificationId: number;
   type: "sender-wallet-result";
 }

--- a/packages/sender/src/lib/sender.ts
+++ b/packages/sender/src/lib/sender.ts
@@ -151,13 +151,13 @@ export function setupSender({
           await this.init();
         }
 
-        const { accessKey } = await wallet.requestSignIn({
+        const { accessKey, error } = await wallet.requestSignIn({
           contractId: options.contractId,
           methodNames: options.methodNames,
         });
 
-        if (!accessKey) {
-          throw new Error("Failed to sign in");
+        if (!accessKey || error) {
+          throw new Error(`Failed to sign in: ${error.type}`);
         }
 
         updateState((prevState) => ({

--- a/packages/sender/src/lib/sender.ts
+++ b/packages/sender/src/lib/sender.ts
@@ -157,7 +157,10 @@ export function setupSender({
         });
 
         if (!accessKey || error) {
-          throw new Error(`Failed to sign in: ${error.type}`);
+          throw new Error(
+            (typeof error === "string" ? error : error.type) ||
+              "Failed to sign in"
+          );
         }
 
         updateState((prevState) => ({


### PR DESCRIPTION
# Description

 - Improved the message error on alert by showing the type of the error

## Notes

From our current implementation what we can do is to improve the message so the dApp user can understand (have more info) on why they can’t signIn with this wallet because signIn is requested by the modal it’s not possible to catch the error outside of it.

Closes #251 
<!-- REMOVE ALL THE TEMPLATE BELOW IF THE PR IS A RELEASE -->


# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change. This type of change is the main reason for the PR.
<!-- CHECKLIST_TYPE: ONE -->
- [x] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->

# Breaking changes
<!-- CHECKLIST_TYPE: ONE -->
<!-- SPECIFY BREAKING CHANGES AS A ONE-LINER -->
- [ ] BREAKING CHANGE - SPECIFY: _______
- [x] NO BREAKING CHANGE - this PR doesn't contain any breaking changes and it's backwards compatible
<!-- /CHECKLIST_TYPE -->
