### PR TITLE
chore: Support for Multiple PR Templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,36 +1,8 @@
-# Description
+Thanks for taking the time to submit a pull request!
 
-Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+If you haven't already, be sure to take a look at the [CONTRIBUTING](https://github.com/near/wallet-selector/blob/main/CONTRIBUTING.md) documentation to get up to speed with the practices in this repository.
 
-Closes # (issue)
-<!-- REMOVE ALL THE TEMPLATE BELOW IF THE PR IS A RELEASE -->
+When you're ready, switch to the "Preview" tab to select an applicable template:
 
-
-# Checklist:
-<!-- CHECKLIST_TYPE: ALL -->
-- [ ] I have performed a self-review of my own code
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] I have made corresponding changes to the documentation
-- [ ] My changes generate no new warnings
-<!-- /CHECKLIST_TYPE -->
-
-# Type of change. This type of change is the main reason for the PR.
-<!-- CHECKLIST_TYPE: ONE -->
-- [ ] FIX - a PR of this type patches a bug.
-- [ ] FEATURE - a PR of this type introduces a new feature.
-- [ ] BUILD - a PR of this type introduces build changes.
-- [ ] CI - a PR of this type introduces CI changes.
-- [ ] DOCS - a PR of this type introduces DOCS improvement.
-- [ ] STYLE - a PR of this type introduces style changes.
-- [ ] REFACTOR - a PR of this type introduces refactoring.
-- [ ] PERFORMANCE - a PR of this type introduces performance changes.
-- [ ] TEST - a PR of this type adds more tests.
-- [ ] CHORE - a PR introduces other changes than the specified above.
-<!-- /CHECKLIST_TYPE -->
-
-# Breaking changes
-<!-- CHECKLIST_TYPE: ONE -->
-<!-- SPECIFY BREAKING CHANGES AS A ONE-LINER -->
-- [ ] BREAKING CHANGE - SPECIFY: _______
-- [ ] NO BREAKING CHANGE - this PR doesn't contain any breaking changes and it's backwards compatible
-<!-- /CHECKLIST_TYPE -->
+- [General template (most common)](?expand=1&template=general.md)
+- [Wallet integration template](?expand=1&template=wallet_integration.md)

--- a/.github/PULL_REQUEST_TEMPLATE/general.md
+++ b/.github/PULL_REQUEST_TEMPLATE/general.md
@@ -1,0 +1,25 @@
+# Description
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+# Checklist:
+<!-- CHECKLIST_TYPE: ALL -->
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+<!-- /CHECKLIST_TYPE -->
+
+# Type of change.
+<!-- CHECKLIST_TYPE: ONE -->
+- [ ] FIX - a PR of this type patches a bug.
+- [ ] FEATURE - a PR of this type introduces a new feature.
+- [ ] BUILD - a PR of this type introduces build changes.
+- [ ] CI - a PR of this type introduces CI changes.
+- [ ] DOCS - a PR of this type introduces DOCS improvement.
+- [ ] STYLE - a PR of this type introduces style changes.
+- [ ] REFACTOR - a PR of this type introduces refactoring.
+- [ ] PERFORMANCE - a PR of this type introduces performance changes.
+- [ ] TEST - a PR of this type adds more tests.
+- [ ] CHORE - a PR introduces other changes than the specified above.
+<!-- /CHECKLIST_TYPE -->

--- a/.github/PULL_REQUEST_TEMPLATE/wallet_integration.md
+++ b/.github/PULL_REQUEST_TEMPLATE/wallet_integration.md
@@ -1,0 +1,11 @@
+# Description
+
+Please include a summary of the wallet and how users can install it. Be sure to take a look at our guide on [Custom Wallets](https://github.com/near/wallet-selector/blob/main/packages/core/docs/guides/custom-wallets.md) to understand core concepts when integrating with Wallet Selector.
+
+# Checklist:
+<!-- CHECKLIST_TYPE: ALL -->
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+<!-- /CHECKLIST_TYPE -->


### PR DESCRIPTION
# Description

- Added a second PR template specifically for wallet integrations.
- Removed break changes checklist due to various bugs in the automation around it.

# Notes

- Merging into `dev` won't update the existing templates. It's only once it's in `main` that they'll take effect.

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [ ] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [x] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->