### PR TITLE
v3.0.1 Release (dev -> main)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,6 @@ const selector = await NearWalletSelector.init({
 });
 ```
 
-## Known Issues
-
-At the time of writing, there is an issue with Sender where the signed in state is lost when navigating back to a dApp you had previously signed in to - this includes browser refreshes.
-
 ## Contributing
 
 Contributors may find the [`examples`](./examples) directory useful as it provides a quick and consistent way to manually test new changes and/or bug fixes.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "near-wallet-selector",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "This is a wallet modal that allows users to interact with NEAR dApps with a selection of available wallets.",
   "keywords": [
     "near",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "near-wallet-selector",
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.0",
   "description": "This is a wallet modal that allows users to interact with NEAR dApps with a selection of available wallets.",
   "keywords": [
     "near",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@near-wallet-selector/core",
-  "version": "3.0.0"
+  "version": "3.0.1"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@near-wallet-selector/core",
-  "version": "3.0.0-alpha.2"
+  "version": "3.0.0"
 }

--- a/packages/ledger/package.json
+++ b/packages/ledger/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@near-wallet-selector/ledger",
-  "version": "3.0.0-alpha.0"
+  "version": "3.0.0"
 }

--- a/packages/ledger/package.json
+++ b/packages/ledger/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@near-wallet-selector/ledger",
-  "version": "3.0.0"
+  "version": "3.0.1"
 }

--- a/packages/math-wallet/package.json
+++ b/packages/math-wallet/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@near-wallet-selector/math-wallet",
-  "version": "3.0.0-alpha.0"
+  "version": "3.0.0"
 }

--- a/packages/math-wallet/package.json
+++ b/packages/math-wallet/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@near-wallet-selector/math-wallet",
-  "version": "3.0.0"
+  "version": "3.0.1"
 }

--- a/packages/near-wallet/package.json
+++ b/packages/near-wallet/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@near-wallet-selector/near-wallet",
-  "version": "3.0.0-alpha.0"
+  "version": "3.0.0"
 }

--- a/packages/near-wallet/package.json
+++ b/packages/near-wallet/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@near-wallet-selector/near-wallet",
-  "version": "3.0.0"
+  "version": "3.0.1"
 }

--- a/packages/sender/package.json
+++ b/packages/sender/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@near-wallet-selector/sender",
-  "version": "3.0.0-alpha.0"
+  "version": "3.0.0"
 }

--- a/packages/sender/package.json
+++ b/packages/sender/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@near-wallet-selector/sender",
-  "version": "3.0.0"
+  "version": "3.0.1"
 }

--- a/packages/sender/src/lib/injected-sender.ts
+++ b/packages/sender/src/lib/injected-sender.ts
@@ -13,7 +13,11 @@ interface AccessKey {
 
 export interface RequestSignInResponse {
   accessKey: AccessKey;
-  error: string;
+  error:
+    | string
+    | {
+        type: string;
+      };
   notificationId: number;
   type: "sender-wallet-result";
 }

--- a/packages/sender/src/lib/sender.ts
+++ b/packages/sender/src/lib/sender.ts
@@ -151,13 +151,16 @@ export function setupSender({
           await this.init();
         }
 
-        const { accessKey } = await wallet.requestSignIn({
+        const { accessKey, error } = await wallet.requestSignIn({
           contractId: options.contractId,
           methodNames: options.methodNames,
         });
 
-        if (!accessKey) {
-          throw new Error("Failed to sign in");
+        if (!accessKey || error) {
+          throw new Error(
+            (typeof error === "string" ? error : error.type) ||
+              "Failed to sign in"
+          );
         }
 
         updateState((prevState) => ({

--- a/packages/sender/src/lib/sender.ts
+++ b/packages/sender/src/lib/sender.ts
@@ -10,6 +10,8 @@ import {
 
 import { InjectedSender } from "./injected-sender";
 
+const INJECTED_WALLET_LOADING_MS = 300;
+
 declare global {
   interface Window {
     near: InjectedSender | undefined;
@@ -101,6 +103,15 @@ export function setupSender({
 
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         wallet = window.near!;
+
+        try {
+          // Add extra wait to ensure Sender signin status be read from browser extension background env
+          await waitFor(() => wallet?.isSignedIn(), {
+            timeout: INJECTED_WALLET_LOADING_MS,
+          });
+        } catch (e) {
+          logger.log("Sender:init: haven't signed in yet", e);
+        }
 
         wallet.on("accountChanged", async (newAccountId) => {
           logger.log("Sender:onAccountChange", newAccountId);

--- a/packages/wallet-connect/package.json
+++ b/packages/wallet-connect/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@near-wallet-selector/wallet-connect",
-  "version": "3.0.0-alpha.0"
+  "version": "3.0.0"
 }

--- a/packages/wallet-connect/package.json
+++ b/packages/wallet-connect/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@near-wallet-selector/wallet-connect",
-  "version": "3.0.0"
+  "version": "3.0.1"
 }


### PR DESCRIPTION
# Highlights

- Bumped version to `3.0.1` (#258).
- Improved Sender error when `requestSignIn` fails (#255).