### PR TITLE
feat: Resolved conflicts

### DIFF
--- a/packages/core/src/lib/options.ts
+++ b/packages/core/src/lib/options.ts
@@ -38,5 +38,6 @@ export const resolveOptions = (params: WalletSelectorParams): Options => {
     network: resolveNetwork(params.network),
     contractId: params.contractId,
     methodNames: params.methodNames,
+    debug: params.debug,
   };
 };

--- a/packages/core/src/lib/options.types.ts
+++ b/packages/core/src/lib/options.types.ts
@@ -14,4 +14,5 @@ export type Options = Pick<
   "contractId" | "methodNames"
 > & {
   network: Network;
+  debug?: boolean;
 };

--- a/packages/core/src/lib/wallet-selector.ts
+++ b/packages/core/src/lib/wallet-selector.ts
@@ -9,7 +9,7 @@ import {
 import { WalletSelectorModal } from "./modal/modal.types";
 import { setupModal } from "./modal/modal";
 import { Wallet } from "./wallet";
-import { EventEmitter } from "./services";
+import { EventEmitter, Logger } from "./services";
 
 export const setupWalletSelector = async (
   params: WalletSelectorParams
@@ -23,6 +23,8 @@ export const setupWalletSelector = async (
     store,
     emitter
   );
+
+  Logger.debug = options.debug || false;
 
   await controller.init();
 

--- a/packages/core/src/lib/wallet-selector.types.ts
+++ b/packages/core/src/lib/wallet-selector.types.ts
@@ -12,6 +12,7 @@ export interface WalletSelectorParams {
   methodNames?: Array<string>;
   wallets: Array<WalletModule>;
   ui?: ModalOptions;
+  debug?: boolean;
 }
 
 export interface WalletSelectorStore {


### PR DESCRIPTION
# Description
Now developers can add a `debug: true` property to the options when initializing the wallet selector and it will let them debug using the logger.

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change. This type of change is the main reason for the PR.
<!-- CHECKLIST_TYPE: ONE -->
- [ ] FIX - a PR of this type patches a bug.
- [x] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->

# Breaking changes
<!-- CHECKLIST_TYPE: ONE -->
<!-- SPECIFY BREAKING CHANGES AS A ONE-LINER -->
- [ ] BREAKING CHANGE - SPECIFY: _______
- [x] NO BREAKING CHANGE - this PR doesn't contain any breaking changes and it's backwards compatible
<!-- /CHECKLIST_TYPE -->
