### PR TITLE
fix: Next.js support

### DIFF
--- a/packages/core/src/lib/services/logger/logging.service.ts
+++ b/packages/core/src/lib/services/logger/logging.service.ts
@@ -38,4 +38,4 @@ export class Logger {
   }
 }
 
-export const logger = new Logger();
+export const logger = typeof window !== "undefined" ? new Logger() : undefined;

--- a/packages/core/src/lib/services/persistent-storage/persistent-storage.service.ts
+++ b/packages/core/src/lib/services/persistent-storage/persistent-storage.service.ts
@@ -64,4 +64,4 @@ export class PersistentStorage {
   }
 }
 
-export const storage = new PersistentStorage();
+export const storage = typeof window !== "undefined" ? new PersistentStorage() : undefined;

--- a/packages/ledger/tsconfig.lib.json
+++ b/packages/ledger/tsconfig.lib.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
     "declaration": true,
-    "types": []
+    "types": [],
+    "module": "commonjs"
   },
   "include": ["**/*.ts"],
   "exclude": ["**/*.spec.ts"]

--- a/packages/math-wallet/tsconfig.lib.json
+++ b/packages/math-wallet/tsconfig.lib.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
     "declaration": true,
-    "types": []
+    "types": [],
+    "module": "commonjs"
   },
   "include": ["**/*.ts"],
   "exclude": ["**/*.spec.ts"]

--- a/packages/near-wallet/tsconfig.lib.json
+++ b/packages/near-wallet/tsconfig.lib.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
     "declaration": true,
-    "types": []
+    "types": [],
+    "module": "commonjs"
   },
   "include": ["**/*.ts"],
   "exclude": ["**/*.spec.ts"]

--- a/packages/sender/tsconfig.lib.json
+++ b/packages/sender/tsconfig.lib.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
     "declaration": true,
-    "types": []
+    "types": [],
+    "module": "commonjs"
   },
   "include": ["**/*.ts"],
   "exclude": ["**/*.spec.ts"]

--- a/packages/wallet-connect/tsconfig.lib.json
+++ b/packages/wallet-connect/tsconfig.lib.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "types": ["node"]
+    "types": ["node"],
+    "module": "commonjs"
   },
   "files": [
     "../../node_modules/@nrwl/react/typings/cssmodule.d.ts",


### PR DESCRIPTION
# Description

- Fix server side compilation issue by adding window object check
- Use commonjs for various wallet adapters


### Caveat (NEXT.js only)

[Images imported in the SDK] (https://github.com/near/wallet-selector/blob/df1d42a6610d4ee22b6c7b3a86329e74ca7e3ed2/packages/near-wallet/src/lib/near-wallet.ts#L97) won't work directly. You must separately add those images in public/assets folder.

Closes #297 


# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change. This type of change is the main reason for the PR.
<!-- CHECKLIST_TYPE: ONE -->
- [x] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->

# Breaking changes
<!-- CHECKLIST_TYPE: ONE -->
<!-- SPECIFY BREAKING CHANGES AS A ONE-LINER -->
- [ ] BREAKING CHANGE - SPECIFY: _______
- [ ] NO BREAKING CHANGE - this PR doesn't contain any breaking changes and it's backwards compatible
<!-- /CHECKLIST_TYPE -->
