### PR TITLE
build: Change Builder to Support (esm, cjs, umd)

### DIFF
--- a/packages/ledger/project.json
+++ b/packages/ledger/project.json
@@ -4,22 +4,27 @@
   "projectType": "library",
   "targets": {
     "build": {
-      "executor": "@nrwl/js:tsc",
+      "executor": "@nrwl/web:rollup",
       "outputs": ["{options.outputPath}"],
-      "targetDependencies": {
-        "build": [{
-          "target": "build",
-          "projects": "dependencies"
-        }]
-      },
       "options": {
         "outputPath": "dist/packages/ledger",
-        "main": "packages/ledger/src/index.ts",
         "tsConfig": "packages/ledger/tsconfig.lib.json",
+        "project": "packages/ledger/package.json",
+        "entryFile": "packages/ledger/src/index.ts",
         "buildableProjectDepsInPackageJsonType": "dependencies",
+        "compiler": "babel",
+        "format": ["esm", "umd", "cjs"],
         "assets": [
-          "packages/ledger/*.md",
-          "packages/ledger/assets/*"
+          {
+            "glob": "packages/ledger/README.md",
+            "input": ".",
+            "output": "."
+          },
+          {
+            "glob": "packages/ledger/assets/*",
+            "input": ".",
+            "output": "assets"
+          }
         ]
       }
     },

--- a/packages/math-wallet/project.json
+++ b/packages/math-wallet/project.json
@@ -4,22 +4,27 @@
   "projectType": "library",
   "targets": {
     "build": {
-      "executor": "@nrwl/js:tsc",
+      "executor": "@nrwl/web:rollup",
       "outputs": ["{options.outputPath}"],
-      "targetDependencies": {
-        "build": [{
-          "target": "build",
-          "projects": "dependencies"
-        }]
-      },
       "options": {
         "outputPath": "dist/packages/math-wallet",
-        "main": "packages/math-wallet/src/index.ts",
         "tsConfig": "packages/math-wallet/tsconfig.lib.json",
+        "project": "packages/math-wallet/package.json",
+        "entryFile": "packages/math-wallet/src/index.ts",
         "buildableProjectDepsInPackageJsonType": "dependencies",
+        "compiler": "babel",
+        "format": ["esm", "umd", "cjs"],
         "assets": [
-          "packages/math-wallet/*.md",
-          "packages/math-wallet/assets/*"
+          {
+            "glob": "packages/math-wallet/README.md",
+            "input": ".",
+            "output": "."
+          },
+          {
+            "glob": "packages/math-wallet/assets/*",
+            "input": ".",
+            "output": "assets"
+          }
         ]
       }
     },

--- a/packages/near-wallet/project.json
+++ b/packages/near-wallet/project.json
@@ -4,22 +4,27 @@
   "projectType": "library",
   "targets": {
     "build": {
-      "executor": "@nrwl/js:tsc",
+      "executor": "@nrwl/web:rollup",
       "outputs": ["{options.outputPath}"],
-      "targetDependencies": {
-        "build": [{
-          "target": "build",
-          "projects": "dependencies"
-        }]
-      },
       "options": {
         "outputPath": "dist/packages/near-wallet",
-        "main": "packages/near-wallet/src/index.ts",
         "tsConfig": "packages/near-wallet/tsconfig.lib.json",
+        "project": "packages/near-wallet/package.json",
+        "entryFile": "packages/near-wallet/src/index.ts",
         "buildableProjectDepsInPackageJsonType": "dependencies",
+        "compiler": "babel",
+        "format": ["esm", "umd", "cjs"],
         "assets": [
-          "packages/near-wallet/*.md",
-          "packages/near-wallet/assets/*"
+          {
+            "glob": "packages/near-wallet/README.md",
+            "input": ".",
+            "output": "."
+          },
+          {
+            "glob": "packages/near-wallet/assets/*",
+            "input": ".",
+            "output": "assets"
+          }
         ]
       }
     },

--- a/packages/sender/project.json
+++ b/packages/sender/project.json
@@ -4,22 +4,27 @@
   "projectType": "library",
   "targets": {
     "build": {
-      "executor": "@nrwl/js:tsc",
+      "executor": "@nrwl/web:rollup",
       "outputs": ["{options.outputPath}"],
-      "targetDependencies": {
-        "build": [{
-          "target": "build",
-          "projects": "dependencies"
-        }]
-      },
       "options": {
         "outputPath": "dist/packages/sender",
-        "main": "packages/sender/src/index.ts",
         "tsConfig": "packages/sender/tsconfig.lib.json",
+        "project": "packages/sender/package.json",
+        "entryFile": "packages/sender/src/index.ts",
         "buildableProjectDepsInPackageJsonType": "dependencies",
+        "compiler": "babel",
+        "format": ["esm", "umd", "cjs"],
         "assets": [
-          "packages/sender/*.md",
-          "packages/sender/assets/*"
+          {
+            "glob": "packages/sender/README.md",
+            "input": ".",
+            "output": "."
+          },
+          {
+            "glob": "packages/sender/assets/*",
+            "input": ".",
+            "output": "assets"
+          }
         ]
       }
     },

--- a/packages/wallet-connect/project.json
+++ b/packages/wallet-connect/project.json
@@ -4,22 +4,27 @@
   "projectType": "library",
   "targets": {
     "build": {
-      "executor": "@nrwl/js:tsc",
+      "executor": "@nrwl/web:rollup",
       "outputs": ["{options.outputPath}"],
-      "targetDependencies": {
-        "build": [{
-          "target": "build",
-          "projects": "dependencies"
-        }]
-      },
       "options": {
         "outputPath": "dist/packages/wallet-connect",
-        "main": "packages/wallet-connect/src/index.ts",
         "tsConfig": "packages/wallet-connect/tsconfig.lib.json",
+        "project": "packages/wallet-connect/package.json",
+        "entryFile": "packages/wallet-connect/src/index.ts",
         "buildableProjectDepsInPackageJsonType": "dependencies",
+        "compiler": "babel",
+        "format": ["esm", "umd", "cjs"],
         "assets": [
-          "packages/wallet-connect/*.md",
-          "packages/wallet-connect/assets/*"
+          {
+            "glob": "packages/wallet-connect/README.md",
+            "input": ".",
+            "output": "."
+          },
+          {
+            "glob": "packages/wallet-connect/assets/*",
+            "input": ".",
+            "output": "assets"
+          }
         ]
       }
     },

--- a/packages/wallet-utils/project.json
+++ b/packages/wallet-utils/project.json
@@ -4,22 +4,27 @@
   "projectType": "library",
   "targets": {
     "build": {
-      "executor": "@nrwl/js:tsc",
+      "executor": "@nrwl/web:rollup",
       "outputs": ["{options.outputPath}"],
-      "targetDependencies": {
-        "build": [{
-          "target": "build",
-          "projects": "dependencies"
-        }]
-      },
       "options": {
         "outputPath": "dist/packages/wallet-utils",
-        "main": "packages/wallet-utils/src/index.ts",
         "tsConfig": "packages/wallet-utils/tsconfig.lib.json",
+        "project": "packages/wallet-utils/package.json",
+        "entryFile": "packages/wallet-utils/src/index.ts",
         "buildableProjectDepsInPackageJsonType": "dependencies",
+        "compiler": "babel",
+        "format": ["esm", "umd", "cjs"],
         "assets": [
-          "packages/wallet-utils/*.md",
-          "packages/wallet-utils/assets/*"
+          {
+            "glob": "packages/wallet-utils/README.md",
+            "input": ".",
+            "output": "."
+          },
+          {
+            "glob": "packages/wallet-utils/assets/*",
+            "input": ".",
+            "output": "assets"
+          }
         ]
       }
     },


### PR DESCRIPTION
# Description

This PR is addresses the issue with some of the frameworks which don't transpile ES6 modules outside the projects /src folder.
By changing the builder to `@nrwl/web:rollup` we align all the packages to provide support for (esm, cjs, umd) like `core` and `modal-ui`

- Changed builder builder to @nrwl/web:rollup
- Added formats `"format": ["esm", "umd", "cjs"]` option.

Closes # (issue)
<!-- REMOVE ALL THE TEMPLATE BELOW IF THE PR IS A RELEASE -->


# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change. This type of change is the main reason for the PR.
<!-- CHECKLIST_TYPE: ONE -->
- [ ] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [x] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->

# Breaking changes
<!-- CHECKLIST_TYPE: ONE -->
<!-- SPECIFY BREAKING CHANGES AS A ONE-LINER -->
- [ ] BREAKING CHANGE - SPECIFY: _______
- [x] NO BREAKING CHANGE - this PR doesn't contain any breaking changes and it's backwards compatible
<!-- /CHECKLIST_TYPE -->
