### PR TITLE
refactor: Support Single Derivation Path with Multiple Account Id-s

### DIFF
--- a/packages/modal-ui/src/lib/components/DerivationPath.tsx
+++ b/packages/modal-ui/src/lib/components/DerivationPath.tsx
@@ -94,27 +94,6 @@ export const DerivationPath: React.FC<DerivationPathProps> = ({
     }
   };
 
-  const handleSignIn = () => {
-    const mapAccounts = accounts.map((account: HardwareWalletAccount) => {
-      return {
-        derivationPath: account.derivationPath,
-        publicKey: account.publicKey,
-        accountId: account.accountId,
-      };
-    });
-
-    return hardwareWallet!
-      .signIn({
-        contractId: options.contractId,
-        methodNames: options.methodNames,
-        accounts: mapAccounts,
-      })
-      .then(() => onConnected())
-      .catch((err) => {
-        onError(`Error: ${err.message}`);
-      });
-  };
-
   const handleValidateAccount = async () => {
     const wallet = await selector.wallet(params.walletId);
 
@@ -154,13 +133,6 @@ export const DerivationPath: React.FC<DerivationPathProps> = ({
       setConnecting(false);
     }
   };
-  const handleEnterClick: KeyboardEventHandler<HTMLInputElement> = async (
-    e
-  ) => {
-    if (e.key === "Enter") {
-      await handleValidateAccount();
-    }
-  };
 
   const handleAddCustomAccountId = async () => {
     try {
@@ -185,6 +157,35 @@ export const DerivationPath: React.FC<DerivationPathProps> = ({
       onError(message);
     } finally {
       setConnecting(false);
+    }
+  };
+
+  const handleSignIn = () => {
+    const mapAccounts = accounts.map((account: HardwareWalletAccount) => {
+      return {
+        derivationPath: account.derivationPath,
+        publicKey: account.publicKey,
+        accountId: account.accountId,
+      };
+    });
+
+    return hardwareWallet!
+      .signIn({
+        contractId: options.contractId,
+        methodNames: options.methodNames,
+        accounts: mapAccounts,
+      })
+      .then(() => onConnected())
+      .catch((err) => {
+        onError(`Error: ${err.message}`);
+      });
+  };
+
+  const handleEnterClick: KeyboardEventHandler<HTMLInputElement> = async (
+    e
+  ) => {
+    if (e.key === "Enter") {
+      await handleValidateAccount();
     }
   };
 

--- a/packages/modal-ui/src/lib/components/DerivationPath.tsx
+++ b/packages/modal-ui/src/lib/components/DerivationPath.tsx
@@ -142,7 +142,6 @@ export const DerivationPath: React.FC<DerivationPathProps> = ({
       if (!multipleAccounts) {
         setRoute("OverviewAccounts");
       } else {
-        setConnecting(false);
         setRoute("ChooseAccount");
       }
     } catch (err) {

--- a/packages/modal-ui/src/lib/components/DerivationPath.tsx
+++ b/packages/modal-ui/src/lib/components/DerivationPath.tsx
@@ -245,9 +245,11 @@ export const DerivationPath: React.FC<DerivationPathProps> = ({
           onSubmit={(acc, e) => {
             e.preventDefault();
             setAccounts((prevAccounts) => {
-              prevAccounts = prevAccounts.filter((account) => account.selected);
+              const selectedAccounts = prevAccounts.filter(
+                (account) => account.selected
+              );
 
-              return [...prevAccounts];
+              return [...selectedAccounts];
             });
             setRoute("OverviewAccounts");
           }}

--- a/packages/modal-ui/src/lib/components/DerivationPath.tsx
+++ b/packages/modal-ui/src/lib/components/DerivationPath.tsx
@@ -25,6 +25,7 @@ export type HardwareWalletAccountState = HardwareWalletAccount & {
 
 type HardwareRoutes =
   | "EnterDerivationPath"
+  | "NoAccountsFound"
   | "ChooseAccount"
   | "AddCustomAccountId"
   | "OverviewAccounts";
@@ -130,8 +131,13 @@ export const DerivationPath: React.FC<DerivationPathProps> = ({
         setRoute("AddCustomAccountId");
         return;
       }
-
+      const noAccounts = resolvedAccounts.length === 0;
       const multipleAccounts = resolvedAccounts.length > 1;
+
+      if (noAccounts) {
+        setRoute("NoAccountsFound");
+        return;
+      }
 
       if (!multipleAccounts) {
         setRoute("OverviewAccounts");
@@ -221,6 +227,29 @@ export const DerivationPath: React.FC<DerivationPathProps> = ({
             </button>
             <button className="right-button" onClick={handleValidateAccount}>
               Continue
+            </button>
+          </div>
+        </div>
+      )}
+
+      {route === "NoAccountsFound" && (
+        <div className="no-accounts-found-wrapper">
+          <p>
+            Can't found any account associated with this Ledger. Please create a
+            new NEAR account on{" "}
+            <a href="https://app.mynearwallet.com/create" target="_blank">
+              MyNearWallet
+            </a>{" "}
+            or connect an another Ledger.
+          </p>
+          <div className="action-buttons">
+            <button
+              className="left-button"
+              onClick={() => {
+                setRoute("EnterDerivationPath");
+              }}
+            >
+              Back
             </button>
           </div>
         </div>

--- a/packages/modal-ui/src/lib/components/DerivationPath.tsx
+++ b/packages/modal-ui/src/lib/components/DerivationPath.tsx
@@ -233,7 +233,14 @@ export const DerivationPath: React.FC<DerivationPathProps> = ({
           <p>
             Can't found any account associated with this Ledger. Please create a
             new NEAR account on{" "}
-            <a href="https://app.mynearwallet.com/create" target="_blank">
+            <a
+              href={`https://${
+                selector.options.network.networkId === "testnet"
+                  ? "testnet"
+                  : "app"
+              }.mynearwallet.com/create`}
+              target="_blank"
+            >
               MyNearWallet
             </a>{" "}
             or connect an another Ledger.

--- a/packages/modal-ui/src/lib/components/DerivationPath.tsx
+++ b/packages/modal-ui/src/lib/components/DerivationPath.tsx
@@ -51,8 +51,7 @@ export const DerivationPath: React.FC<DerivationPathProps> = ({
 
   const handleAddAccount = (account: HardwareWalletAccountState) => {
     setAccounts((prevAccounts) => {
-      prevAccounts.push(account);
-      return [...prevAccounts];
+      return [...prevAccounts, account];
     });
   };
 

--- a/packages/modal-ui/src/lib/components/DerivationPath.tsx
+++ b/packages/modal-ui/src/lib/components/DerivationPath.tsx
@@ -86,7 +86,6 @@ export const DerivationPath: React.FC<DerivationPathProps> = ({
           selected,
         });
       }
-      setAccounts(foundAccounts);
 
       return foundAccounts;
     } catch (e) {
@@ -117,6 +116,7 @@ export const DerivationPath: React.FC<DerivationPathProps> = ({
         setRoute("NoAccountsFound");
         return;
       }
+      setAccounts(resolvedAccounts);
 
       if (!multipleAccounts) {
         setRoute("OverviewAccounts");

--- a/packages/modal-ui/src/lib/components/DerivationPath.tsx
+++ b/packages/modal-ui/src/lib/components/DerivationPath.tsx
@@ -48,7 +48,6 @@ export const DerivationPath: React.FC<DerivationPathProps> = ({
   const [hardwareWallet, setHardwareWallet] = useState<Wallet>();
   const [customAccountId, setCustomAccountId] = useState("");
   const [connecting, setConnecting] = useState(false);
-  const [indexerFailed, setIndexerFailed] = useState(false);
 
   const handleAddAccount = (account: HardwareWalletAccountState) => {
     setAccounts((prevAccounts) => {
@@ -92,7 +91,6 @@ export const DerivationPath: React.FC<DerivationPathProps> = ({
         selected,
       };
     } catch (e) {
-      setIndexerFailed(true);
       return null;
     }
   };
@@ -130,8 +128,7 @@ export const DerivationPath: React.FC<DerivationPathProps> = ({
 
     try {
       const account = await resolveAccount(wallet);
-
-      if (!account || indexerFailed) {
+      if (!account) {
         setRoute("AddCustomAccountId");
         return;
       }

--- a/packages/modal-ui/src/lib/components/DerivationPath.tsx
+++ b/packages/modal-ui/src/lib/components/DerivationPath.tsx
@@ -1,12 +1,12 @@
 import React, { KeyboardEventHandler, useState } from "react";
 import type {
   HardwareWallet,
+  HardwareWalletAccount,
   Wallet,
   WalletSelector,
 } from "@near-wallet-selector/core";
 import type { ModalOptions } from "../modal.types";
 import type { DerivationPathModalRouteParams } from "./Modal.types";
-import type { HardwareWalletAccount } from "@near-wallet-selector/core";
 import HardwareWalletAccountsForm from "./HardwareWalletAccountsForm";
 import { WalletConnecting } from "./WalletConnecting";
 
@@ -75,19 +75,15 @@ export const DerivationPath: React.FC<DerivationPathProps> = ({
     );
     try {
       const accountIds = await getAccountIds(publicKey);
-      const foundAccounts: Array<HardwareWalletAccountState> = [];
 
-      for (let i = 0; i < accountIds.length; i++) {
-        const selected = i === 0;
-        foundAccounts.push({
+      return accountIds.map((accountId, index) => {
+        return {
           derivationPath,
           publicKey,
-          accountId: accountIds[i],
-          selected,
-        });
-      }
-
-      return foundAccounts;
+          accountId,
+          selected: index === 0,
+        };
+      });
     } catch (e) {
       return null;
     }

--- a/packages/modal-ui/src/lib/components/HardwareWalletAccountsForm.tsx
+++ b/packages/modal-ui/src/lib/components/HardwareWalletAccountsForm.tsx
@@ -1,9 +1,9 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import type { HardwareWalletAccountState } from "./DerivationPath";
 
 interface FormProps {
-  hardwareWalletAccounts: Array<HardwareWalletAccountState>;
-  onAccountChanged: (derivationPath: string, selectedAccountId: string) => void;
+  accounts: Array<HardwareWalletAccountState>;
+  onSelectedChanged: (index: number, selected: boolean) => void;
   onSubmit: (
     accounts: Array<HardwareWalletAccountState>,
     e: React.FormEvent<HTMLFormElement>
@@ -11,48 +11,56 @@ interface FormProps {
 }
 
 const HardwareWalletAccountsForm: React.FC<FormProps> = ({
-  hardwareWalletAccounts,
-  onAccountChanged,
+  accounts,
+  onSelectedChanged,
   onSubmit,
 }) => {
+  const [disableButton, setDisableButton] = useState(false);
+
+  useEffect(() => {
+    const selected = accounts.some((x) => x.selected);
+    setDisableButton(!selected);
+  }, [accounts]);
+
   return (
     <div className="choose-ledger-account-form-wrapper">
       <p>
-        Multiple accounts found. Please choose an account per derivation path.
+        We found {accounts.length} accounts on your device. Select the
+        account(s) you wish to connect.
       </p>
       <form
         className="form"
         onSubmit={(e) => {
-          onSubmit(hardwareWalletAccounts, e);
+          onSubmit(accounts, e);
         }}
       >
         <div>
-          {hardwareWalletAccounts.map((account, accountIndex) => {
-            return (
-              <div key={accountIndex} className="form-control">
-                <label>{account.derivationPath}</label>
-                <select
-                  disabled={account.accountIds.length === 1}
-                  defaultValue={account.selectedAccountId}
+          <div className="form-control">
+            {accounts.map((account, index) => (
+              <div key={index}>
+                <input
                   onChange={(e) => {
-                    onAccountChanged(account.derivationPath, e.target.value);
+                    onSelectedChanged(index, e.target.checked);
                   }}
-                >
-                  {account.accountIds.map((accountId) => {
-                    return (
-                      <option key={accountId} value={accountId}>
-                        {accountId}
-                      </option>
-                    );
-                  })}
-                </select>
+                  checked={account.selected}
+                  type="checkbox"
+                  id={account.accountId}
+                  name={account.accountId}
+                  value={account.accountId}
+                />
+                <label htmlFor={account.accountId}> {account.accountId}</label>
+                <br />
               </div>
-            );
-          })}
+            ))}
+          </div>
 
           <div className="action-buttons">
-            <button className="right-button" type="submit">
-              Connect
+            <button
+              className="right-button"
+              type="submit"
+              disabled={disableButton}
+            >
+              Continue
             </button>
           </div>
         </div>

--- a/packages/modal-ui/src/lib/components/HardwareWalletAccountsForm.tsx
+++ b/packages/modal-ui/src/lib/components/HardwareWalletAccountsForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import type { HardwareWalletAccountState } from "./DerivationPath";
 
 interface FormProps {
@@ -15,13 +15,6 @@ const HardwareWalletAccountsForm: React.FC<FormProps> = ({
   onSelectedChanged,
   onSubmit,
 }) => {
-  const [disableButton, setDisableButton] = useState(false);
-
-  useEffect(() => {
-    const selected = accounts.some((x) => x.selected);
-    setDisableButton(!selected);
-  }, [accounts]);
-
   return (
     <div className="choose-ledger-account-form-wrapper">
       <p>
@@ -58,7 +51,7 @@ const HardwareWalletAccountsForm: React.FC<FormProps> = ({
             <button
               className="right-button"
               type="submit"
-              disabled={disableButton}
+              disabled={!accounts.some((x) => x.selected)}
             >
               Continue
             </button>

--- a/packages/modal-ui/src/lib/components/styles.css
+++ b/packages/modal-ui/src/lib/components/styles.css
@@ -239,6 +239,15 @@
   color: var(--wallet-selector-error, var(--error));
 }
 
+.nws-modal-wrapper .modal .derivation-path-wrapper .no-accounts-found-wrapper a {
+  color: #5f8afa;
+  text-decoration: none;
+}
+
+.nws-modal-wrapper .modal .derivation-path-wrapper .no-accounts-found-wrapper .action-buttons {
+  justify-content: flex-start;
+}
+
 .nws-modal-wrapper .modal .derivation-path-wrapper .enter-derivation-path .view-account {
   font-size: 15px;
   color: #5f8afa;

--- a/packages/modal-ui/src/lib/components/styles.css
+++ b/packages/modal-ui/src/lib/components/styles.css
@@ -217,13 +217,6 @@
  * Modal Ledger Derivation Path Section/Wrapper
  */
 
-.nws-modal-wrapper .modal .derivation-path-wrapper .derivation-path-list {
-  display: flex;
-  justify-content: center;
-  flex-direction: column;
-  margin-bottom: 16px;
-}
-
 .nws-modal-wrapper .modal .derivation-path-wrapper input {
   margin-right: 8px;
 }
@@ -246,16 +239,77 @@
   color: var(--wallet-selector-error, var(--error));
 }
 
+.nws-modal-wrapper .modal .derivation-path-wrapper .enter-derivation-path .view-account {
+  font-size: 15px;
+  color: #5f8afa;
+  cursor: pointer;
+}
+.nws-modal-wrapper .modal .derivation-path-wrapper .enter-derivation-path .view-account:hover {
+  text-decoration: underline;
+}
+
+.nws-modal-wrapper .modal .derivation-path-wrapper .enter-derivation-path .view-account:hover {
+  text-decoration: underline;
+}
+
+.nws-modal-wrapper .modal .derivation-path-wrapper .enter-derivation-path .error {
+  font-size: 12px;
+}
+
+.nws-modal-wrapper .modal .derivation-path-wrapper .action-buttons {
+  margin-top: 20px;
+}
+
+.nws-modal-wrapper .modal .derivation-path-wrapper .action-buttons .right-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.nws-modal-wrapper .modal .derivation-path-wrapper .overview-wrapper .overview-header {
+  padding: 10px;
+  border-bottom: 1px solid rgb(216, 216, 216);
+  margin-bottom: 10px;
+}
+
+.nws-modal-wrapper .modal .derivation-path-wrapper .overview-wrapper .overview-header h4 {
+  margin: 0;
+}
+
+.nws-modal-wrapper .modal .derivation-path-wrapper .overview-wrapper .overview-header span {
+  color: rgb(95, 138, 250);
+  cursor: pointer;
+}
+
+.nws-modal-wrapper .modal .derivation-path-wrapper .overview-wrapper .account {
+  padding: 10px;
+  cursor: pointer;
+  font-size: 15px;
+}
+
+.nws-modal-wrapper .modal .derivation-path-wrapper .overview-wrapper .action-buttons {
+  justify-content: flex-end;
+}
+
+.nws-modal-wrapper .modal .derivation-path-wrapper .enter-custom-account .input-wrapper {
+  display: flex;
+  justify-content: center;
+}
+
+.nws-modal-wrapper .modal .derivation-path-wrapper .enter-custom-account input {
+  max-width: 250px;
+}
+
+.nws-modal-wrapper .modal .derivation-path-wrapper .enter-custom-account .action-buttons {
+  justify-content: flex-end;
+}
+
 /**
  * Modal Wallet ChooseLedgerAccountForm/Wrapper
  */
 .nws-modal-wrapper .modal .choose-ledger-account-form-wrapper .form-control {
-  display: flex;
   margin-bottom: 16px;
   padding: 10px;
   box-shadow: rgb(0 0 0 / 16%) 0 1px 4px;
-  justify-content: space-between;
-  align-items: center;
   color: var(--text-color);
 }
 .nws-modal-wrapper .modal .choose-ledger-account-form-wrapper .form-control label {


### PR DESCRIPTION
# Description

The reason for this refactoring and switching to a single derivation path with multiple account id(s) is to simplify the UI/UX and apparently this is a common use case in the ecosystem from the feedback we've got in the last calls with NEAR.

- Added support to select a single derivation path.
- Select one or multiple account id(s) for the chosen derivation path.
- Added fallback when indexer service fails (provide account id manually).

Closes # (issue)
<!-- REMOVE ALL THE TEMPLATE BELOW IF THE PR IS A RELEASE -->


# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change. This type of change is the main reason for the PR.
<!-- CHECKLIST_TYPE: ONE -->
- [ ] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [x] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->

# Breaking changes
<!-- CHECKLIST_TYPE: ONE -->
<!-- SPECIFY BREAKING CHANGES AS A ONE-LINER -->
- [ ] BREAKING CHANGE - SPECIFY: _______
- [x] NO BREAKING CHANGE - this PR doesn't contain any breaking changes and it's backwards compatible
<!-- /CHECKLIST_TYPE -->
