### PR TITLE
refactor: Remove `betanet` Network Preset

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -29,7 +29,7 @@ const selector = await setupWalletSelector({
 
 ## Options
 
-- `network` (`NetworkId | Network`): Network ID or object matching that of your dApp configuration . Network ID can be either `mainnet`, `testnet` or `betanet`.
+- `network` (`NetworkId | Network`): Network ID or object matching that of your dApp configuration . Network ID can be either `mainnet` or `testnet`.
   - `networkId` (`string`): Custom network ID (e.g. `localnet`).
   - `nodeUrl` (`string`): Custom URL for RPC requests.
   - `helperUrl` (`string`): Custom URL for creating accounts.

--- a/packages/core/src/lib/options.spec.ts
+++ b/packages/core/src/lib/options.spec.ts
@@ -27,19 +27,6 @@ describe("getNetworkPreset", () => {
       indexerUrl: "https://testnet-api.kitwallet.app",
     });
   });
-
-  it("returns the correct config for 'betanet'", () => {
-    const networkId: NetworkId = "betanet";
-    const network = getNetworkPreset(networkId);
-
-    expect(network).toEqual({
-      networkId,
-      nodeUrl: "https://rpc.betanet.near.org",
-      helperUrl: "https://helper.betanet.near.org",
-      explorerUrl: "https://explorer.betanet.near.org",
-      indexerUrl: "",
-    });
-  });
 });
 
 describe("resolveNetwork", () => {

--- a/packages/core/src/lib/options.ts
+++ b/packages/core/src/lib/options.ts
@@ -20,15 +20,6 @@ export const getNetworkPreset = (networkId: NetworkId): Network => {
         explorerUrl: "https://explorer.testnet.near.org",
         indexerUrl: "https://testnet-api.kitwallet.app",
       };
-    case "betanet":
-      return {
-        networkId,
-        nodeUrl: "https://rpc.betanet.near.org",
-        helperUrl: "https://helper.betanet.near.org",
-        explorerUrl: "https://explorer.betanet.near.org",
-        //TODO: Update value with the correct endpoint once it's available.
-        indexerUrl: "",
-      };
     default:
       throw Error(`Failed to find config for: '${networkId}'`);
   }

--- a/packages/core/src/lib/options.types.ts
+++ b/packages/core/src/lib/options.types.ts
@@ -1,4 +1,4 @@
-export type NetworkId = "mainnet" | "testnet" | "betanet";
+export type NetworkId = "mainnet" | "testnet";
 
 export interface Network {
   networkId: string;

--- a/packages/my-near-wallet/README.md
+++ b/packages/my-near-wallet/README.md
@@ -34,7 +34,7 @@ const selector = await setupWalletSelector({
 
 ## Options
 
-- `walletUrl` (`string?`): Wallet URL used to redirect when signing transactions. This parameter is required for `betanet` and custom network configuration.
+- `walletUrl` (`string?`): Wallet URL used to redirect when signing transactions. This parameter is required for custom network configuration.
 - `iconUrl`: (`string?`): Image URL for the icon shown in the modal. This can also be a relative path or base64 encoded image. Defaults to `./assets/my-near-wallet-icon.png`.
 
 ## Assets

--- a/packages/near-wallet/src/lib/near-wallet.ts
+++ b/packages/near-wallet/src/lib/near-wallet.ts
@@ -20,8 +20,6 @@ const resolveWalletUrl = (network: Network, walletUrl?: string) => {
       return "https://wallet.near.org";
     case "testnet":
       return "https://wallet.testnet.near.org";
-    case "betanet":
-      return "https://wallet.betanet.near.org";
     default:
       throw new Error("Invalid wallet url");
   }

--- a/packages/wallet-connect/src/lib/wallet-connect.ts
+++ b/packages/wallet-connect/src/lib/wallet-connect.ts
@@ -61,7 +61,7 @@ const WalletConnect: WalletBehaviourFactory<
 
     const { networkId } = options.network;
 
-    if (["mainnet", "testnet", "betanet"].includes(networkId)) {
+    if (["mainnet", "testnet"].includes(networkId)) {
       return `near:${networkId}`;
     }
 


### PR DESCRIPTION
# Description

- Removed `betanet` network preset.

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change. This type of change is the main reason for the PR.
<!-- CHECKLIST_TYPE: ONE -->
- [ ] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [x] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->