### PR TITLE
feat: Replaced alert with custom modal

### DIFF
--- a/packages/core/src/lib/modal/components/AlertModal.tsx
+++ b/packages/core/src/lib/modal/components/AlertModal.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+interface AlertModalProps {
+  message: string;
+  setAlertMessage: (message: string | null) => void;
+}
+
+export const AlertModal: React.FC<AlertModalProps> = ({
+  message,
+  setAlertMessage,
+}) => {
+  const close = () => {
+    setAlertMessage(null);
+  };
+
+  return (
+    <div className="Modal-alert">
+      <div className="Modal-alert-window">
+        <div className="Modal-alert-message">{message}</div>
+        <button onClick={close}>OK</button>
+      </div>
+    </div>
+  );
+};

--- a/packages/core/src/lib/modal/components/AlertModal.tsx
+++ b/packages/core/src/lib/modal/components/AlertModal.tsx
@@ -16,6 +16,20 @@ export const AlertModal: React.FC<AlertModalProps> = ({
   return (
     <div className="Modal-alert">
       <div className="Modal-alert-window">
+        <div className="Modal-alert-close">
+          <button onClick={close}>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              fill="#A7A7A7"
+            >
+              <path d="M0 0h24v24H0z" fill="none" />
+              <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
+            </svg>
+          </button>
+        </div>
         <div className="Modal-alert-message">{message}</div>
         <button onClick={close}>OK</button>
       </div>

--- a/packages/core/src/lib/modal/components/Modal.styles.ts
+++ b/packages/core/src/lib/modal/components/Modal.styles.ts
@@ -325,17 +325,31 @@ export default `
 }
 
 .Modal-alert-window {
-  width: 500px;
+  width: 80%;
+  max-width: 500px;
   margin: 0 auto;
   margin-top: 2em;
   background: white;
   border-radius: 5px;
-  padding: 2em;
+  padding: 1.5em;
   box-shadow: 0 2px 10px 0 #626263;
 }
 
+.Modal-alert-close {
+  text-align: right;
+}
+
+.Modal-alert-close button {
+  border: 0;
+  cursor: pointer;
+  height: 24px;
+  padding: 0px;
+  background-color: transparent;
+}
+
 .Modal-alert-message {
-  margin-bottom: 1em;
+  margin-bottom: 1.5em;
+  font-size: 16px;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/packages/core/src/lib/modal/components/Modal.styles.ts
+++ b/packages/core/src/lib/modal/components/Modal.styles.ts
@@ -315,6 +315,29 @@ export default `
     border-color: var(--black);
 }
 
+.Modal-alert {
+  z-index: 100;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100vh;
+}
+
+.Modal-alert-window {
+  width: 500px;
+  margin: 0 auto;
+  margin-top: 2em;
+  background: white;
+  border-radius: 5px;
+  padding: 2em;
+  box-shadow: 0 2px 10px 0 #626263;
+}
+
+.Modal-alert-message {
+  margin-bottom: 1em;
+}
+
 @media (prefers-color-scheme: dark) {
   .Modal .Modal-content {
     background-color: var(--dark-gray);

--- a/packages/core/src/lib/modal/components/Modal.styles.ts
+++ b/packages/core/src/lib/modal/components/Modal.styles.ts
@@ -1,7 +1,7 @@
 export default `
 @import url('https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600&display=swap');
 
-.Modal {
+#near-wallet-selector-modal {
   --backdrop-bg: #26262630;
   --black: #262626;
   --black-rgb: 38, 38, 38;
@@ -272,6 +272,43 @@ export default `
   align-items: center;
 }
 
+.Modal-alert {
+  z-index: 100;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100vh;
+}
+
+.Modal-alert-window {
+  width: 80%;
+  max-width: 500px;
+  margin: 0 auto;
+  margin-top: 2em;
+  background: white;
+  border-radius: 5px;
+  padding: 1.5em;
+  box-shadow: 0 2px 10px 0 var(--backdrop-bg);
+}
+
+.Modal-alert-close {
+  text-align: right;
+}
+
+.Modal-alert-close button {
+  border: 0;
+  cursor: pointer;
+  height: 24px;
+  padding: 0px;
+  background-color: transparent;
+}
+
+.Modal-alert-message {
+  margin-bottom: 1.5em;
+  font-size: 16px;
+}
+
 .Modal-dark-theme .Modal-content {
   background-color: var(--dark-gray);
   color: var(--white);
@@ -315,41 +352,9 @@ export default `
     border-color: var(--black);
 }
 
-.Modal-alert {
-  z-index: 100;
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100vh;
-}
-
-.Modal-alert-window {
-  width: 80%;
-  max-width: 500px;
-  margin: 0 auto;
-  margin-top: 2em;
-  background: white;
-  border-radius: 5px;
-  padding: 1.5em;
-  box-shadow: 0 2px 10px 0 #626263;
-}
-
-.Modal-alert-close {
-  text-align: right;
-}
-
-.Modal-alert-close button {
-  border: 0;
-  cursor: pointer;
-  height: 24px;
-  padding: 0px;
-  background-color: transparent;
-}
-
-.Modal-alert-message {
-  margin-bottom: 1.5em;
-  font-size: 16px;
+.Modal-dark-theme .Modal-alert-window {
+  background-color: var(--dark-gray);
+  color: white;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -395,6 +400,11 @@ export default `
   .Modal .Modal-content .left-button:hover {
       background-color: rgba(var(--black-rgb), 0.8);
       border-color: var(--black);
+  }
+
+  .Modal-alert-window {
+    background-color: var(--dark-gray);
+    color: white;
   }
 }
 

--- a/packages/core/src/lib/modal/components/Modal.tsx
+++ b/packages/core/src/lib/modal/components/Modal.tsx
@@ -7,6 +7,7 @@ import { LedgerDerivationPath } from "./LedgerDerivationPath";
 import { WalletNotInstalled } from "./WalletNotInstalled";
 import { WalletNetworkChanged } from "./WalletNetworkChanged";
 import { WalletOptions } from "./WalletOptions";
+import { AlertModal } from "./AlertModal";
 
 interface ModalProps {
   // TODO: Remove omit once modal is a separate package.
@@ -45,6 +46,7 @@ export const Modal: React.FC<ModalProps> = ({
   const [notInstalledWallet, setNotInstalledWallet] = useState<Wallet | null>(
     null
   );
+  const [alertMessage, setAlertMessage] = useState<string | null>(null);
 
   useEffect(() => {
     setRouteName("WalletOptions");
@@ -90,6 +92,9 @@ export const Modal: React.FC<ModalProps> = ({
   return (
     <div>
       <style>{styles}</style>
+      {alertMessage !== null && (
+        <AlertModal message={alertMessage} setAlertMessage={setAlertMessage} />
+      )}
       <div
         className={`Modal ${getThemeClass(options?.theme)}`}
         onClick={handleDismissOutsideClick}
@@ -119,6 +124,7 @@ export const Modal: React.FC<ModalProps> = ({
               setRouteName={setRouteName}
               setNotInstalledWallet={setNotInstalledWallet}
               hide={hide}
+              setAlertMessage={setAlertMessage}
             />
           )}
           {routeName === "LedgerDerivationPath" && (

--- a/packages/core/src/lib/modal/components/Modal.tsx
+++ b/packages/core/src/lib/modal/components/Modal.tsx
@@ -90,15 +90,12 @@ export const Modal: React.FC<ModalProps> = ({
   }
 
   return (
-    <div>
+    <div className={getThemeClass(options?.theme)}>
       <style>{styles}</style>
       {alertMessage !== null && (
         <AlertModal message={alertMessage} setAlertMessage={setAlertMessage} />
       )}
-      <div
-        className={`Modal ${getThemeClass(options?.theme)}`}
-        onClick={handleDismissOutsideClick}
-      >
+      <div className="Modal" onClick={handleDismissOutsideClick}>
         <div className="Modal-content">
           <div className="Modal-header">
             <h2>Connect Wallet</h2>

--- a/packages/core/src/lib/modal/components/WalletOptions.tsx
+++ b/packages/core/src/lib/modal/components/WalletOptions.tsx
@@ -15,6 +15,7 @@ interface WalletOptionsProps {
   setRouteName: (routeName: ModalRouteName) => void;
   setNotInstalledWallet: (wallet: Wallet | null) => void;
   hide: () => void;
+  setAlertMessage: (message: string | null) => void;
 }
 
 export const WalletOptions: React.FC<WalletOptionsProps> = ({
@@ -25,6 +26,7 @@ export const WalletOptions: React.FC<WalletOptionsProps> = ({
   setRouteName,
   setNotInstalledWallet,
   hide,
+  setAlertMessage,
 }) => {
   const [disabled, setDisabled] = useState(false);
   const [wallets, setWallets] = useState(selector.store.getState().wallets);
@@ -58,7 +60,7 @@ export const WalletOptions: React.FC<WalletOptionsProps> = ({
       logger.log(`Failed to select ${wallet.name}`);
       logger.error(err);
 
-      alert(`Failed to sign in with ${wallet.name}: ${err.message}`);
+      setAlertMessage(`Failed to sign in with ${wallet.name}: ${err.message}`);
     });
 
     if (response) {


### PR DESCRIPTION
# Description
Instead of using the `alert()` function I created a custom component and state to show and hide custom alert box on errors. 


# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change. This type of change is the main reason for the PR.
<!-- CHECKLIST_TYPE: ONE -->
- [ ] FIX - a PR of this type patches a bug.
- [x] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->

# Breaking changes
<!-- CHECKLIST_TYPE: ONE -->
<!-- SPECIFY BREAKING CHANGES AS A ONE-LINER -->
- [ ] BREAKING CHANGE - SPECIFY: _______
- [x] NO BREAKING CHANGE - this PR doesn't contain any breaking changes and it's backwards compatible
<!-- /CHECKLIST_TYPE -->
