### PR TITLE
fix: Improve Wallet Selector Initialization

### DIFF
--- a/packages/core/src/lib/services/wallet-modules/wallet-modules.service.ts
+++ b/packages/core/src/lib/services/wallet-modules/wallet-modules.service.ts
@@ -262,6 +262,16 @@ export class WalletModules {
       return null;
     }
 
+    const { selectedWalletId } = this.store.getState();
+
+    // If user uninstalled/removed a wallet which was previously signed in with
+    // best we can do is clean up state on our side.
+    if (!module.metadata.available && selectedWalletId) {
+      this.onWalletSignedOut(selectedWalletId);
+
+      return null;
+    }
+
     return (await module.wallet()) as Variation;
   }
 


### PR DESCRIPTION
# Description

- Fix `wallet-selector` initialization when a user was previously `signedIn` via an injected wallet but later on removed that wallet
- Wallet Selector now clears the signed in state.

Closes #388 
<!-- REMOVE ALL THE TEMPLATE BELOW IF THE PR IS A RELEASE -->


# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change. This type of change is the main reason for the PR.
<!-- CHECKLIST_TYPE: ONE -->
- [x] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->

# Breaking changes
<!-- CHECKLIST_TYPE: ONE -->
<!-- SPECIFY BREAKING CHANGES AS A ONE-LINER -->
- [ ] BREAKING CHANGE - SPECIFY: _______
- [x] NO BREAKING CHANGE - this PR doesn't contain any breaking changes and it's backwards compatible
<!-- /CHECKLIST_TYPE -->
