### PR TITLE
fix: Added deprecated flag as configurable setup option

### DIFF
--- a/packages/ledger/src/lib/ledger.ts
+++ b/packages/ledger/src/lib/ledger.ts
@@ -35,6 +35,7 @@ interface LedgerState {
 
 export interface LedgerParams {
   iconUrl?: string;
+  deprecated?: boolean;
 }
 
 export const STORAGE_ACCOUNTS = "accounts";
@@ -271,6 +272,7 @@ const Ledger: WalletBehaviourFactory<HardwareWallet> = async ({
 
 export function setupLedger({
   iconUrl = "./assets/ledger-icon.png",
+  deprecated = false,
 }: LedgerParams = {}): WalletModuleFactory<HardwareWallet> {
   return async () => {
     const mobile = isMobile();
@@ -287,7 +289,7 @@ export function setupLedger({
         name: "Ledger",
         description: null,
         iconUrl,
-        deprecated: false,
+        deprecated,
         available: supported,
       },
       init: Ledger,

--- a/packages/math-wallet/src/lib/math-wallet.ts
+++ b/packages/math-wallet/src/lib/math-wallet.ts
@@ -21,6 +21,7 @@ declare global {
 
 export interface MathWalletParams {
   iconUrl?: string;
+  deprecated?: boolean;
 }
 
 interface MathWalletState {
@@ -141,6 +142,7 @@ const MathWallet: WalletBehaviourFactory<InjectedWallet> = async ({
 
 export const setupMathWallet = ({
   iconUrl = "./assets/math-wallet-icon.png",
+  deprecated = false,
 }: MathWalletParams = {}): WalletModuleFactory<InjectedWallet> => {
   return async () => {
     const mobile = isMobile();
@@ -159,7 +161,7 @@ export const setupMathWallet = ({
         iconUrl,
         downloadUrl:
           "https://chrome.google.com/webstore/detail/math-wallet/afbcbjpbpfadlkmhmclhkeeodmamcflc",
-        deprecated: false,
+        deprecated,
         available: installed,
       },
       init: MathWallet,

--- a/packages/meteor-wallet/src/lib/meteor-wallet-types.ts
+++ b/packages/meteor-wallet/src/lib/meteor-wallet-types.ts
@@ -3,6 +3,7 @@ import { keyStores } from "near-api-js";
 
 export interface MeteorWalletParams_Injected {
   iconUrl?: string;
+  deprecated?: boolean;
 }
 
 export interface MeteorWalletState {

--- a/packages/meteor-wallet/src/lib/meteor-wallet.ts
+++ b/packages/meteor-wallet/src/lib/meteor-wallet.ts
@@ -198,6 +198,7 @@ const createMeteorWalletInjected: WalletBehaviourFactory<
 
 export function setupMeteorWallet({
   iconUrl = "./assets/meteor-icon.png",
+  deprecated = false,
 }: MeteorWalletParams_Injected = {}): WalletModuleFactory<InjectedWallet> {
   return async () => {
     return {
@@ -208,7 +209,7 @@ export function setupMeteorWallet({
         name: "Meteor Wallet",
         description: null,
         iconUrl,
-        deprecated: false,
+        deprecated,
         downloadUrl: "https://wallet.meteorwallet.app",
       },
       init: (options) => {

--- a/packages/my-near-wallet/src/lib/my-near-wallet.ts
+++ b/packages/my-near-wallet/src/lib/my-near-wallet.ts
@@ -18,6 +18,7 @@ import { createAction } from "@near-wallet-selector/wallet-utils";
 export interface MyNearWalletParams {
   walletUrl?: string;
   iconUrl?: string;
+  deprecated?: boolean;
 }
 
 interface MyNearWalletState {
@@ -203,6 +204,7 @@ const MyNearWallet: WalletBehaviourFactory<
 export function setupMyNearWallet({
   walletUrl,
   iconUrl = "./assets/my-near-wallet-icon.png",
+  deprecated = false,
 }: MyNearWalletParams = {}): WalletModuleFactory<BrowserWallet> {
   return async () => {
     return {
@@ -212,7 +214,7 @@ export function setupMyNearWallet({
         name: "MyNearWallet",
         description: null,
         iconUrl,
-        deprecated: false,
+        deprecated,
         available: true,
       },
       init: (options) => {

--- a/packages/near-wallet/src/lib/near-wallet.ts
+++ b/packages/near-wallet/src/lib/near-wallet.ts
@@ -28,6 +28,7 @@ const resolveWalletUrl = (network: Network, walletUrl?: string) => {
 export function setupNearWallet({
   walletUrl,
   iconUrl = "./assets/near-wallet-icon.png",
+  deprecated = false,
 }: NearWalletParams = {}): WalletModuleFactory<BrowserWallet> {
   return async (options) => {
     const wallet = await setupMyNearWallet({
@@ -47,7 +48,7 @@ export function setupNearWallet({
         name: "NEAR Wallet",
         description: null,
         iconUrl,
-        deprecated: true,
+        deprecated,
         available: true,
       },
     };

--- a/packages/nightly-connect/src/lib/nightly-connect.ts
+++ b/packages/nightly-connect/src/lib/nightly-connect.ts
@@ -202,6 +202,7 @@ const NightlyConnect: WalletBehaviourFactory<
 
 export type SetupNightlyConnectParams = NightlyConnectParams & {
   iconUrl?: string;
+  deprecated?: boolean;
 };
 
 export function setupNightlyConnect({
@@ -209,6 +210,7 @@ export function setupNightlyConnect({
   timeout,
   url,
   iconUrl = "./assets/nightly-connect.png",
+  deprecated = false,
 }: SetupNightlyConnectParams): WalletModuleFactory<BridgeWallet> {
   return async () => {
     return {
@@ -218,7 +220,7 @@ export function setupNightlyConnect({
         name: "Nightly Connect",
         description: null,
         iconUrl: iconUrl,
-        deprecated: false,
+        deprecated,
         available: true,
       },
       init: (options) => {

--- a/packages/nightly/src/lib/nightly.ts
+++ b/packages/nightly/src/lib/nightly.ts
@@ -182,9 +182,11 @@ const Nightly: WalletBehaviourFactory<InjectedWallet> = async ({
 
 export interface NightlyWalletParams {
   iconUrl?: string;
+  deprecated?: boolean;
 }
 export function setupNightly({
   iconUrl = "./assets/nightly.png",
+  deprecated = false,
 }: NightlyWalletParams = {}): WalletModuleFactory<InjectedWallet> {
   return async () => {
     const mobile = isMobile();
@@ -207,7 +209,7 @@ export function setupNightly({
         iconUrl,
         // Will replace we open beta with stable version
         downloadUrl: "https://www.nightly.app",
-        deprecated: false,
+        deprecated,
         available: installed,
       },
       init: Nightly,

--- a/packages/sender/src/lib/sender.ts
+++ b/packages/sender/src/lib/sender.ts
@@ -19,6 +19,7 @@ declare global {
 
 export interface SenderParams {
   iconUrl?: string;
+  deprecated?: boolean;
 }
 
 interface SenderState {
@@ -230,6 +231,7 @@ const Sender: WalletBehaviourFactory<InjectedWallet> = async ({
 
 export function setupSender({
   iconUrl = "./assets/sender-icon.png",
+  deprecated = false,
 }: SenderParams = {}): WalletModuleFactory<InjectedWallet> {
   return async () => {
     const mobile = isMobile();
@@ -254,7 +256,7 @@ export function setupSender({
         iconUrl,
         downloadUrl:
           "https://chrome.google.com/webstore/detail/sender-wallet/epapihdplajcdnnkdeiahlgigofloibg",
-        deprecated: false,
+        deprecated,
         available: installed,
       },
       init: Sender,

--- a/packages/wallet-connect/src/lib/wallet-connect.ts
+++ b/packages/wallet-connect/src/lib/wallet-connect.ts
@@ -16,6 +16,7 @@ export interface WalletConnectParams {
   relayUrl?: string;
   iconUrl?: string;
   chainId?: string;
+  deprecated?: boolean;
 }
 
 interface WalletConnectExtraOptions {
@@ -232,6 +233,7 @@ export function setupWalletConnect({
   chainId,
   relayUrl = "wss://relay.walletconnect.com",
   iconUrl = "./assets/wallet-connect-icon.png",
+  deprecated = false,
 }: WalletConnectParams): WalletModuleFactory<BridgeWallet> {
   return async () => {
     return {
@@ -241,7 +243,7 @@ export function setupWalletConnect({
         name: "WalletConnect",
         description: null,
         iconUrl,
-        deprecated: false,
+        deprecated,
         available: true,
       },
       init: (options) => {


### PR DESCRIPTION
# Description
Added optional `deprecated?: boolean` flag as configurable setup option for all wallets. By default its false.

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change. This type of change is the main reason for the PR.
<!-- CHECKLIST_TYPE: ONE -->
- [x] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->

# Breaking changes
<!-- CHECKLIST_TYPE: ONE -->
<!-- SPECIFY BREAKING CHANGES AS A ONE-LINER -->
- [ ] BREAKING CHANGE - SPECIFY: _______
- [x] NO BREAKING CHANGE - this PR doesn't contain any breaking changes and it's backwards compatible
<!-- /CHECKLIST_TYPE -->
