### PR TITLE
fix: `signAndSendTransaction(s)` response type change in Sender wallet

### DIFF
--- a/packages/sender/src/lib/injected-sender.ts
+++ b/packages/sender/src/lib/injected-sender.ts
@@ -74,13 +74,23 @@ export interface SignAndSendTransactionParams {
   actions: Array<Action>;
 }
 
+export interface FunctionCallError {
+  error: {
+    index: number;
+    kind: object;
+    message: string;
+    transaction_outcome: object;
+    type: "FunctionCallError";
+  };
+}
+
 // Seems to reuse signAndSendTransactions internally, hence the wrong method name and list of responses.
 export interface SignAndSendTransactionResponse {
   actionType: "DAPP/DAPP_POPUP_RESPONSE";
   method: "signAndSendTransactions";
   notificationId: number;
   error?: string;
-  response?: Array<providers.FinalExecutionOutcome>;
+  response?: Array<providers.FinalExecutionOutcome> | FunctionCallError;
   type: "sender-wallet-extensionResult";
 }
 
@@ -89,7 +99,7 @@ export interface SignAndSendTransactionsResponse {
   method: "signAndSendTransactions";
   notificationId: number;
   error?: string;
-  response?: Array<providers.FinalExecutionOutcome>;
+  response?: Array<providers.FinalExecutionOutcome> | FunctionCallError;
   type: "sender-wallet-extensionResult";
 }
 

--- a/packages/sender/src/lib/sender.ts
+++ b/packages/sender/src/lib/sender.ts
@@ -191,6 +191,8 @@ const Sender: WalletBehaviourFactory<InjectedWallet> = async ({
         .then((res) => {
           if (res.error) {
             throw new Error(res.error);
+          } else if (res.response && "error" in res.response) {
+            throw new Error(res.response.error.message);
           }
 
           // Shouldn't happen but avoids inconsistent responses.
@@ -216,6 +218,8 @@ const Sender: WalletBehaviourFactory<InjectedWallet> = async ({
         .then((res) => {
           if (res.error) {
             throw new Error(res.error);
+          } else if (res.response && "error" in res.response) {
+            throw new Error(res.response.error.message);
           }
 
           // Shouldn't happen but avoids inconsistent responses.


### PR DESCRIPTION
# Description

The PR is to fix the incompatible `signAndSendTransaction` response type with Sender v1.0.0 and later version. 

Closes #392


# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change. This type of change is the main reason for the PR.
<!-- CHECKLIST_TYPE: ONE -->
- [x] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->

# Breaking changes
<!-- CHECKLIST_TYPE: ONE -->
<!-- SPECIFY BREAKING CHANGES AS A ONE-LINER -->
- [ ] BREAKING CHANGE
- [x] NO BREAKING CHANGE - this PR doesn't contain any breaking changes and it's backwards compatible
<!-- /CHECKLIST_TYPE -->
