### PR TITLE
feat: Add Support for verifyOwner

### DIFF
--- a/examples/angular/src/app/components/content/content.component.html
+++ b/examples/angular/src/app/components/content/content.component.html
@@ -2,6 +2,7 @@
   <div>
     <button (click)="signOut()">Log out</button>
     <button (click)="switchWallet()">Switch Wallet</button>
+    <button (click)="onVerifyOwner()">Verify Owner</button>
     <button *ngIf="accounts.length > 1" (click)="switchAccount()">
       Switch Account
     </button>

--- a/examples/angular/src/app/components/content/content.component.ts
+++ b/examples/angular/src/app/components/content/content.component.ts
@@ -114,10 +114,10 @@ export class ContentComponent implements OnInit, OnDestroy {
   async onVerifyOwner() {
     const wallet = await this.selector.wallet();
     try {
-      const signature = await wallet.verifyOwner();
+      const owner = await wallet.verifyOwner();
 
-      if (signature) {
-        alert(`Signature for verification: ${signature.signature.toString()}`);
+      if (owner) {
+        alert(`Signature for verification: ${JSON.stringify(owner)}`);
       }
     } catch (err) {
       const message =

--- a/examples/angular/src/app/components/content/content.component.ts
+++ b/examples/angular/src/app/components/content/content.component.ts
@@ -114,7 +114,9 @@ export class ContentComponent implements OnInit, OnDestroy {
   async onVerifyOwner() {
     const wallet = await this.selector.wallet();
     try {
-      const owner = await wallet.verifyOwner();
+      const owner = await wallet.verifyOwner({
+        message: "test message for verification",
+      });
 
       if (owner) {
         alert(`Signature for verification: ${JSON.stringify(owner)}`);

--- a/examples/angular/src/app/components/content/content.component.ts
+++ b/examples/angular/src/app/components/content/content.component.ts
@@ -111,6 +111,21 @@ export class ContentComponent implements OnInit, OnDestroy {
     alert("Switched account to " + nextAccountId);
   }
 
+  async onVerifyOwner() {
+    const wallet = await this.selector.wallet();
+    try {
+      const signature = await wallet.verifyOwner();
+
+      if (signature) {
+        alert(`Signature for verification: ${signature.signature.toString()}`);
+      }
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Something went wrong";
+      alert(message);
+    }
+  }
+
   subscribeToEvents() {
     this.subscription = this.selector.store.observable
       .pipe(

--- a/examples/react/components/Content.tsx
+++ b/examples/react/components/Content.tsx
@@ -164,6 +164,21 @@ const Content: React.FC = () => {
     [selector, accountId]
   );
 
+  const handleVerifyOwner = async () => {
+    const wallet = await selector.wallet();
+    try {
+      const signature = await wallet.verifyOwner();
+
+      if (signature) {
+        alert(`Signature for verification: ${signature.signature.toString()}`);
+      }
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Something went wrong";
+      alert(message);
+    }
+  };
+
   const handleSubmit = useCallback(
     async (e: SubmitEvent) => {
       e.preventDefault();
@@ -220,6 +235,7 @@ const Content: React.FC = () => {
       <div>
         <button onClick={handleSignOut}>Log out</button>
         <button onClick={handleSwitchWallet}>Switch Wallet</button>
+        <button onClick={handleVerifyOwner}>Verify Owner</button>
         {accounts.length > 1 && (
           <button onClick={handleSwitchAccount}>Switch Account</button>
         )}

--- a/examples/react/components/Content.tsx
+++ b/examples/react/components/Content.tsx
@@ -167,10 +167,10 @@ const Content: React.FC = () => {
   const handleVerifyOwner = async () => {
     const wallet = await selector.wallet();
     try {
-      const signature = await wallet.verifyOwner();
+      const owner = await wallet.verifyOwner();
 
-      if (signature) {
-        alert(`Signature for verification: ${signature.signature.toString()}`);
+      if (owner) {
+        alert(`Signature for verification: ${JSON.stringify(owner)}`);
       }
     } catch (err) {
       const message =

--- a/examples/react/components/Content.tsx
+++ b/examples/react/components/Content.tsx
@@ -167,7 +167,9 @@ const Content: React.FC = () => {
   const handleVerifyOwner = async () => {
     const wallet = await selector.wallet();
     try {
-      const owner = await wallet.verifyOwner();
+      const owner = await wallet.verifyOwner({
+        message: "test message for verification",
+      });
 
       if (owner) {
         alert(`Signature for verification: ${JSON.stringify(owner)}`);

--- a/packages/core/docs/api/wallet.md
+++ b/packages/core/docs/api/wallet.md
@@ -193,7 +193,7 @@ Returns one or more accounts when signed in. This method can be useful for walle
   - `meta` (`string?`): Applicable to browser wallets (e.g. MyNearWallet) extra data that will be passed to the callback url once the signing is approved.
 
 **Returns**
-- `Promise<void | utils.key_pair.Signature>`: Browser wallets won't return the signing outcome as they may need to redirect for signing. For MyNearWallet the outcome is passed to the callback url.
+- `Promise<void | VerifiedOwner>`: Browser wallets won't return the signing outcome as they may need to redirect for signing. For MyNearWallet the outcome is passed to the callback url.
 
 **Description**
 

--- a/packages/core/docs/api/wallet.md
+++ b/packages/core/docs/api/wallet.md
@@ -186,9 +186,7 @@ Returns one or more accounts when signed in. This method can be useful for walle
 
 **Parameters**
 - `params` (`object`)
-  - `message` (`string?`): The message requested sign. Defaults to `verify owner` string.
-  - `signerId` (`string?`): Account ID used to sign the message. Defaults to the first account.
-  - `publicKey` (`PublicKey?`): Public key used to sign the message. Defaults to the public key of the signed in account.
+  - `message` (`string`): The message requested sign. Defaults to `verify owner` string.
   - `callbackUrl` (`string?`): Applicable to browser wallets (e.g. MyNearWallet). This is the callback url once the signing is approved. Defaults to `window.location.href`.
   - `meta` (`string?`): Applicable to browser wallets (e.g. MyNearWallet) extra data that will be passed to the callback url once the signing is approved.
 

--- a/packages/core/docs/api/wallet.md
+++ b/packages/core/docs/api/wallet.md
@@ -182,6 +182,37 @@ Returns one or more accounts when signed in. This method can be useful for walle
 })();
 ```
 
+### `.verifyOwner(params)`
+
+**Parameters**
+- `params` (`object`)
+  - `message` (`string?`): The message requested sign. Defaults to `verify owner` string.
+  - `signerId` (`string?`): Account ID used to sign the message. Defaults to the first account.
+  - `publicKey` (`PublicKey?`): Public key used to sign the message. Defaults to the public key of the signed in account.
+  - `callbackUrl` (`string?`): Applicable to browser wallets (e.g. MyNearWallet). This is the callback url once the signing is approved. Defaults to `window.location.href`.
+  - `meta` (`string?`): Applicable to browser wallets (e.g. MyNearWallet) extra data that will be passed to the callback url once the signing is approved.
+
+**Returns**
+- `Promise<void | utils.key_pair.Signature>`: Browser wallets won't return the signing outcome as they may need to redirect for signing. For MyNearWallet the outcome is passed to the callback url.
+
+**Description**
+
+Signs the message and verifies the owner. Message is not sent to blockchain.
+
+> Note: This feature is currently supported only by MyNearWallet on **testnet**. Sender can sign messages when unlocked.
+**Example**
+
+```ts
+// MyNearWallet
+(async () => {
+  const wallet = await selector.wallet("my-near-wallet");
+  await wallet.verifyOwner({
+    message: "Test message",
+  });
+})();
+```
+
+
 ### `.signAndSendTransaction(params)`
 
 **Parameters**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -45,6 +45,8 @@ export type {
   BridgeWalletMetadata,
   BridgeWalletBehaviour,
   BridgeWallet,
+  VerifiedOwner,
+  VerifyOwnerParams,
   Account,
   Transaction,
   Action,

--- a/packages/core/src/lib/wallet/wallet.types.ts
+++ b/packages/core/src/lib/wallet/wallet.types.ts
@@ -38,6 +38,15 @@ export interface VerifyOwnerParams {
   meta?: string;
 }
 
+export interface VerifiedOwner {
+  accountId: string;
+  message: string;
+  blockId: string;
+  publicKey: string;
+  signature: string;
+  keyType: utils.key_pair.KeyType;
+}
+
 export interface SignAndSendTransactionParams {
   signerId?: string;
   receiverId?: string;
@@ -52,9 +61,7 @@ interface BaseWalletBehaviour {
   signIn(params: SignInParams): Promise<Array<Account>>;
   signOut(): Promise<void>;
   getAccounts(): Promise<Array<Account>>;
-  verifyOwner(
-    params?: VerifyOwnerParams
-  ): Promise<utils.key_pair.Signature | void>;
+  verifyOwner(params?: VerifyOwnerParams): Promise<VerifiedOwner | void>;
   signAndSendTransaction(
     params: SignAndSendTransactionParams
   ): Promise<providers.FinalExecutionOutcome>;

--- a/packages/core/src/lib/wallet/wallet.types.ts
+++ b/packages/core/src/lib/wallet/wallet.types.ts
@@ -10,7 +10,6 @@ import type { Options } from "../options.types";
 import type { ReadOnlyStore } from "../store.types";
 import type { Transaction, Action } from "./transactions.types";
 import type { Modify, Optional } from "../utils.types";
-import { PublicKey } from "near-api-js/lib/utils";
 import type { FinalExecutionOutcome } from "near-api-js/lib/providers";
 
 interface BaseWalletMetadata {
@@ -31,9 +30,7 @@ export interface SignInParams {
 }
 
 export interface VerifyOwnerParams {
-  message?: string;
-  signerId?: string;
-  publicKey?: PublicKey;
+  message: string;
   callbackUrl?: string;
   meta?: string;
 }
@@ -61,7 +58,7 @@ interface BaseWalletBehaviour {
   signIn(params: SignInParams): Promise<Array<Account>>;
   signOut(): Promise<void>;
   getAccounts(): Promise<Array<Account>>;
-  verifyOwner(params?: VerifyOwnerParams): Promise<VerifiedOwner | void>;
+  verifyOwner(params: VerifyOwnerParams): Promise<VerifiedOwner | void>;
   signAndSendTransaction(
     params: SignAndSendTransactionParams
   ): Promise<providers.FinalExecutionOutcome>;

--- a/packages/core/src/lib/wallet/wallet.types.ts
+++ b/packages/core/src/lib/wallet/wallet.types.ts
@@ -1,4 +1,4 @@
-import { providers } from "near-api-js";
+import { providers, utils } from "near-api-js";
 
 import {
   EventEmitterService,
@@ -10,6 +10,7 @@ import type { Options } from "../options.types";
 import type { ReadOnlyStore } from "../store.types";
 import type { Transaction, Action } from "./transactions.types";
 import type { Modify, Optional } from "../utils.types";
+import { PublicKey } from "near-api-js/lib/utils";
 import type { FinalExecutionOutcome } from "near-api-js/lib/providers";
 
 interface BaseWalletMetadata {
@@ -29,6 +30,14 @@ export interface SignInParams {
   methodNames?: Array<string>;
 }
 
+export interface VerifyOwnerParams {
+  message?: string;
+  signerId?: string;
+  publicKey?: PublicKey;
+  callbackUrl?: string;
+  meta?: string;
+}
+
 export interface SignAndSendTransactionParams {
   signerId?: string;
   receiverId?: string;
@@ -43,6 +52,9 @@ interface BaseWalletBehaviour {
   signIn(params: SignInParams): Promise<Array<Account>>;
   signOut(): Promise<void>;
   getAccounts(): Promise<Array<Account>>;
+  verifyOwner(
+    params?: VerifyOwnerParams
+  ): Promise<utils.key_pair.Signature | void>;
   signAndSendTransaction(
     params: SignAndSendTransactionParams
   ): Promise<providers.FinalExecutionOutcome>;

--- a/packages/ledger/src/lib/ledger.ts
+++ b/packages/ledger/src/lib/ledger.ts
@@ -220,8 +220,8 @@ const Ledger: WalletBehaviourFactory<HardwareWallet> = async ({
       return getAccounts();
     },
 
-    async verifyOwner({ message = "verify owner", signerId, publicKey } = {}) {
-      logger.log("Ledger:verifyOwner", { message, signerId, publicKey });
+    async verifyOwner({ message }) {
+      logger.log("Ledger:verifyOwner", { message });
 
       throw new Error(`Method not supported by ${metadata.name}`);
     },

--- a/packages/ledger/src/lib/ledger.ts
+++ b/packages/ledger/src/lib/ledger.ts
@@ -223,36 +223,7 @@ const Ledger: WalletBehaviourFactory<HardwareWallet> = async ({
     async verifyOwner({ message = "verify owner", signerId, publicKey } = {}) {
       logger.log("Ledger:verifyOwner", { message, signerId, publicKey });
 
-      const account = getActiveAccount(store.getState());
-
-      if (!account) {
-        throw new Error("No active account");
-      }
-
-      // Note: Connection must be triggered by user interaction.
-      await connectLedgerDevice();
-
-      const networkId = options.network.networkId;
-      const accountId = signerId || account.accountId;
-      const pubKey =
-        publicKey || (await signer.getPublicKey(accountId, networkId));
-      const block = await provider.block({ finality: "final" });
-
-      const msg = JSON.stringify({
-        accountId,
-        message,
-        blockId: block.header.hash,
-        publicKey: Buffer.from(pubKey.data).toString("base64"),
-        keyType: pubKey.keyType,
-      });
-
       throw new Error(`Method not supported by ${metadata.name}`);
-
-      return signer.signMessage(
-        new Uint8Array(Buffer.from(msg)),
-        accountId,
-        networkId
-      );
     },
 
     async signAndSendTransaction({ signerId, receiverId, actions }) {

--- a/packages/math-wallet/src/lib/math-wallet.ts
+++ b/packages/math-wallet/src/lib/math-wallet.ts
@@ -119,22 +119,29 @@ const MathWallet: WalletBehaviourFactory<InjectedWallet> = async ({
         publicKey || (await _state.wallet.signer.getPublicKey(accountId));
       const block = await provider.block({ finality: "final" });
 
-      const msg = JSON.stringify({
+      const data = {
         accountId,
         message,
         blockId: block.header.hash,
         publicKey: Buffer.from(pubKey.data).toString("base64"),
         keyType: pubKey.keyType,
-      });
+      };
+      const encoded = JSON.stringify(data);
 
       // Note: Math Wallet currently hangs when calling signMessage.
       throw new Error(`Method not supported by ${metadata.name}`);
 
-      return _state.wallet.signer.signMessage(
-        new Uint8Array(Buffer.from(msg)),
+      const signed = await _state.wallet.signer.signMessage(
+        new Uint8Array(Buffer.from(encoded)),
         accountId,
         options.network.networkId
       );
+
+      return {
+        ...data,
+        signature: Buffer.from(signed.signature).toString("base64"),
+        keyType: signed.publicKey.keyType,
+      };
     },
 
     async signAndSendTransaction({ signerId, receiverId, actions }) {

--- a/packages/math-wallet/src/lib/math-wallet.ts
+++ b/packages/math-wallet/src/lib/math-wallet.ts
@@ -105,8 +105,8 @@ const MathWallet: WalletBehaviourFactory<InjectedWallet> = async ({
       return getAccounts();
     },
 
-    async verifyOwner({ message = "verify owner", signerId, publicKey } = {}) {
-      logger.log("MathWallet:verifyOwner", { message, signerId, publicKey });
+    async verifyOwner({ message }) {
+      logger.log("MathWallet:verifyOwner", { message });
 
       const account = getActiveAccount(store.getState());
 
@@ -114,9 +114,8 @@ const MathWallet: WalletBehaviourFactory<InjectedWallet> = async ({
         throw new Error("No active account");
       }
 
-      const accountId = signerId || account.accountId;
-      const pubKey =
-        publicKey || (await _state.wallet.signer.getPublicKey(accountId));
+      const accountId = account.accountId;
+      const pubKey = await _state.wallet.signer.getPublicKey(accountId);
       const block = await provider.block({ finality: "final" });
 
       const data = {

--- a/packages/meteor-wallet/src/lib/meteor-wallet.ts
+++ b/packages/meteor-wallet/src/lib/meteor-wallet.ts
@@ -48,7 +48,7 @@ const setupWalletState = async (
 const createMeteorWalletInjected: WalletBehaviourFactory<
   InjectedWallet,
   { params: MeteorWalletParams_Injected }
-> = async ({ options, logger, store, params }) => {
+> = async ({ metadata, options, logger, store, params }) => {
   const _state = await setupWalletState(params, options.network);
 
   const cleanup = () => {
@@ -153,6 +153,12 @@ const createMeteorWalletInjected: WalletBehaviourFactory<
 
     async getAccounts() {
       return getAccounts();
+    },
+
+    async verifyOwner({ message = "verify owner", signerId, publicKey } = {}) {
+      logger.log("MeteorWallet:verifyOwner", { message, signerId, publicKey });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
     },
 
     async signAndSendTransaction({ signerId, receiverId, actions }) {

--- a/packages/meteor-wallet/src/lib/meteor-wallet.ts
+++ b/packages/meteor-wallet/src/lib/meteor-wallet.ts
@@ -155,8 +155,8 @@ const createMeteorWalletInjected: WalletBehaviourFactory<
       return getAccounts();
     },
 
-    async verifyOwner({ message = "verify owner", signerId, publicKey } = {}) {
-      logger.log("MeteorWallet:verifyOwner", { message, signerId, publicKey });
+    async verifyOwner({ message }) {
+      logger.log("MeteorWallet:verifyOwner", { message });
 
       throw new Error(`Method not supported by ${metadata.name}`);
     },

--- a/packages/my-near-wallet/src/lib/my-near-wallet.ts
+++ b/packages/my-near-wallet/src/lib/my-near-wallet.ts
@@ -74,7 +74,7 @@ const setupWalletState = async (
 const MyNearWallet: WalletBehaviourFactory<
   BrowserWallet,
   { params: MyNearWalletExtraOptions }
-> = async ({ options, store, params, logger }) => {
+> = async ({ metadata, options, store, params, logger }) => {
   const _state = await setupWalletState(params, options.network);
 
   const cleanup = () => {
@@ -153,6 +153,39 @@ const MyNearWallet: WalletBehaviourFactory<
 
     async getAccounts() {
       return getAccounts();
+    },
+
+    async verifyOwner({
+      message = "verify owner",
+      signerId,
+      publicKey,
+      callbackUrl,
+      meta,
+    } = {}) {
+      logger.log("verifyOwner", { message, signerId, publicKey });
+
+      const account = _state.wallet.account();
+
+      if (!account) {
+        throw new Error("Wallet not signed in");
+      }
+      const locationUrl =
+        typeof window !== "undefined" ? window.location.href : "";
+
+      const url = callbackUrl || locationUrl;
+
+      if (!url) {
+        throw new Error(`The callbackUrl is missing for ${metadata.name}`);
+      }
+
+      const encodedUrl = encodeURIComponent(url);
+      const extraMeta = meta ? `&meta=${meta}` : "";
+
+      window.location.replace(
+        `${params.walletUrl}/verify-owner?message=${message}&callbackUrl=${encodedUrl}${extraMeta}`
+      );
+
+      return;
     },
 
     async signAndSendTransaction({

--- a/packages/my-near-wallet/src/lib/my-near-wallet.ts
+++ b/packages/my-near-wallet/src/lib/my-near-wallet.ts
@@ -155,14 +155,8 @@ const MyNearWallet: WalletBehaviourFactory<
       return getAccounts();
     },
 
-    async verifyOwner({
-      message = "verify owner",
-      signerId,
-      publicKey,
-      callbackUrl,
-      meta,
-    } = {}) {
-      logger.log("verifyOwner", { message, signerId, publicKey });
+    async verifyOwner({ message, callbackUrl, meta }) {
+      logger.log("verifyOwner", { message });
 
       const account = _state.wallet.account();
 

--- a/packages/nightly-connect/src/lib/nightly-connect.ts
+++ b/packages/nightly-connect/src/lib/nightly-connect.ts
@@ -156,12 +156,8 @@ const NightlyConnect: WalletBehaviourFactory<
       return getAccounts().map(({ accountId }) => ({ accountId }));
     },
 
-    async verifyOwner({ message = "verify owner", signerId, publicKey } = {}) {
-      logger.log("NightlyConnect:verifyOwner", {
-        message,
-        signerId,
-        publicKey,
-      });
+    async verifyOwner({ message }) {
+      logger.log("NightlyConnect:verifyOwner", { message });
 
       throw new Error(`Method not supported by ${metadata.name}`);
     },

--- a/packages/nightly-connect/src/lib/nightly-connect.ts
+++ b/packages/nightly-connect/src/lib/nightly-connect.ts
@@ -44,7 +44,7 @@ const setupNightlyConnectState = (): NightlyConnectState => {
 const NightlyConnect: WalletBehaviourFactory<
   BridgeWallet,
   { params: NightlyConnectParams }
-> = async ({ store, params, logger, options, provider, emitter }) => {
+> = async ({ metadata, store, params, logger, options, provider, emitter }) => {
   const _state = setupNightlyConnectState();
 
   const getAccounts = () => {
@@ -154,6 +154,16 @@ const NightlyConnect: WalletBehaviourFactory<
 
     async getAccounts() {
       return getAccounts().map(({ accountId }) => ({ accountId }));
+    },
+
+    async verifyOwner({ message = "verify owner", signerId, publicKey } = {}) {
+      logger.log("NightlyConnect:verifyOwner", {
+        message,
+        signerId,
+        publicKey,
+      });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
     },
 
     async signAndSendTransaction({ signerId, receiverId, actions }) {

--- a/packages/nightly/src/lib/nightly.ts
+++ b/packages/nightly/src/lib/nightly.ts
@@ -40,6 +40,7 @@ const isInstalled = () => {
   return waitFor(() => !!window.nightly!.near!).catch(() => false);
 };
 const Nightly: WalletBehaviourFactory<InjectedWallet> = async ({
+  metadata,
   options,
   store,
   logger,
@@ -139,6 +140,12 @@ const Nightly: WalletBehaviourFactory<InjectedWallet> = async ({
 
     async getAccounts() {
       return getAccounts().map(({ accountId }) => ({ accountId }));
+    },
+
+    async verifyOwner({ message = "verify owner", signerId, publicKey } = {}) {
+      logger.log("Nightly:verifyOwner", { message, signerId, publicKey });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
     },
 
     async signAndSendTransaction({ signerId, receiverId, actions }) {

--- a/packages/nightly/src/lib/nightly.ts
+++ b/packages/nightly/src/lib/nightly.ts
@@ -142,8 +142,8 @@ const Nightly: WalletBehaviourFactory<InjectedWallet> = async ({
       return getAccounts().map(({ accountId }) => ({ accountId }));
     },
 
-    async verifyOwner({ message = "verify owner", signerId, publicKey } = {}) {
-      logger.log("Nightly:verifyOwner", { message, signerId, publicKey });
+    async verifyOwner({ message }) {
+      logger.log("Nightly:verifyOwner", { message });
 
       throw new Error(`Method not supported by ${metadata.name}`);
     },

--- a/packages/sender/src/lib/injected-sender.ts
+++ b/packages/sender/src/lib/injected-sender.ts
@@ -1,7 +1,7 @@
 // Interfaces based on "documentation": https://github.com/SenderWallet/sender-wallet-integration-tutorial
 
 // Empty string if we haven't signed in before.
-import { providers } from "near-api-js";
+import { Account, providers } from "near-api-js";
 
 interface AccessKey {
   publicKey: {
@@ -114,6 +114,7 @@ export interface InjectedSender {
   callbacks: Record<keyof SenderEvents, unknown>;
   getAccountId: () => string | null;
   getRpc: () => Promise<GetRpcResponse>;
+  account(): Account | null;
   requestSignIn: (
     params: RequestSignInParams
   ) => Promise<RequestSignInResponse>;

--- a/packages/sender/src/lib/sender.ts
+++ b/packages/sender/src/lib/sender.ts
@@ -198,19 +198,26 @@ const Sender: WalletBehaviourFactory<InjectedWallet> = async ({
         (await account.connection.signer.getPublicKey(accountId, networkId));
       const block = await provider.block({ finality: "final" });
 
-      const msg = JSON.stringify({
+      const data = {
         accountId,
         message,
         blockId: block.header.hash,
         publicKey: Buffer.from(pubKey.data).toString("base64"),
         keyType: pubKey.keyType,
-      });
+      };
+      const encoded = JSON.stringify(data);
 
-      return account.connection.signer.signMessage(
-        new Uint8Array(Buffer.from(msg)),
+      const signed = await account.connection.signer.signMessage(
+        new Uint8Array(Buffer.from(encoded)),
         accountId,
         networkId
       );
+
+      return {
+        ...data,
+        signature: Buffer.from(signed.signature).toString("base64"),
+        keyType: signed.publicKey.keyType,
+      };
     },
 
     async signAndSendTransaction({ signerId, receiverId, actions }) {

--- a/packages/sender/src/lib/sender.ts
+++ b/packages/sender/src/lib/sender.ts
@@ -175,8 +175,8 @@ const Sender: WalletBehaviourFactory<InjectedWallet> = async ({
       return getAccounts();
     },
 
-    async verifyOwner({ message = "verify owner", signerId, publicKey } = {}) {
-      logger.log("Sender:verifyOwner", { message, signerId, publicKey });
+    async verifyOwner({ message }) {
+      logger.log("Sender:verifyOwner", { message });
 
       const account = _state.wallet.account();
 
@@ -192,10 +192,11 @@ const Sender: WalletBehaviourFactory<InjectedWallet> = async ({
       }
 
       const networkId = options.network.networkId;
-      const accountId = signerId || account.accountId;
-      const pubKey =
-        publicKey ||
-        (await account.connection.signer.getPublicKey(accountId, networkId));
+      const accountId = account.accountId;
+      const pubKey = await account.connection.signer.getPublicKey(
+        accountId,
+        networkId
+      );
       const block = await provider.block({ finality: "final" });
 
       const data = {

--- a/packages/wallet-connect/src/lib/wallet-connect.ts
+++ b/packages/wallet-connect/src/lib/wallet-connect.ts
@@ -177,8 +177,8 @@ const WalletConnect: WalletBehaviourFactory<
       return getAccounts();
     },
 
-    async verifyOwner({ message = "verify owner", signerId, publicKey } = {}) {
-      logger.log("WalletConnect:verifyOwner", { message, signerId, publicKey });
+    async verifyOwner({ message }) {
+      logger.log("WalletConnect:verifyOwner", { message });
 
       throw new Error(`Method not supported by ${metadata.name}`);
     },

--- a/packages/wallet-connect/src/lib/wallet-connect.ts
+++ b/packages/wallet-connect/src/lib/wallet-connect.ts
@@ -66,7 +66,7 @@ const setupWalletConnectState = async (
 const WalletConnect: WalletBehaviourFactory<
   BridgeWallet,
   { params: WalletConnectExtraOptions }
-> = async ({ options, store, params, emitter, logger }) => {
+> = async ({ metadata, options, store, params, emitter, logger }) => {
   const _state = await setupWalletConnectState(params);
 
   const getChainId = () => {
@@ -175,6 +175,12 @@ const WalletConnect: WalletBehaviourFactory<
 
     async getAccounts() {
       return getAccounts();
+    },
+
+    async verifyOwner({ message = "verify owner", signerId, publicKey } = {}) {
+      logger.log("WalletConnect:verifyOwner", { message, signerId, publicKey });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
     },
 
     async signAndSendTransaction({ signerId, receiverId, actions }) {


### PR DESCRIPTION
# Description

- Added support for `verifyOwner` to the API of all wallet integrations.
  - On MyNearWallet  this feature is only supported on **testnet**
  - On Sender this feature works only when Sender is unlocked.
  - Other wallets throw a "Method not supported" error.
  

## Note

  The work for this PR initially started here: #320, there were some build issues that I was unable to solve quickly, I copied everything from there and addressed requested changes here in separate commits.

Closes #318.

<!-- REMOVE ALL THE TEMPLATE BELOW IF THE PR IS A RELEASE -->


# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change. This type of change is the main reason for the PR.
<!-- CHECKLIST_TYPE: ONE -->
- [ ] FIX - a PR of this type patches a bug.
- [x] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->

# Breaking changes
<!-- CHECKLIST_TYPE: ONE -->
<!-- SPECIFY BREAKING CHANGES AS A ONE-LINER -->
- [ ] BREAKING CHANGE - SPECIFY: _______
- [x] NO BREAKING CHANGE - this PR doesn't contain any breaking changes and it's backwards compatible
<!-- /CHECKLIST_TYPE -->
