### PR TITLE
Added debug property to options for developers to debug

### DIFF
--- a/packages/core/src/lib/NearWalletSelector.tsx
+++ b/packages/core/src/lib/NearWalletSelector.tsx
@@ -7,7 +7,7 @@ import { Action, Transaction, WalletEvents } from "./wallet";
 import { Options } from "./Options";
 import { NetworkConfiguration, resolveNetwork } from "./network";
 import { updateState } from "./state";
-import { Emitter, EventEmitter } from "./services";
+import { Emitter, EventEmitter, Logger } from "./services";
 import { MODAL_ELEMENT_ID } from "./constants";
 import { Optional } from "./Optional";
 
@@ -38,6 +38,8 @@ export default class NearWalletSelector {
   }
 
   private constructor(options: Options) {
+    Logger.debug = options.debug || false;
+
     const network = resolveNetwork(options.network);
     const emitter = new EventEmitter<WalletEvents>();
     const controller = new WalletController(options, network, emitter);

--- a/packages/core/src/lib/Options.ts
+++ b/packages/core/src/lib/Options.ts
@@ -13,4 +13,5 @@ export interface Options {
     theme?: Theme;
     description?: string;
   };
+  debug?: boolean;
 }


### PR DESCRIPTION
# Description
Now developers can add a `debug: true` property to the options when initializing the wallet selector and it will let them debug using the logger.

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change. This type of change is the main reason for the PR.
<!-- CHECKLIST_TYPE: ONE -->
- [ ] FIX - a PR of this type patches a bug.
- [x] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->

# Breaking changes
<!-- CHECKLIST_TYPE: ONE -->
<!-- SPECIFY BREAKING CHANGES AS A ONE-LINER -->
- [ ] BREAKING CHANGE - SPECIFY: _______
- [x] NO BREAKING CHANGE - this PR doesn't contain any breaking changes and it's backwards compatible
<!-- /CHECKLIST_TYPE -->
