### PR TITLE
SQAC-146: Connect with Contract Params

### DIFF
--- a/examples/react/src/components/Content.tsx
+++ b/examples/react/src/components/Content.tsx
@@ -4,6 +4,8 @@ import { AccountView, CodeResult } from "near-api-js/lib/providers/provider";
 
 import { Account, Message } from "../interfaces";
 import { useWalletSelector } from "../contexts/WalletSelectorContext";
+import { CONTRACT_ID } from "../constants";
+
 import SignIn from "./SignIn";
 import Form from "./Form";
 import Messages from "./Messages";
@@ -40,13 +42,13 @@ const Content: React.FC = () => {
   }, [accountId, selector.options]);
 
   const getMessages = useCallback(() => {
-    const { network, contractId } = selector.options;
+    const { network } = selector.options;
     const provider = new providers.JsonRpcProvider({ url: network.nodeUrl });
 
     return provider
       .query<CodeResult>({
         request_type: "call_function",
-        account_id: contractId,
+        account_id: CONTRACT_ID,
         method_name: "getMessages",
         args_base64: "",
         finality: "optimistic",
@@ -102,7 +104,7 @@ const Content: React.FC = () => {
   };
 
   const handleSendMultipleTransactions = async () => {
-    const { contractId } = selector.options;
+    const { contract } = selector.store.getState();
     const wallet = await selector.wallet();
 
     await wallet.signAndSendTransactions({
@@ -123,7 +125,7 @@ const Content: React.FC = () => {
           ],
         },
         {
-          receiverId: contractId,
+          receiverId: contract!.contractId,
           actions: [
             {
               type: "FunctionCall",

--- a/examples/react/src/constants.ts
+++ b/examples/react/src/constants.ts
@@ -1,0 +1,1 @@
+export const CONTRACT_ID = "guest-book.testnet";

--- a/examples/react/src/contexts/WalletSelectorContext.tsx
+++ b/examples/react/src/contexts/WalletSelectorContext.tsx
@@ -9,11 +9,12 @@ import {
   setupModal,
   WalletSelectorModal,
 } from "@near-wallet-selector/modal-ui";
-import { setupNearWallet } from "@near-wallet-selector/near-wallet";
+// import { setupNearWallet } from "@near-wallet-selector/near-wallet";
 import { setupSender } from "@near-wallet-selector/sender";
-import { setupMathWallet } from "@near-wallet-selector/math-wallet";
-import { setupLedger } from "@near-wallet-selector/ledger";
-import { setupWalletConnect } from "@near-wallet-selector/wallet-connect";
+// import { setupMathWallet } from "@near-wallet-selector/math-wallet";
+// import { setupLedger } from "@near-wallet-selector/ledger";
+// import { setupWalletConnect } from "@near-wallet-selector/wallet-connect";
+import { CONTRACT_ID } from "../constants";
 
 declare global {
   interface Window {
@@ -66,28 +67,27 @@ export const WalletSelectorContextProvider: React.FC = ({ children }) => {
   useEffect(() => {
     setupWalletSelector({
       network: "testnet",
-      contractId: "guest-book.testnet",
       debug: true,
       modules: [
-        setupNearWallet(),
+        // setupNearWallet(),
         setupSender(),
-        setupMathWallet(),
-        setupLedger(),
-        setupWalletConnect({
-          projectId: "c4f79cc...",
-          metadata: {
-            name: "NEAR Wallet Selector",
-            description: "Example dApp used by NEAR Wallet Selector",
-            url: "https://github.com/near/wallet-selector",
-            icons: ["https://avatars.githubusercontent.com/u/37784886"],
-          },
-        }),
+        // setupMathWallet(),
+        // setupLedger(),
+        // setupWalletConnect({
+        //   projectId: "c4f79cc...",
+        //   metadata: {
+        //     name: "NEAR Wallet Selector",
+        //     description: "Example dApp used by NEAR Wallet Selector",
+        //     url: "https://github.com/near/wallet-selector",
+        //     icons: ["https://avatars.githubusercontent.com/u/37784886"],
+        //   },
+        // }),
       ],
     })
       .then((instance) => {
-        const selectorModal = setupModal(instance);
-        const state = instance.store.getState();
+        const selectorModal = setupModal(instance, { contractId: CONTRACT_ID });
 
+        const state = instance.store.getState();
         syncAccountState(localStorage.getItem("accountId"), state.accounts);
 
         window.selector = instance;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,7 @@ export {
   WalletSelector,
   WalletSelectorParams,
   WalletSelectorEvents,
+  WalletSelectorStore,
 } from "./lib/wallet-selector.types";
 export { setupWalletSelector } from "./lib/wallet-selector";
 
@@ -15,6 +16,7 @@ export { Optional } from "./lib/utils.types";
 
 export {
   WalletSelectorState,
+  ContractState,
   ModuleState,
   AccountState,
 } from "./lib/store.types";

--- a/packages/core/src/lib/constants.ts
+++ b/packages/core/src/lib/constants.ts
@@ -1,3 +1,4 @@
 export const PACKAGE_NAME = "near-wallet-selector";
+export const CONTRACT = "contract";
 export const SELECTED_WALLET_ID = `selectedWalletId`;
 export const PENDING_SELECTED_WALLET_ID = `selectedWalletId:pending`;

--- a/packages/core/src/lib/options.ts
+++ b/packages/core/src/lib/options.ts
@@ -37,8 +37,6 @@ export const resolveNetwork = (network: NetworkId | Network): Network => {
 export const resolveOptions = (params: WalletSelectorParams) => {
   const options: Options = {
     network: resolveNetwork(params.network),
-    contractId: params.contractId,
-    methodNames: params.methodNames,
     debug: params.debug || false,
   };
 

--- a/packages/core/src/lib/options.types.ts
+++ b/packages/core/src/lib/options.types.ts
@@ -1,5 +1,3 @@
-import { WalletSelectorParams } from "./wallet-selector.types";
-
 export type NetworkId = "mainnet" | "testnet" | "betanet";
 
 export interface Network {
@@ -9,10 +7,7 @@ export interface Network {
   explorerUrl: string;
 }
 
-export type Options = Pick<
-  WalletSelectorParams,
-  "contractId" | "methodNames"
-> & {
+export interface Options {
   network: Network;
   debug: boolean;
-};
+}

--- a/packages/core/src/lib/services/wallet-modules/wallet-modules.service.ts
+++ b/packages/core/src/lib/services/wallet-modules/wallet-modules.service.ts
@@ -12,7 +12,11 @@ import { AccountState, ModuleState, Store } from "../../store.types";
 import { EventEmitter } from "../event-emitter/event-emitter.service";
 import { WalletSelectorEvents } from "../../wallet-selector.types";
 import { Logger, logger } from "../logger/logger.service";
-import { PACKAGE_NAME, PENDING_SELECTED_WALLET_ID } from "../../constants";
+import {
+  PACKAGE_NAME,
+  CONTRACT,
+  PENDING_SELECTED_WALLET_ID,
+} from "../../constants";
 import { JsonStorage } from "../storage/json-storage.service";
 import { Provider } from "../provider/provider.service";
 
@@ -117,6 +121,7 @@ export class WalletModules {
   ) {
     const { selectedWalletId } = this.store.getState();
     const jsonStorage = new JsonStorage(this.storage, PACKAGE_NAME);
+    const contract = { contractId, methodNames };
 
     if (!accounts.length) {
       const module = this.getModule(walletId)!;
@@ -133,18 +138,18 @@ export class WalletModules {
       await this.disconnectWallet(selectedWalletId);
     }
 
-    await jsonStorage.setItem("contract", { contractId, methodNames });
+    await jsonStorage.setItem(CONTRACT, contract);
 
     this.store.dispatch({
       type: "WALLET_CONNECTED",
-      payload: { walletId, accounts },
+      payload: { walletId, contract, accounts },
     });
   }
 
   private async onWalletDisconnected(walletId: string) {
     const jsonStorage = new JsonStorage(this.storage, PACKAGE_NAME);
 
-    await jsonStorage.removeItem("contract");
+    await jsonStorage.removeItem(CONTRACT);
 
     this.store.dispatch({
       type: "WALLET_DISCONNECTED",

--- a/packages/core/src/lib/services/wallet-modules/wallet-modules.service.ts
+++ b/packages/core/src/lib/services/wallet-modules/wallet-modules.service.ts
@@ -221,6 +221,7 @@ export class WalletModules {
         type: module.type,
         metadata: module.metadata,
         options: this.options,
+        store: this.store.toReadOnly(),
         provider: new Provider(this.options.network.nodeUrl),
         emitter: this.setupWalletEmitter(module),
         logger: new Logger(module.id),

--- a/packages/core/src/lib/store.ts
+++ b/packages/core/src/lib/store.ts
@@ -6,7 +6,7 @@ import {
   WalletSelectorState,
   WalletSelectorAction,
 } from "./store.types";
-import { PACKAGE_NAME, SELECTED_WALLET_ID } from "./constants";
+import { PACKAGE_NAME, CONTRACT, SELECTED_WALLET_ID } from "./constants";
 
 const reducer = (
   state: WalletSelectorState,
@@ -26,7 +26,7 @@ const reducer = (
       };
     }
     case "WALLET_CONNECTED": {
-      const { walletId, accounts } = action.payload;
+      const { walletId, contract, accounts } = action.payload;
 
       if (!accounts.length) {
         return state;
@@ -34,6 +34,7 @@ const reducer = (
 
       return {
         ...state,
+        contract,
         accounts,
         selectedWalletId: walletId,
       };
@@ -47,6 +48,7 @@ const reducer = (
 
       return {
         ...state,
+        contract: null,
         accounts: [],
         selectedWalletId: null,
       };
@@ -71,6 +73,7 @@ const reducer = (
 export const createStore = async (storage: StorageService): Promise<Store> => {
   const jsonStorage = new JsonStorage(storage, PACKAGE_NAME);
   const initialState: WalletSelectorState = {
+    contract: await jsonStorage.getItem(CONTRACT),
     modules: [],
     accounts: [],
     selectedWalletId: await jsonStorage.getItem(SELECTED_WALLET_ID),

--- a/packages/core/src/lib/store.ts
+++ b/packages/core/src/lib/store.ts
@@ -110,5 +110,9 @@ export const createStore = async (storage: StorageService): Promise<Store> => {
     observable: state$,
     getState: () => state$.getValue(),
     dispatch: (action) => actions$.next(action),
+    toReadOnly: () => ({
+      getState: () => state$.getValue(),
+      observable: state$.asObservable(),
+    }),
   };
 };

--- a/packages/core/src/lib/store.types.ts
+++ b/packages/core/src/lib/store.types.ts
@@ -1,4 +1,4 @@
-import { BehaviorSubject } from "rxjs";
+import { BehaviorSubject, Observable } from "rxjs";
 
 import { Wallet, Account } from "./wallet";
 
@@ -54,8 +54,14 @@ export type WalletSelectorAction =
       };
     };
 
+export interface ReadOnlyStore {
+  getState(): WalletSelectorState;
+  observable: Observable<WalletSelectorState>;
+}
+
 export interface Store {
   observable: BehaviorSubject<WalletSelectorState>;
   getState(): WalletSelectorState;
   dispatch(action: WalletSelectorAction): void;
+  toReadOnly(): ReadOnlyStore;
 }

--- a/packages/core/src/lib/store.types.ts
+++ b/packages/core/src/lib/store.types.ts
@@ -2,6 +2,11 @@ import { BehaviorSubject } from "rxjs";
 
 import { Wallet, Account } from "./wallet";
 
+export interface ContractState {
+  contractId: string;
+  methodNames: Array<string>;
+}
+
 export type ModuleState<Variation extends Wallet = Wallet> = {
   id: Variation["id"];
   type: Variation["type"];
@@ -12,6 +17,7 @@ export type ModuleState<Variation extends Wallet = Wallet> = {
 export type AccountState = Account;
 
 export interface WalletSelectorState {
+  contract: ContractState | null;
   modules: Array<ModuleState>;
   accounts: Array<AccountState>;
   selectedWalletId: string | null;
@@ -30,6 +36,7 @@ export type WalletSelectorAction =
       type: "WALLET_CONNECTED";
       payload: {
         walletId: string;
+        contract: ContractState;
         accounts: Array<AccountState>;
       };
     }

--- a/packages/core/src/lib/wallet-selector.ts
+++ b/packages/core/src/lib/wallet-selector.ts
@@ -27,10 +27,7 @@ export const setupWalletSelector = async (
   await walletModules.setup();
 
   return {
-    store: {
-      getState: () => store.getState(),
-      observable: store.observable.asObservable(),
-    },
+    store: store.toReadOnly(),
     get connected() {
       const { accounts } = store.getState();
 

--- a/packages/core/src/lib/wallet-selector.types.ts
+++ b/packages/core/src/lib/wallet-selector.types.ts
@@ -1,7 +1,5 @@
-import { Observable } from "rxjs";
-
 import { Wallet, WalletModuleFactory } from "./wallet/wallet.types";
-import { WalletSelectorState } from "./store.types";
+import { ReadOnlyStore } from "./store.types";
 import { Network, NetworkId, Options } from "./options.types";
 import { Subscription, StorageService } from "./services";
 
@@ -12,10 +10,7 @@ export interface WalletSelectorParams {
   debug?: boolean;
 }
 
-export interface WalletSelectorStore {
-  getState: () => WalletSelectorState;
-  observable: Observable<WalletSelectorState>;
-}
+export type WalletSelectorStore = ReadOnlyStore;
 
 export type WalletSelectorEvents = {
   networkChanged: { walletId: string; networkId: string };

--- a/packages/core/src/lib/wallet-selector.types.ts
+++ b/packages/core/src/lib/wallet-selector.types.ts
@@ -7,8 +7,6 @@ import { Subscription, StorageService } from "./services";
 
 export interface WalletSelectorParams {
   network: NetworkId | Network;
-  contractId: string;
-  methodNames?: Array<string>;
   modules: Array<WalletModuleFactory>;
   storage?: StorageService;
   debug?: boolean;

--- a/packages/core/src/lib/wallet/wallet.types.ts
+++ b/packages/core/src/lib/wallet/wallet.types.ts
@@ -7,6 +7,7 @@ import {
   JsonStorageService,
 } from "../services";
 import { Options } from "../options.types";
+import { ReadOnlyStore } from "../store.types";
 import { Transaction, Action } from "./transactions.types";
 import { Modify, Optional } from "../utils.types";
 
@@ -166,6 +167,7 @@ export interface WalletBehaviourOptions<Variation extends Wallet> {
   type: Variation["type"];
   metadata: Variation["metadata"];
   options: Options;
+  store: ReadOnlyStore;
   provider: ProviderService;
   emitter: EventEmitterService<WalletEvents>;
   logger: LoggerService;

--- a/packages/core/src/lib/wallet/wallet.types.ts
+++ b/packages/core/src/lib/wallet/wallet.types.ts
@@ -16,8 +16,27 @@ interface BaseWalletMetadata {
   iconUrl: string;
 }
 
+export interface Account {
+  accountId: string;
+}
+
+export interface ConnectParams {
+  contractId: string;
+  methodNames?: Array<string>;
+}
+
+export interface SignAndSendTransactionParams {
+  signerId?: string;
+  receiverId?: string;
+  actions: Array<Action>;
+}
+
+export interface SignAndSendTransactionsParams {
+  transactions: Array<Optional<Transaction, "signerId">>;
+}
+
 interface BaseWalletBehaviour<ExecutionOutcome> {
-  connect(): Promise<Array<Account>>;
+  connect(params: ConnectParams): Promise<Array<Account>>;
   disconnect(): Promise<void>;
   getAccounts(): Promise<Array<Account>>;
   signAndSendTransaction(
@@ -38,22 +57,12 @@ type BaseWallet<
   metadata: Metadata;
 } & Behaviour;
 
-export interface Account {
-  accountId: string;
-}
-
-export interface SignAndSendTransactionParams {
-  signerId?: string;
-  receiverId?: string;
-  actions: Array<Action>;
-}
-
-export interface SignAndSendTransactionsParams {
-  transactions: Array<Optional<Transaction, "signerId">>;
-}
-
 export type WalletEvents = {
-  connected: { accounts: Array<Account> };
+  connected: {
+    contractId: string;
+    methodNames: Array<string>;
+    accounts: Array<Account>;
+  };
   disconnected: null;
   accountsChanged: { accounts: Array<Account> };
   networkChanged: { networkId: string };
@@ -90,7 +99,7 @@ export type InjectedWallet = BaseWallet<
 
 export type HardwareWalletMetadata = BaseWalletMetadata;
 
-export interface HardwareWalletConnectParams {
+export interface HardwareWalletConnectParams extends ConnectParams {
   derivationPaths: Array<string>;
 }
 

--- a/packages/math-wallet/src/lib/math-wallet.ts
+++ b/packages/math-wallet/src/lib/math-wallet.ts
@@ -1,5 +1,6 @@
 import { isMobile } from "is-mobile";
 import {
+  WalletSelectorStore,
   WalletModuleFactory,
   WalletBehaviourFactory,
   InjectedWallet,
@@ -31,16 +32,17 @@ const isInstalled = () => {
 };
 
 const setupMathWalletState = async (
-  contractId: string
+  store: WalletSelectorStore
 ): Promise<MathWalletState> => {
   const wallet = window.nearWalletApi!;
+  const { contract } = store.getState();
 
   // This wallet currently has weird behaviour regarding signer.account.
   // - When you initially sign in, you get a SignedInAccount interface.
   // - When the extension loads after this, you get a PreviouslySignedInAccount interface.
   // This method normalises the behaviour to only return the SignedInAccount interface.
-  if (wallet.signer.account && "address" in wallet.signer.account) {
-    await wallet.login({ contractId });
+  if (contract && wallet.signer.account && "address" in wallet.signer.account) {
+    await wallet.login({ contractId: contract.contractId });
   }
 
   return {
@@ -50,10 +52,11 @@ const setupMathWalletState = async (
 
 const MathWallet: WalletBehaviourFactory<InjectedWallet> = async ({
   options,
+  store,
   provider,
   logger,
 }) => {
-  const _state = await setupMathWalletState(options.contractId);
+  const _state = await setupMathWalletState(store);
 
   const getSignedInAccount = () => {
     if (
@@ -77,34 +80,33 @@ const MathWallet: WalletBehaviourFactory<InjectedWallet> = async ({
   };
 
   const transformTransactions = (
-    transactions: Array<Optional<Transaction, "signerId">>
+    transactions: Array<Optional<Transaction, "signerId" | "receiverId">>
   ): Array<Transaction> => {
     const account = getSignedInAccount();
+    const { contract } = store.getState();
 
-    if (!account) {
+    if (!account || !contract) {
       throw new Error("Wallet not connected");
     }
 
-    return transactions.map((t) => {
-      const signerId = t.signerId ? t.signerId : account.accountId;
-
+    return transactions.map((transaction) => {
       return {
-        receiverId: t.receiverId,
-        actions: t.actions,
-        signerId,
+        signerId: transaction.signerId || account.accountId,
+        receiverId: transaction.receiverId || contract.contractId,
+        actions: transaction.actions,
       };
     });
   };
 
   return {
-    async connect() {
+    async connect({ contractId }) {
       const existingAccounts = getAccounts();
 
       if (existingAccounts.length) {
         return existingAccounts;
       }
 
-      await _state.wallet.login({ contractId: options.contractId });
+      await _state.wallet.login({ contractId });
 
       return getAccounts();
     },
@@ -118,19 +120,8 @@ const MathWallet: WalletBehaviourFactory<InjectedWallet> = async ({
       return getAccounts();
     },
 
-    async signAndSendTransaction({
-      signerId,
-      receiverId = options.contractId,
-      actions,
-    }) {
+    async signAndSendTransaction({ signerId, receiverId, actions }) {
       logger.log("signAndSendTransaction", { signerId, receiverId, actions });
-
-      const account = getSignedInAccount();
-
-      if (!account) {
-        throw new Error("Not signed in");
-      }
-
       const signedTransactions = await signTransactions(
         transformTransactions([{ signerId, receiverId, actions }]),
         _state.wallet.signer,
@@ -142,12 +133,6 @@ const MathWallet: WalletBehaviourFactory<InjectedWallet> = async ({
 
     async signAndSendTransactions({ transactions }) {
       logger.log("signAndSendTransactions", { transactions });
-
-      const account = getSignedInAccount();
-
-      if (!account) {
-        throw new Error("Wallet not connected");
-      }
 
       const signedTransactions = await signTransactions(
         transformTransactions(transactions),

--- a/packages/modal-ui/src/lib/components/LedgerDerivationPath.tsx
+++ b/packages/modal-ui/src/lib/components/LedgerDerivationPath.tsx
@@ -1,8 +1,10 @@
 import React, { ChangeEvent, KeyboardEventHandler, useState } from "react";
 import { WalletSelector } from "@near-wallet-selector/core";
+import { ModalOptions } from "../modal.types";
 
 interface LedgerDerivationPathProps {
   selector: WalletSelector;
+  options: ModalOptions;
   onBack: () => void;
   onConnected: () => void;
 }
@@ -11,6 +13,7 @@ export const DEFAULT_DERIVATION_PATH = "44'/397'/0'/0'/1'";
 
 export const LedgerDerivationPath: React.FC<LedgerDerivationPathProps> = ({
   selector,
+  options,
   onBack,
   onConnected,
 }) => {
@@ -36,7 +39,11 @@ export const LedgerDerivationPath: React.FC<LedgerDerivationPathProps> = ({
     setIsLoading(true);
 
     return wallet
-      .connect({ derivationPaths: [ledgerDerivationPath] })
+      .connect({
+        contractId: options.contractId,
+        methodNames: options.methodNames,
+        derivationPaths: [ledgerDerivationPath],
+      })
       .then(() => onConnected())
       .catch((err) => setLedgerError(`Error: ${err.message}`))
       .finally(() => setIsLoading(false));

--- a/packages/modal-ui/src/lib/components/Modal.tsx
+++ b/packages/modal-ui/src/lib/components/Modal.tsx
@@ -12,7 +12,7 @@ import styles from "./Modal.styles";
 
 interface ModalProps {
   selector: WalletSelector;
-  options?: ModalOptions;
+  options: ModalOptions;
   visible: boolean;
   hide: () => void;
 }
@@ -116,6 +116,7 @@ export const Modal: React.FC<ModalProps> = ({
           {routeName === "LedgerDerivationPath" && (
             <LedgerDerivationPath
               selector={selector}
+              options={options}
               onConnected={handleDismissClick}
               onBack={() => setRouteName("WalletOptions")}
             />

--- a/packages/modal-ui/src/lib/components/WalletOptions.tsx
+++ b/packages/modal-ui/src/lib/components/WalletOptions.tsx
@@ -5,7 +5,7 @@ import { ModalOptions } from "../modal.types";
 
 interface WalletOptionsProps {
   selector: WalletSelector;
-  options?: ModalOptions;
+  options: ModalOptions;
   onConnectHardwareWallet: () => void;
   onConnected: () => void;
   onError: (error: Error) => void;
@@ -44,7 +44,11 @@ export const WalletOptions: React.FC<WalletOptionsProps> = ({
         return onConnectHardwareWallet();
       }
 
-      await wallet.connect();
+      await wallet.connect({
+        contractId: options.contractId,
+        methodNames: options.methodNames,
+      });
+
       onConnected();
     } catch (err) {
       const { name } = module.metadata;

--- a/packages/modal-ui/src/lib/modal.tsx
+++ b/packages/modal-ui/src/lib/modal.tsx
@@ -9,7 +9,7 @@ const MODAL_ELEMENT_ID = "near-wallet-selector-modal";
 
 export const setupModal = (
   selector: WalletSelector,
-  options?: ModalOptions
+  options: ModalOptions
 ): WalletSelectorModal => {
   const el = document.createElement("div");
   el.id = MODAL_ELEMENT_ID;

--- a/packages/modal-ui/src/lib/modal.types.ts
+++ b/packages/modal-ui/src/lib/modal.types.ts
@@ -1,6 +1,8 @@
 export type Theme = "dark" | "light" | "auto";
 
 export interface ModalOptions {
+  contractId: string;
+  methodNames?: Array<string>;
   theme?: Theme;
   description?: string;
 }

--- a/packages/sender/src/lib/sender.ts
+++ b/packages/sender/src/lib/sender.ts
@@ -141,7 +141,7 @@ const Sender: WalletBehaviourFactory<InjectedWallet> = async ({
   }
 
   return {
-    async connect() {
+    async connect({ contractId, methodNames }) {
       const existingAccounts = getAccounts();
 
       if (existingAccounts.length) {
@@ -149,8 +149,8 @@ const Sender: WalletBehaviourFactory<InjectedWallet> = async ({
       }
 
       const { accessKey, error } = await _state.wallet.requestSignIn({
-        contractId: options.contractId,
-        methodNames: options.methodNames,
+        contractId,
+        methodNames,
       });
 
       if (!accessKey || error) {
@@ -173,11 +173,7 @@ const Sender: WalletBehaviourFactory<InjectedWallet> = async ({
       return getAccounts();
     },
 
-    async signAndSendTransaction({
-      signerId,
-      receiverId = options.contractId,
-      actions,
-    }) {
+    async signAndSendTransaction({ signerId, receiverId, actions }) {
       logger.log("signAndSendTransaction", { signerId, receiverId, actions });
 
       if (!_state.wallet.isSignedIn()) {
@@ -186,7 +182,8 @@ const Sender: WalletBehaviourFactory<InjectedWallet> = async ({
 
       return _state.wallet
         .signAndSendTransaction({
-          receiverId,
+          // TODO: Get default contractId from store.
+          receiverId: receiverId || "guest-book.testnet",
           actions: transformActions(actions),
         })
         .then((res) => {

--- a/packages/sender/src/lib/sender.ts
+++ b/packages/sender/src/lib/sender.ts
@@ -41,6 +41,7 @@ const setupSenderState = (): SenderState => {
 const Sender: WalletBehaviourFactory<InjectedWallet> = async ({
   options,
   metadata,
+  store,
   emitter,
   logger,
 }) => {
@@ -176,14 +177,15 @@ const Sender: WalletBehaviourFactory<InjectedWallet> = async ({
     async signAndSendTransaction({ signerId, receiverId, actions }) {
       logger.log("signAndSendTransaction", { signerId, receiverId, actions });
 
-      if (!_state.wallet.isSignedIn()) {
+      const { contract } = store.getState();
+
+      if (!_state.wallet.isSignedIn() || !contract) {
         throw new Error("Wallet not connected");
       }
 
       return _state.wallet
         .signAndSendTransaction({
-          // TODO: Get default contractId from store.
-          receiverId: receiverId || "guest-book.testnet",
+          receiverId: receiverId || contract.contractId,
           actions: transformActions(actions),
         })
         .then((res) => {

--- a/packages/wallet-connect/src/lib/wallet-connect.ts
+++ b/packages/wallet-connect/src/lib/wallet-connect.ts
@@ -177,9 +177,10 @@ const WalletConnect: WalletBehaviourFactory<
         actions,
       });
 
+      const accounts = getAccounts();
       const { contract } = store.getState();
 
-      if (!_state.session || !contract) {
+      if (!_state.session || !accounts.length || !contract) {
         throw new Error("Wallet not connected");
       }
 
@@ -190,7 +191,7 @@ const WalletConnect: WalletBehaviourFactory<
         request: {
           method: "near_signAndSendTransaction",
           params: {
-            signerId,
+            signerId: signerId || accounts[0].accountId,
             receiverId: receiverId || contract.contractId,
             actions,
           },


### PR DESCRIPTION
# Description

- Migrated `contractId` and `methodNames` to a wallet level.
- `contractId` and `methodNames` are now part of state.
- Wallets now have access to a read-only variation of the store.
- Fixed bug with WalletConnect when `signerId` is not passed.
- Fixed bug with WalletConnect when a session is deleted.

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change. This type of change is the main reason for the PR.
<!-- CHECKLIST_TYPE: ONE -->
- [x] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->

# Breaking changes
<!-- CHECKLIST_TYPE: ONE -->
<!-- SPECIFY BREAKING CHANGES AS A ONE-LINER -->
- [ ] BREAKING CHANGE - SPECIFY: _______
- [x] NO BREAKING CHANGE - this PR doesn't contain any breaking changes and it's backwards compatible
<!-- /CHECKLIST_TYPE -->
