### PR TITLE
Revert Build Configuration for Wallet Connect

### DIFF
--- a/packages/wallet-connect/project.json
+++ b/packages/wallet-connect/project.json
@@ -4,27 +4,22 @@
   "projectType": "library",
   "targets": {
     "build": {
-      "executor": "@nrwl/web:rollup",
+      "executor": "@nrwl/js:tsc",
       "outputs": ["{options.outputPath}"],
+      "targetDependencies": {
+        "build": [{
+          "target": "build",
+          "projects": "dependencies"
+        }]
+      },
       "options": {
         "outputPath": "dist/packages/wallet-connect",
+        "main": "packages/wallet-connect/src/index.ts",
         "tsConfig": "packages/wallet-connect/tsconfig.lib.json",
-        "project": "packages/wallet-connect/package.json",
-        "entryFile": "packages/wallet-connect/src/index.ts",
         "buildableProjectDepsInPackageJsonType": "dependencies",
-        "compiler": "babel",
-        "format": ["esm", "umd", "cjs"],
         "assets": [
-          {
-            "glob": "packages/wallet-connect/README.md",
-            "input": ".",
-            "output": "."
-          },
-          {
-            "glob": "packages/wallet-connect/assets/*",
-            "input": ".",
-            "output": "assets"
-          }
+          "packages/wallet-connect/*.md",
+          "packages/wallet-connect/assets/*"
         ]
       }
     },

--- a/packages/wallet-connect/tsconfig.lib.json
+++ b/packages/wallet-connect/tsconfig.lib.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "types": ["node"]
+    "types": ["node"],
+    "module": "commonjs"
   },
   "files": [
     "../../node_modules/@nrwl/react/typings/cssmodule.d.ts",


### PR DESCRIPTION
# Description

This PR is to revert the build configuration for `wallet-connect` package since using `@nrwl/web:rollup` seems to cause compilation errors for other projects.

- Reverted builder to `@nrwl/js:tsc`

Closes # (issue)
<!-- REMOVE ALL THE TEMPLATE BELOW IF THE PR IS A RELEASE -->


# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change. This type of change is the main reason for the PR.
<!-- CHECKLIST_TYPE: ONE -->
- [ ] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->

# Breaking changes
<!-- CHECKLIST_TYPE: ONE -->
<!-- SPECIFY BREAKING CHANGES AS A ONE-LINER -->
- [ ] BREAKING CHANGE - SPECIFY: _______
- [ ] NO BREAKING CHANGE - this PR doesn't contain any breaking changes and it's backwards compatible
<!-- /CHECKLIST_TYPE -->
