### PR TITLE
Add `callbackUrl` Support for Near Wallet (main)

### DIFF
--- a/packages/core/src/lib/wallet/wallet.ts
+++ b/packages/core/src/lib/wallet/wallet.ts
@@ -21,6 +21,16 @@ export interface SignAndSendTransactionsParams {
   transactions: Array<Transaction>;
 }
 
+export interface BrowserWalletSignAndSendTransactionParams
+  extends SignAndSendTransactionParams {
+  callbackUrl?: string;
+}
+
+export interface BrowserWalletSignAndSendTransactionsParams
+  extends SignAndSendTransactionsParams {
+  callbackUrl?: string;
+}
+
 export interface AccountInfo {
   accountId: string;
 }
@@ -70,6 +80,12 @@ interface BaseWallet<ExecutionOutcome = providers.FinalExecutionOutcome> {
 
 export interface BrowserWallet extends BaseWallet<void> {
   type: "browser";
+  signAndSendTransaction(
+    params: BrowserWalletSignAndSendTransactionParams
+  ): Promise<void>;
+  signAndSendTransactions(
+    params: BrowserWalletSignAndSendTransactionsParams
+  ): Promise<void>;
 }
 
 export interface InjectedWallet extends BaseWallet {

--- a/packages/near-wallet/src/lib/near-wallet.ts
+++ b/packages/near-wallet/src/lib/near-wallet.ts
@@ -167,11 +167,17 @@ export function setupNearWallet({
         return getAccounts();
       },
 
-      async signAndSendTransaction({ signerId, receiverId, actions }) {
+      async signAndSendTransaction({
+        signerId,
+        receiverId,
+        actions,
+        callbackUrl,
+      }) {
         logger.log("NearWallet:signAndSendTransaction", {
           signerId,
           receiverId,
           actions,
+          callbackUrl,
         });
 
         const account = wallet.account();
@@ -179,17 +185,22 @@ export function setupNearWallet({
         return account["signAndSendTransaction"]({
           receiverId,
           actions: transformActions(actions),
+          walletCallbackUrl: callbackUrl,
         }).then(() => {
           // Suppress response since transactions with deposits won't actually
           // return FinalExecutionOutcome.
         });
       },
 
-      async signAndSendTransactions({ transactions }) {
-        logger.log("NearWallet:signAndSendTransactions", { transactions });
+      async signAndSendTransactions({ transactions, callbackUrl }) {
+        logger.log("NearWallet:signAndSendTransactions", {
+          transactions,
+          callbackUrl,
+        });
 
         return wallet.requestSignTransactions({
           transactions: await transformTransactions(transactions),
+          callbackUrl,
         });
       },
     };


### PR DESCRIPTION
# Description

- Added the support for passing an optional `callbackUrl` when calling `signAndSendTransaction` and `signAndSendTransactions`.

Closes #290.

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change. This type of change is the main reason for the PR.
<!-- CHECKLIST_TYPE: ONE -->
- [ ] FIX - a PR of this type patches a bug.
- [x] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->

# Breaking changes
<!-- CHECKLIST_TYPE: ONE -->
<!-- SPECIFY BREAKING CHANGES AS A ONE-LINER -->
- [ ] BREAKING CHANGE - SPECIFY: _______
- [x] NO BREAKING CHANGE - this PR doesn't contain any breaking changes and it's backwards compatible
<!-- /CHECKLIST_TYPE -->
