### PR TITLE
fix: Fallback for Ledger when Indexer Service is Unavailable

### DIFF
--- a/packages/modal-ui/src/lib/components/styles.css
+++ b/packages/modal-ui/src/lib/components/styles.css
@@ -224,6 +224,12 @@
   margin-bottom: 16px;
 }
 
+.nws-modal-wrapper .modal .derivation-path-wrapper .derivation-path-list .center {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
 .nws-modal-wrapper .modal .derivation-path-wrapper input {
   margin-right: 8px;
 }


### PR DESCRIPTION
# Description

- As a fallback when kitwallet indexer fails showed an input to enter an account id manually.

## NOTE
This fallback has been added because yesterday kitwallet indexer (testnet) https://testnet-api.kitwallet.app/ and (mainnet) https://api.kitwallet.app/ added a restriction which caused our ledger inplementation to be unusable. We were seeing a `404` error when trying to find accounts linked to a `publicKey`.

Closes # (issue)
<!-- REMOVE ALL THE TEMPLATE BELOW IF THE PR IS A RELEASE -->


# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change. This type of change is the main reason for the PR.
<!-- CHECKLIST_TYPE: ONE -->
- [x] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->

# Breaking changes
<!-- CHECKLIST_TYPE: ONE -->
<!-- SPECIFY BREAKING CHANGES AS A ONE-LINER -->
- [ ] BREAKING CHANGE - SPECIFY: _______
- [x] NO BREAKING CHANGE - this PR doesn't contain any breaking changes and it's backwards compatible
<!-- /CHECKLIST_TYPE -->
