### PR TITLE
fix: Handle accountChanged for Sender

### DIFF
--- a/packages/sender/src/lib/sender.ts
+++ b/packages/sender/src/lib/sender.ts
@@ -180,9 +180,8 @@ const Sender: WalletBehaviourFactory<InjectedWallet> = ({
       const wallet = await setupWallet();
       const existingAccounts = getAccounts();
 
-      // TODO: Sender returns no accounts when locked.
-      //  We should wait until they've fixed this on their end.
       if (existingAccounts.length) {
+        emitter.emit("connected", { accounts: existingAccounts });
         return existingAccounts;
       }
 

--- a/packages/sender/src/lib/sender.ts
+++ b/packages/sender/src/lib/sender.ts
@@ -116,7 +116,9 @@ const Sender: WalletBehaviourFactory<InjectedWallet> = ({
     _state.wallet.on("accountChanged", async (newAccountId) => {
       logger.log("Sender:onAccountChange", newAccountId);
 
-      await disconnect();
+      cleanup();
+
+      emitter.emit("disconnected", null);
     });
 
     _state.wallet.on("rpcChanged", async ({ rpc }) => {

--- a/packages/sender/src/lib/sender.ts
+++ b/packages/sender/src/lib/sender.ts
@@ -23,13 +23,17 @@ export interface SenderParams {
   iconUrl?: string;
 }
 
+interface SenderState {
+  wallet: InjectedSender | null;
+}
+
 const Sender: WalletBehaviourFactory<InjectedWallet> = ({
   options,
   metadata,
   emitter,
   logger,
 }) => {
-  let _wallet: InjectedSender | null = null;
+  const _state: SenderState = { wallet: null };
 
   const isInstalled = async () => {
     try {
@@ -42,21 +46,21 @@ const Sender: WalletBehaviourFactory<InjectedWallet> = ({
   };
 
   const cleanup = () => {
-    _wallet = null;
+    _state.wallet = null;
   };
 
   // TODO: Remove event listeners.
   // Must only trigger "disconnected" if we were connected.
   const disconnect = async () => {
-    if (!_wallet) {
+    if (!_state.wallet) {
       return;
     }
 
-    if (!_wallet.isSignedIn()) {
+    if (!_state.wallet.isSignedIn()) {
       return cleanup();
     }
 
-    const res = await _wallet.signOut();
+    const res = await _state.wallet.signOut();
 
     if (!res) {
       throw new Error("Failed to disconnect");
@@ -75,11 +79,11 @@ const Sender: WalletBehaviourFactory<InjectedWallet> = ({
   };
 
   const getAccounts = () => {
-    if (!_wallet) {
+    if (!_state.wallet) {
       return [];
     }
 
-    const accountId = _wallet.getAccountId();
+    const accountId = _state.wallet.getAccountId();
 
     if (!accountId) {
       return [];
@@ -89,8 +93,8 @@ const Sender: WalletBehaviourFactory<InjectedWallet> = ({
   };
 
   const setupWallet = async (): Promise<InjectedSender> => {
-    if (_wallet) {
-      return _wallet;
+    if (_state.wallet) {
+      return _state.wallet;
     }
 
     const installed = await isInstalled();
@@ -99,23 +103,23 @@ const Sender: WalletBehaviourFactory<InjectedWallet> = ({
       throw errors.createWalletNotInstalledError(metadata);
     }
 
-    _wallet = window.near!;
+    _state.wallet = window.near!;
 
     try {
       // Add extra wait to ensure Sender's sign in status is read from the
       // browser extension background env.
-      await waitFor(() => !!_wallet?.isSignedIn(), { timeout: 300 });
+      await waitFor(() => !!_state.wallet?.isSignedIn(), { timeout: 300 });
     } catch (e) {
       logger.log("Sender:setupWallet: Not signed in yet");
     }
 
-    _wallet.on("accountChanged", async (newAccountId) => {
+    _state.wallet.on("accountChanged", async (newAccountId) => {
       logger.log("Sender:onAccountChange", newAccountId);
 
       await disconnect();
     });
 
-    _wallet.on("rpcChanged", async ({ rpc }) => {
+    _state.wallet.on("rpcChanged", async ({ rpc }) => {
       if (options.network.networkId !== rpc.networkId) {
         await disconnect();
 
@@ -123,15 +127,15 @@ const Sender: WalletBehaviourFactory<InjectedWallet> = ({
       }
     });
 
-    return _wallet;
+    return _state.wallet;
   };
 
   const getWallet = (): InjectedSender => {
-    if (!_wallet) {
+    if (!_state.wallet) {
       throw new Error(`${metadata.name} not connected`);
     }
 
-    return _wallet;
+    return _state.wallet;
   };
 
   const isValidActions = (


### PR DESCRIPTION
# Description

- Cleanup and emit disconnected when switching between accounts in Sender extension.
- Emit connected if there are existing accounts for sender.

<!-- REMOVE ALL THE TEMPLATE BELOW IF THE PR IS A RELEASE -->


# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change. This type of change is the main reason for the PR.
<!-- CHECKLIST_TYPE: ONE -->
- [x] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->

# Breaking changes
<!-- CHECKLIST_TYPE: ONE -->
<!-- SPECIFY BREAKING CHANGES AS A ONE-LINER -->
- [ ] BREAKING CHANGE - SPECIFY: _______
- [x] NO BREAKING CHANGE - this PR doesn't contain any breaking changes and it's backwards compatible
<!-- /CHECKLIST_TYPE -->
