### PR TITLE
fix: sender signout bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "near-wallet-selector",
-  "version": "3.0.2-dev.1",
+  "version": "3.0.2",
   "description": "This is a wallet modal that allows users to interact with NEAR dApps with a selection of available wallets.",
   "keywords": [
     "near",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "near-wallet-selector",
-  "version": "3.0.1",
+  "version": "3.0.2-dev.0",
   "description": "This is a wallet modal that allows users to interact with NEAR dApps with a selection of available wallets.",
   "keywords": [
     "near",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "near-wallet-selector",
-  "version": "3.0.2-dev.0",
+  "version": "3.0.2-dev.1",
   "description": "This is a wallet modal that allows users to interact with NEAR dApps with a selection of available wallets.",
   "keywords": [
     "near",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@near-wallet-selector/core",
-  "version": "3.0.2-dev.1"
+  "version": "3.0.2"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@near-wallet-selector/core",
-  "version": "3.0.2-dev.0"
+  "version": "3.0.2-dev.1"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@near-wallet-selector/core",
-  "version": "3.0.1"
+  "version": "3.0.2-dev.0"
 }

--- a/packages/ledger/package.json
+++ b/packages/ledger/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@near-wallet-selector/ledger",
-  "version": "3.0.1"
+  "version": "3.0.2-dev.0"
 }

--- a/packages/ledger/package.json
+++ b/packages/ledger/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@near-wallet-selector/ledger",
-  "version": "3.0.2-dev.0"
+  "version": "3.0.2-dev.1"
 }

--- a/packages/ledger/package.json
+++ b/packages/ledger/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@near-wallet-selector/ledger",
-  "version": "3.0.2-dev.1"
+  "version": "3.0.2"
 }

--- a/packages/math-wallet/package.json
+++ b/packages/math-wallet/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@near-wallet-selector/math-wallet",
-  "version": "3.0.2-dev.0"
+  "version": "3.0.2-dev.1"
 }

--- a/packages/math-wallet/package.json
+++ b/packages/math-wallet/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@near-wallet-selector/math-wallet",
-  "version": "3.0.1"
+  "version": "3.0.2-dev.0"
 }

--- a/packages/math-wallet/package.json
+++ b/packages/math-wallet/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@near-wallet-selector/math-wallet",
-  "version": "3.0.2-dev.1"
+  "version": "3.0.2"
 }

--- a/packages/near-wallet/package.json
+++ b/packages/near-wallet/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@near-wallet-selector/near-wallet",
-  "version": "3.0.1"
+  "version": "3.0.2-dev.0"
 }

--- a/packages/near-wallet/package.json
+++ b/packages/near-wallet/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@near-wallet-selector/near-wallet",
-  "version": "3.0.2-dev.0"
+  "version": "3.0.2-dev.1"
 }

--- a/packages/near-wallet/package.json
+++ b/packages/near-wallet/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@near-wallet-selector/near-wallet",
-  "version": "3.0.2-dev.1"
+  "version": "3.0.2"
 }

--- a/packages/sender/package.json
+++ b/packages/sender/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@near-wallet-selector/sender",
-  "version": "3.0.2-dev.1"
+  "version": "3.0.2"
 }

--- a/packages/sender/package.json
+++ b/packages/sender/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@near-wallet-selector/sender",
-  "version": "3.0.1"
+  "version": "3.0.2-dev.0"
 }

--- a/packages/sender/package.json
+++ b/packages/sender/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@near-wallet-selector/sender",
-  "version": "3.0.2-dev.0"
+  "version": "3.0.2-dev.1"
 }

--- a/packages/sender/src/lib/injected-sender.ts
+++ b/packages/sender/src/lib/injected-sender.ts
@@ -113,7 +113,7 @@ export interface InjectedSender {
   requestSignIn: (
     params: RequestSignInParams
   ) => Promise<RequestSignInResponse>;
-  signOut: () => boolean;
+  signOut: () => Promise<boolean>;
   isSignedIn: () => boolean;
   on: <Event extends keyof SenderEvents>(
     event: Event,

--- a/packages/sender/src/lib/injected-sender.ts
+++ b/packages/sender/src/lib/injected-sender.ts
@@ -22,6 +22,8 @@ export interface RequestSignInResponse {
   type: "sender-wallet-result";
 }
 
+export type SignOutResponse = boolean | { error: string | { type: string } };
+
 export interface RpcInfo {
   explorerUrl: string;
   helperUrl: string;
@@ -113,7 +115,7 @@ export interface InjectedSender {
   requestSignIn: (
     params: RequestSignInParams
   ) => Promise<RequestSignInResponse>;
-  signOut: () => Promise<boolean>;
+  signOut: () => Promise<SignOutResponse>;
   isSignedIn: () => boolean;
   on: <Event extends keyof SenderEvents>(
     event: Event,

--- a/packages/sender/src/lib/sender.ts
+++ b/packages/sender/src/lib/sender.ts
@@ -180,8 +180,12 @@ export function setupSender({
 
       async signOut() {
         const res = await wallet.signOut();
-        if (!res) {
-          throw new Error("Failed to sign out");
+
+        if (typeof res !== "boolean" && res.error) {
+          throw new Error(
+            (typeof res.error === "string" ? res.error : res.error.type) ||
+              "Failed to connect"
+          );
         }
 
         updateState((prevState) => ({

--- a/packages/sender/src/lib/sender.ts
+++ b/packages/sender/src/lib/sender.ts
@@ -179,8 +179,7 @@ export function setupSender({
       },
 
       async signOut() {
-        const res = wallet.signOut();
-
+        const res = await wallet.signOut();
         if (!res) {
           throw new Error("Failed to sign out");
         }

--- a/packages/wallet-connect/package.json
+++ b/packages/wallet-connect/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@near-wallet-selector/wallet-connect",
-  "version": "3.0.2-dev.0"
+  "version": "3.0.2-dev.1"
 }

--- a/packages/wallet-connect/package.json
+++ b/packages/wallet-connect/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@near-wallet-selector/wallet-connect",
-  "version": "3.0.1"
+  "version": "3.0.2-dev.0"
 }

--- a/packages/wallet-connect/package.json
+++ b/packages/wallet-connect/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@near-wallet-selector/wallet-connect",
-  "version": "3.0.2-dev.1"
+  "version": "3.0.2"
 }


### PR DESCRIPTION
# Description

Sender has been updated yesterday and they have introduced a breaking change.
Previously `near.signOut()` returned `boolean` but now it is an `async` function which returns a promise which in the end resolves either `true `value or an `error` object.

This PR fixes the `signOut `for sender