### PR TITLE
fix: Set near-api-js as Peer Dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,15 @@ NEAR Wallet Selector makes it easy for users to interact with your dApp by provi
 
 ## Installation and Usage
 
-The easiest way to use NEAR Wallet Selector is to install the [`core`](https://www.npmjs.com/package/@near-wallet-selector/core) package from the NPM registry:
+The easiest way to use NEAR Wallet Selector is to install the [`core`](https://www.npmjs.com/package/@near-wallet-selector/core) package from the NPM registry, some packages may require `near-api-js` v0.44.2 or above check them at [`packages`](./packages)
+
+```bash
+# Using Yarn
+yarn add near-api-js@^0.44.2
+
+# Using NPM.
+npm install near-api-js@^0.44.2
+```
 
 ```bash
 # Using Yarn

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4,17 +4,7 @@ This is the core package for NEAR Wallet Selector.
 
 ## Installation and Usage
 
-The easiest way to use this package is to install it from the NPM registry:
-
-```bash
-# Using Yarn
-yarn add @near-wallet-selector/core
-
-# Using NPM.
-npm install @near-wallet-selector/core
-```
-
-This package requires `near-api-js` v0.44.2 or above:
+The easiest way to use this package is to install it from the NPM registry, this package requires `near-api-js` v0.44.2 or above:
 
 ```bash
 # Using Yarn
@@ -22,6 +12,14 @@ yarn add near-api-js@^0.44.2
 
 # Using NPM.
 npm install near-api-js@^0.44.2
+```
+
+```bash
+# Using Yarn
+yarn add @near-wallet-selector/core
+
+# Using NPM.
+npm install @near-wallet-selector/core
 ```
 
 Then use it in your dApp:

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -14,6 +14,16 @@ yarn add @near-wallet-selector/core
 npm install @near-wallet-selector/core
 ```
 
+This package requires `near-api-js` v0.44.2 or above:
+
+```bash
+# Using Yarn
+yarn add near-api-js@^0.44.2
+
+# Using NPM.
+npm install near-api-js@^0.44.2
+```
+
 Then use it in your dApp:
 
 ```ts

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,4 +1,7 @@
 {
   "name": "@near-wallet-selector/core",
-  "version": "5.0.0"
+  "version": "5.0.0",
+  "peerDependencies": {
+    "near-api-js": "^0.44.2"
+  }
 }

--- a/packages/ledger/README.md
+++ b/packages/ledger/README.md
@@ -14,6 +14,16 @@ yarn add @near-wallet-selector/ledger
 npm install @near-wallet-selector/ledger
 ```
 
+This package requires `near-api-js` v0.44.2 or above:
+
+```bash
+# Using Yarn
+yarn add near-api-js@^0.44.2
+
+# Using NPM.
+npm install near-api-js@^0.44.2
+```
+
 Then use it in your dApp:
 
 ```ts

--- a/packages/ledger/README.md
+++ b/packages/ledger/README.md
@@ -4,17 +4,7 @@ This is the [Ledger](https://www.ledger.com/) package for NEAR Wallet Selector.
 
 ## Installation and Usage
 
-The easiest way to use this package is to install it from the NPM registry:
-
-```bash
-# Using Yarn
-yarn add @near-wallet-selector/ledger
-
-# Using NPM.
-npm install @near-wallet-selector/ledger
-```
-
-This package requires `near-api-js` v0.44.2 or above:
+The easiest way to use this package is to install it from the NPM registry, this package requires `near-api-js` v0.44.2 or above:
 
 ```bash
 # Using Yarn
@@ -22,6 +12,13 @@ yarn add near-api-js@^0.44.2
 
 # Using NPM.
 npm install near-api-js@^0.44.2
+```
+```bash
+# Using Yarn
+yarn add @near-wallet-selector/ledger
+
+# Using NPM.
+npm install @near-wallet-selector/ledger
 ```
 
 Then use it in your dApp:

--- a/packages/ledger/package.json
+++ b/packages/ledger/package.json
@@ -1,4 +1,7 @@
 {
   "name": "@near-wallet-selector/ledger",
-  "version": "5.0.0"
+  "version": "5.0.0",
+  "peerDependencies": {
+    "near-api-js": "^0.44.2"
+  }
 }

--- a/packages/math-wallet/README.md
+++ b/packages/math-wallet/README.md
@@ -14,6 +14,17 @@ yarn add @near-wallet-selector/math-wallet
 npm install @near-wallet-selector/math-wallet
 ```
 
+
+This package requires `near-api-js` v0.44.2 or above:
+
+```bash
+# Using Yarn
+yarn add near-api-js@^0.44.2
+
+# Using NPM.
+npm install near-api-js@^0.44.2
+```
+
 Then use it in your dApp:
 
 ```ts

--- a/packages/math-wallet/README.md
+++ b/packages/math-wallet/README.md
@@ -4,18 +4,7 @@ This is the [Math Wallet](https://chrome.google.com/webstore/detail/math-wallet/
 
 ## Installation and Usage
 
-The easiest way to use this package is to install it from the NPM registry:
-
-```bash
-# Using Yarn
-yarn add @near-wallet-selector/math-wallet
-
-# Using NPM.
-npm install @near-wallet-selector/math-wallet
-```
-
-
-This package requires `near-api-js` v0.44.2 or above:
+The easiest way to use this package is to install it from the NPM registry, this package requires `near-api-js` v0.44.2 or above:
 
 ```bash
 # Using Yarn
@@ -23,6 +12,14 @@ yarn add near-api-js@^0.44.2
 
 # Using NPM.
 npm install near-api-js@^0.44.2
+```
+
+```bash
+# Using Yarn
+yarn add @near-wallet-selector/math-wallet
+
+# Using NPM.
+npm install @near-wallet-selector/math-wallet
 ```
 
 Then use it in your dApp:

--- a/packages/math-wallet/package.json
+++ b/packages/math-wallet/package.json
@@ -1,4 +1,7 @@
 {
   "name": "@near-wallet-selector/math-wallet",
-   "version": "5.0.0"
+  "version": "5.0.0",
+  "peerDependencies": {
+    "near-api-js": "^0.44.2"
+  }
 }

--- a/packages/meteor-wallet/README.md
+++ b/packages/meteor-wallet/README.md
@@ -14,6 +14,17 @@ yarn add @near-wallet-selector/meteor-wallet
 npm install @near-wallet-selector/meteor-wallet
 ```
 
+
+This package requires `near-api-js` v0.44.2 or above:
+
+```bash
+# Using Yarn
+yarn add near-api-js@^0.44.2
+
+# Using NPM.
+npm install near-api-js@^0.44.2
+```
+
 Then use it in your dApp:
 
 ```ts

--- a/packages/meteor-wallet/README.md
+++ b/packages/meteor-wallet/README.md
@@ -4,18 +4,7 @@ This is the [Meteor Wallet](https://meteorwallet.app) package for NEAR Wallet Se
 
 ## Installation and Usage
 
-The easiest way to use this package is to install it from the NPM registry:
-
-```bash
-# Using Yarn
-yarn add @near-wallet-selector/meteor-wallet
-
-# Using NPM.
-npm install @near-wallet-selector/meteor-wallet
-```
-
-
-This package requires `near-api-js` v0.44.2 or above:
+The easiest way to use this package is to install it from the NPM registry, this package requires `near-api-js` v0.44.2 or above:
 
 ```bash
 # Using Yarn
@@ -23,6 +12,13 @@ yarn add near-api-js@^0.44.2
 
 # Using NPM.
 npm install near-api-js@^0.44.2
+```
+```bash
+# Using Yarn
+yarn add @near-wallet-selector/meteor-wallet
+
+# Using NPM.
+npm install @near-wallet-selector/meteor-wallet
 ```
 
 Then use it in your dApp:

--- a/packages/meteor-wallet/package.json
+++ b/packages/meteor-wallet/package.json
@@ -1,4 +1,7 @@
 {
   "name": "@near-wallet-selector/meteor-wallet",
-  "version": "5.0.0"
+  "version": "5.0.0",
+  "peerDependencies": {
+    "near-api-js": "^0.44.2"
+  }
 }

--- a/packages/my-near-wallet/README.md
+++ b/packages/my-near-wallet/README.md
@@ -14,6 +14,16 @@ yarn add @near-wallet-selector/my-near-wallet
 npm install @near-wallet-selector/my-near-wallet
 ```
 
+This package requires `near-api-js` v0.44.2 or above:
+
+```bash
+# Using Yarn
+yarn add near-api-js@^0.44.2
+
+# Using NPM.
+npm install near-api-js@^0.44.2
+```
+
 Then use it in your dApp:
 
 ```ts

--- a/packages/my-near-wallet/README.md
+++ b/packages/my-near-wallet/README.md
@@ -4,17 +4,7 @@ This is the [My NEAR Wallet](https://mynearwallet.com/) package for NEAR Wallet 
 
 ## Installation and Usage
 
-The easiest way to use this package is to install it from the NPM registry:
-
-```bash
-# Using Yarn
-yarn add @near-wallet-selector/my-near-wallet
-
-# Using NPM.
-npm install @near-wallet-selector/my-near-wallet
-```
-
-This package requires `near-api-js` v0.44.2 or above:
+The easiest way to use this package is to install it from the NPM registry, this package requires `near-api-js` v0.44.2 or above:
 
 ```bash
 # Using Yarn
@@ -22,6 +12,13 @@ yarn add near-api-js@^0.44.2
 
 # Using NPM.
 npm install near-api-js@^0.44.2
+```
+```bash
+# Using Yarn
+yarn add @near-wallet-selector/my-near-wallet
+
+# Using NPM.
+npm install @near-wallet-selector/my-near-wallet
 ```
 
 Then use it in your dApp:

--- a/packages/my-near-wallet/package.json
+++ b/packages/my-near-wallet/package.json
@@ -1,4 +1,7 @@
 {
   "name": "@near-wallet-selector/my-near-wallet",
-   "version": "5.0.0"
+  "version": "5.0.0",
+  "peerDependencies": {
+    "near-api-js": "^0.44.2"
+  }
 }

--- a/packages/nightly-connect/README.md
+++ b/packages/nightly-connect/README.md
@@ -4,17 +4,7 @@ This is the [Nightly Connect](https://connect.nightly.app/) package for NEAR Wal
 
 ## Installation and Usage
 
-The easiest way to use this package is to install it from the NPM registry:
-
-```bash
-# Using Yarn
-yarn add @near-wallet-selector/nightly-connect
-
-# Using NPM.
-npm install @near-wallet-selector/nightly-connect
-```
-
-This package requires `near-api-js` v0.44.2 or above:
+The easiest way to use this package is to install it from the NPM registry, this package requires `near-api-js` v0.44.2 or above:
 
 ```bash
 # Using Yarn
@@ -22,6 +12,14 @@ yarn add near-api-js@^0.44.2
 
 # Using NPM.
 npm install near-api-js@^0.44.2
+```
+
+```bash
+# Using Yarn
+yarn add @near-wallet-selector/nightly-connect
+
+# Using NPM.
+npm install @near-wallet-selector/nightly-connect
 ```
 Then use it in your dApp:
 

--- a/packages/nightly-connect/README.md
+++ b/packages/nightly-connect/README.md
@@ -14,6 +14,15 @@ yarn add @near-wallet-selector/nightly-connect
 npm install @near-wallet-selector/nightly-connect
 ```
 
+This package requires `near-api-js` v0.44.2 or above:
+
+```bash
+# Using Yarn
+yarn add near-api-js@^0.44.2
+
+# Using NPM.
+npm install near-api-js@^0.44.2
+```
 Then use it in your dApp:
 
 ```ts

--- a/packages/nightly-connect/package.json
+++ b/packages/nightly-connect/package.json
@@ -1,4 +1,7 @@
 {
   "name": "@near-wallet-selector/nightly-connect",
-  "version": "5.0.0"
+  "version": "5.0.0",
+  "peerDependencies": {
+    "near-api-js": "^0.44.2"
+  }
 }

--- a/packages/nightly/README.md
+++ b/packages/nightly/README.md
@@ -15,6 +15,16 @@ yarn add @near-wallet-selector/nightly
 npm install @near-wallet-selector/nightly
 ```
 
+This package requires `near-api-js` v0.44.2 or above:
+
+```bash
+# Using Yarn
+yarn add near-api-js@^0.44.2
+
+# Using NPM.
+npm install near-api-js@^0.44.2
+```
+
 Then use it in your dApp:
 
 ```ts

--- a/packages/nightly/README.md
+++ b/packages/nightly/README.md
@@ -5,17 +5,7 @@ This is the [Nightly](https://www.nightly.app) package for NEAR Wallet Selector.
 
 ## Installation and Usage
 
-The easiest way to use this package is to install it from the NPM registry:
-
-```bash
-# Using Yarn
-yarn add @near-wallet-selector/nightly
-
-# Using NPM.
-npm install @near-wallet-selector/nightly
-```
-
-This package requires `near-api-js` v0.44.2 or above:
+The easiest way to use this package is to install it from the NPM registry, this package requires `near-api-js` v0.44.2 or above:
 
 ```bash
 # Using Yarn
@@ -23,6 +13,14 @@ yarn add near-api-js@^0.44.2
 
 # Using NPM.
 npm install near-api-js@^0.44.2
+```
+
+```bash
+# Using Yarn
+yarn add @near-wallet-selector/nightly
+
+# Using NPM.
+npm install @near-wallet-selector/nightly
 ```
 
 Then use it in your dApp:

--- a/packages/nightly/package.json
+++ b/packages/nightly/package.json
@@ -1,4 +1,7 @@
 {
   "name": "@near-wallet-selector/nightly",
-   "version": "5.0.0"
+  "version": "5.0.0",
+  "peerDependencies": {
+    "near-api-js": "^0.44.2"
+  }
 }

--- a/packages/sender/README.md
+++ b/packages/sender/README.md
@@ -4,17 +4,7 @@ This is the [Sender](https://chrome.google.com/webstore/detail/sender-wallet/epa
 
 ## Installation and Usage
 
-The easiest way to use this package is to install it from the NPM registry:
-
-```bash
-# Using Yarn
-yarn add @near-wallet-selector/sender
-
-# Using NPM.
-npm install @near-wallet-selector/sender
-```
-
-This package requires `near-api-js` v0.44.2 or above:
+The easiest way to use this package is to install it from the NPM registry, this package requires `near-api-js` v0.44.2 or above:
 
 ```bash
 # Using Yarn
@@ -22,6 +12,13 @@ yarn add near-api-js@^0.44.2
 
 # Using NPM.
 npm install near-api-js@^0.44.2
+```
+```bash
+# Using Yarn
+yarn add @near-wallet-selector/sender
+
+# Using NPM.
+npm install @near-wallet-selector/sender
 ```
 
 Then use it in your dApp:

--- a/packages/sender/README.md
+++ b/packages/sender/README.md
@@ -14,6 +14,16 @@ yarn add @near-wallet-selector/sender
 npm install @near-wallet-selector/sender
 ```
 
+This package requires `near-api-js` v0.44.2 or above:
+
+```bash
+# Using Yarn
+yarn add near-api-js@^0.44.2
+
+# Using NPM.
+npm install near-api-js@^0.44.2
+```
+
 Then use it in your dApp:
 
 ```ts

--- a/packages/sender/package.json
+++ b/packages/sender/package.json
@@ -1,4 +1,7 @@
 {
   "name": "@near-wallet-selector/sender",
-   "version": "5.0.0"
+  "version": "5.0.0",
+  "peerDependencies": {
+    "near-api-js": "^0.44.2"
+  }
 }

--- a/packages/wallet-utils/README.md
+++ b/packages/wallet-utils/README.md
@@ -14,6 +14,16 @@ yarn add @near-wallet-selector/wallet-utils
 npm install @near-wallet-selector/wallet-utils
 ```
 
+This package requires `near-api-js` v0.44.2 or above:
+
+```bash
+# Using Yarn
+yarn add near-api-js@^0.44.2
+
+# Using NPM.
+npm install near-api-js@^0.44.2
+```
+
 Then use it in your custom wallet integration:
 
 ```ts

--- a/packages/wallet-utils/README.md
+++ b/packages/wallet-utils/README.md
@@ -4,17 +4,7 @@ This is the Wallet Utils package for NEAR Wallet Selector.
 
 ## Installation and Usage
 
-The easiest way to use this package is to install it from the NPM registry:
-
-```bash
-# Using Yarn
-yarn add @near-wallet-selector/wallet-utils
-
-# Using NPM.
-npm install @near-wallet-selector/wallet-utils
-```
-
-This package requires `near-api-js` v0.44.2 or above:
+The easiest way to use this package is to install it from the NPM registry, this package requires `near-api-js` v0.44.2 or above:
 
 ```bash
 # Using Yarn
@@ -22,6 +12,14 @@ yarn add near-api-js@^0.44.2
 
 # Using NPM.
 npm install near-api-js@^0.44.2
+```
+
+```bash
+# Using Yarn
+yarn add @near-wallet-selector/wallet-utils
+
+# Using NPM.
+npm install @near-wallet-selector/wallet-utils
 ```
 
 Then use it in your custom wallet integration:

--- a/packages/wallet-utils/package.json
+++ b/packages/wallet-utils/package.json
@@ -1,4 +1,7 @@
 {
   "name": "@near-wallet-selector/wallet-utils",
-   "version": "5.0.0"
+  "version": "5.0.0",
+  "peerDependencies": {
+    "near-api-js": "^0.44.2"
+  }
 }


### PR DESCRIPTION
# Description

- Added `"near-api-js": "^0.44.2"` as a `peerDependency` for the packages which use it directly.
- Solves the first problem reported in this issue: https://github.com/near/wallet-selector/issues/349

Closes # (issue)
<!-- REMOVE ALL THE TEMPLATE BELOW IF THE PR IS A RELEASE -->


# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change. This type of change is the main reason for the PR.
<!-- CHECKLIST_TYPE: ONE -->
- [x] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->

# Breaking changes
<!-- CHECKLIST_TYPE: ONE -->
<!-- SPECIFY BREAKING CHANGES AS A ONE-LINER -->
- [ ] BREAKING CHANGE - SPECIFY: _______
- [x] NO BREAKING CHANGE - this PR doesn't contain any breaking changes and it's backwards compatible
<!-- /CHECKLIST_TYPE -->
