### PR TITLE
fix: Add `indexerUrl` to Network

### DIFF
--- a/packages/core/src/lib/options.spec.ts
+++ b/packages/core/src/lib/options.spec.ts
@@ -11,6 +11,7 @@ describe("getNetworkPreset", () => {
       nodeUrl: "https://rpc.mainnet.near.org",
       helperUrl: "https://helper.mainnet.near.org",
       explorerUrl: "https://explorer.near.org",
+      indexerUrl: "https://api.kitwallet.app",
     });
   });
 
@@ -23,6 +24,7 @@ describe("getNetworkPreset", () => {
       nodeUrl: "https://rpc.testnet.near.org",
       helperUrl: "https://helper.testnet.near.org",
       explorerUrl: "https://explorer.testnet.near.org",
+      indexerUrl: "https://testnet-api.kitwallet.app",
     });
   });
 
@@ -35,6 +37,7 @@ describe("getNetworkPreset", () => {
       nodeUrl: "https://rpc.betanet.near.org",
       helperUrl: "https://helper.betanet.near.org",
       explorerUrl: "https://explorer.betanet.near.org",
+      indexerUrl: "",
     });
   });
 });
@@ -52,6 +55,7 @@ describe("resolveNetwork", () => {
       nodeUrl: "http://127.0.0.1:52993",
       helperUrl: "http://127.0.0.1:52997",
       explorerUrl: "http://127.0.0.1:53009",
+      indexerUrl: "http://127.0.0.1:52997",
     };
 
     expect(resolveNetwork(network)).toEqual(network);

--- a/packages/core/src/lib/options.ts
+++ b/packages/core/src/lib/options.ts
@@ -10,6 +10,7 @@ export const getNetworkPreset = (networkId: NetworkId): Network => {
         nodeUrl: "https://rpc.mainnet.near.org",
         helperUrl: "https://helper.mainnet.near.org",
         explorerUrl: "https://explorer.near.org",
+        indexerUrl: "https://api.kitwallet.app",
       };
     case "testnet":
       return {
@@ -17,6 +18,7 @@ export const getNetworkPreset = (networkId: NetworkId): Network => {
         nodeUrl: "https://rpc.testnet.near.org",
         helperUrl: "https://helper.testnet.near.org",
         explorerUrl: "https://explorer.testnet.near.org",
+        indexerUrl: "https://testnet-api.kitwallet.app",
       };
     case "betanet":
       return {
@@ -24,6 +26,8 @@ export const getNetworkPreset = (networkId: NetworkId): Network => {
         nodeUrl: "https://rpc.betanet.near.org",
         helperUrl: "https://helper.betanet.near.org",
         explorerUrl: "https://explorer.betanet.near.org",
+        //TODO: Update value with the correct endpoint once it's available.
+        indexerUrl: "",
       };
     default:
       throw Error(`Failed to find config for: '${networkId}'`);

--- a/packages/core/src/lib/options.types.ts
+++ b/packages/core/src/lib/options.types.ts
@@ -5,6 +5,7 @@ export interface Network {
   nodeUrl: string;
   helperUrl: string;
   explorerUrl: string;
+  indexerUrl: string;
 }
 
 export interface Options {

--- a/packages/ledger/src/lib/ledger.ts
+++ b/packages/ledger/src/lib/ledger.ts
@@ -161,7 +161,7 @@ const Ledger: WalletBehaviourFactory<HardwareWallet> = async ({
     publicKey,
   }: GetAccountIdFromPublicKeyParams): Promise<string> => {
     const response = await fetch(
-      `${options.network.helperUrl}/publicKey/ed25519:${publicKey}/accounts`
+      `${options.network.indexerUrl}/publicKey/ed25519:${publicKey}/accounts`
     );
 
     if (!response.ok) {


### PR DESCRIPTION
# Description

- Added extra option `indexerUrl` to fix bug for ledger when we query accounts by public key.

Closes #321 
<!-- REMOVE ALL THE TEMPLATE BELOW IF THE PR IS A RELEASE -->


# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change. This type of change is the main reason for the PR.
<!-- CHECKLIST_TYPE: ONE -->
- [x] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->

# Breaking changes
<!-- CHECKLIST_TYPE: ONE -->
<!-- SPECIFY BREAKING CHANGES AS A ONE-LINER -->
- [ ] BREAKING CHANGE - SPECIFY: _______
- [x] NO BREAKING CHANGE - this PR doesn't contain any breaking changes and it's backwards compatible
<!-- /CHECKLIST_TYPE -->
