### PR TITLE
refactor: Sqac 149 prevent side effects of multiple calls to setup modal setup wallet selector

### DIFF
--- a/packages/core/src/lib/wallet-selector.ts
+++ b/packages/core/src/lib/wallet-selector.ts
@@ -8,6 +8,8 @@ import type {
 import { EventEmitter, Logger, WalletModules } from "./services";
 import type { Wallet } from "./wallet";
 
+let walletSelectorInstance: WalletSelector | null = null;
+
 export const setupWalletSelector = async (
   params: WalletSelectorParams
 ): Promise<WalletSelector> => {
@@ -26,35 +28,39 @@ export const setupWalletSelector = async (
 
   await walletModules.setup();
 
-  return {
-    options,
-    store: store.toReadOnly(),
-    wallet: async <Variation extends Wallet = Wallet>(id?: string) => {
-      const { selectedWalletId } = store.getState();
-      const wallet = await walletModules.getWallet<Variation>(
-        id || selectedWalletId
-      );
+  if (!walletSelectorInstance) {
+    walletSelectorInstance = {
+      options,
+      store: store.toReadOnly(),
+      wallet: async <Variation extends Wallet = Wallet>(id?: string) => {
+        const { selectedWalletId } = store.getState();
+        const wallet = await walletModules.getWallet<Variation>(
+          id || selectedWalletId
+        );
 
-      if (!wallet) {
-        if (id) {
-          throw new Error("Invalid wallet id");
+        if (!wallet) {
+          if (id) {
+            throw new Error("Invalid wallet id");
+          }
+
+          throw new Error("No wallet selected");
         }
 
-        throw new Error("No wallet selected");
-      }
+        return wallet;
+      },
+      isSignedIn() {
+        const { accounts } = store.getState();
 
-      return wallet;
-    },
-    isSignedIn() {
-      const { accounts } = store.getState();
+        return Boolean(accounts.length);
+      },
+      on: (eventName, callback) => {
+        return emitter.on(eventName, callback);
+      },
+      off: (eventName, callback) => {
+        emitter.off(eventName, callback);
+      },
+    };
+  }
 
-      return Boolean(accounts.length);
-    },
-    on: (eventName, callback) => {
-      return emitter.on(eventName, callback);
-    },
-    off: (eventName, callback) => {
-      emitter.off(eventName, callback);
-    },
-  };
+  return walletSelectorInstance;
 };

--- a/packages/modal-ui/src/lib/modal.tsx
+++ b/packages/modal-ui/src/lib/modal.tsx
@@ -7,6 +7,8 @@ import { Modal } from "./components/Modal";
 
 const MODAL_ELEMENT_ID = "near-wallet-selector-modal";
 
+let modalInstance: WalletSelectorModal | null = null;
+
 export const setupModal = (
   selector: WalletSelector,
   options: ModalOptions
@@ -29,12 +31,16 @@ export const setupModal = (
 
   render();
 
-  return {
-    show: () => {
-      render(true);
-    },
-    hide: () => {
-      render(false);
-    },
-  };
+  if (!modalInstance) {
+    modalInstance = {
+      show: () => {
+        render(true);
+      },
+      hide: () => {
+        render(false);
+      },
+    };
+  }
+
+  return modalInstance;
 };


### PR DESCRIPTION
# Description
- Calling `setupWalletSelector` and `setupModal` now returns the same instance each time which is stored in memory.

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change. This type of change is the main reason for the PR.
<!-- CHECKLIST_TYPE: ONE -->
- [ ] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [x] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->

# Breaking changes
<!-- CHECKLIST_TYPE: ONE -->
<!-- SPECIFY BREAKING CHANGES AS A ONE-LINER -->
- [ ] BREAKING CHANGE - SPECIFY: _______
- [x] NO BREAKING CHANGE - this PR doesn't contain any breaking changes and it's backwards compatible
<!-- /CHECKLIST_TYPE -->
