### PR TITLE
fix: Add Prefix to css class names which conflict with Bootstrap

### DIFF
--- a/packages/modal-ui/src/lib/components/HardwareWalletAccountsForm.tsx
+++ b/packages/modal-ui/src/lib/components/HardwareWalletAccountsForm.tsx
@@ -28,7 +28,7 @@ const HardwareWalletAccountsForm: React.FC<FormProps> = ({
         }}
       >
         <div>
-          <div className="form-control">
+          <div className="nws-form-control">
             {accounts.map((account, index) => (
               <div key={index}>
                 <input

--- a/packages/modal-ui/src/lib/components/Modal.tsx
+++ b/packages/modal-ui/src/lib/components/Modal.tsx
@@ -92,12 +92,12 @@ export const Modal: React.FC<ModalProps> = ({
       }`}
     >
       <div className="modal-overlay" onClick={handleDismissClick} />
-      <div className="modal">
-        <div className="modal-header">
+      <div className="nws-modal">
+        <div className="nws-modal-header">
           <h2>Connect Wallet</h2>
           <CloseButton onClick={handleDismissClick} />
         </div>
-        <div className="modal-body">
+        <div className="nws-modal-body">
           {route.name === "AlertMessage" && alertMessage && (
             <AlertMessage
               message={alertMessage}

--- a/packages/modal-ui/src/lib/components/styles.css
+++ b/packages/modal-ui/src/lib/components/styles.css
@@ -96,7 +96,7 @@
  * Modal
  */
 
-.nws-modal-wrapper .modal {
+.nws-modal-wrapper .nws-modal {
   background: var(--wallet-selector-content-bg, var(--content-bg));
   width: 400px;
   max-width: 700px;
@@ -114,7 +114,7 @@
   line-height: 1.6;
 }
 
-.nws-modal-wrapper .modal {
+.nws-modal-wrapper .nws-modal {
   box-sizing: content-box;
 }
 
@@ -122,13 +122,13 @@
  * Modal Header
  */
 
-.nws-modal-wrapper .modal .modal-header {
+.nws-modal-wrapper .nws-modal .nws-modal-header {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
 }
 
-.nws-modal-wrapper .modal .modal-header .close-button {
+.nws-modal-wrapper .nws-modal .nws-modal-header .close-button {
   border: 0;
   cursor: pointer;
   height: 24px;
@@ -136,20 +136,20 @@
   background-color: transparent;
 }
 
-.nws-modal-wrapper .modal .modal-header .close-button:active {
+.nws-modal-wrapper .nws-modal .nws-modal-header .close-button:active {
   background: transparent;
 }
 
-.nws-modal-wrapper .modal .modal-header .close-button svg {
+.nws-modal-wrapper .nws-modal .nws-modal-header .close-button svg {
   pointer-events: none;
 }
 
-.nws-modal-wrapper .modal .modal-header .close-button:hover svg {
+.nws-modal-wrapper .nws-modal .nws-modal-header .close-button:hover svg {
   fill: var(--wallet-selector-close-button-color, var(--close-button-color));
   transition: all 0.2s ease-in;
 }
 
-.nws-modal-wrapper .modal .modal-header h2 {
+.nws-modal-wrapper .nws-modal .nws-modal-header h2 {
   color: var(--wallet-selector-heading-color, var(--heading-color));
   font-size: 22px;
   margin-top: 0;
@@ -160,8 +160,8 @@
  * Modal buttons and inputs
  */
 
-.nws-modal-wrapper .modal .modal-body input,
-.nws-modal-wrapper .modal .modal-body button {
+.nws-modal-wrapper .nws-modal .nws-modal-body input,
+.nws-modal-wrapper .nws-modal .nws-modal-body button {
   background: inherit;
   font-size: 14.2px;
   font-family: inherit;
@@ -178,24 +178,24 @@
   cursor: pointer;
 }
 
-.nws-modal-wrapper .modal .action-buttons {
+.nws-modal-wrapper .nws-modal .action-buttons {
   display: flex;
   justify-content: space-between;
   align-items: center;
 }
 
-.nws-modal-wrapper .modal .action-buttons .left-button:hover {
+.nws-modal-wrapper .nws-modal .action-buttons .left-button:hover {
   background-color: var(--wallet-selector-dismiss-button-bg-hover, var(--dismiss-button-bg-hover));
   border-color: var(--wallet-selector-dismiss-button-border-color-hover, var(--dismiss-button-border-color-hover))
 }
 
-.nws-modal-wrapper .modal .action-buttons .right-button {
+.nws-modal-wrapper .nws-modal .action-buttons .right-button {
   color: var(--wallet-selector-confirm-button-color, var(--confirm-button-color));
   background-color: var(--wallet-selector-confirm-button-bg, var(--confirm-button-bg));
   border: 1px solid var(--wallet-selector-confirm-button-border-color, var(--confirm-button-border-color));
 }
 
-.nws-modal-wrapper .modal .action-buttons .right-button:hover {
+.nws-modal-wrapper .nws-modal .action-buttons .right-button:hover {
   background-color: var(--wallet-selector-confirm-button-bg-hover, var(--confirm-button-bg-hover));
 }
 
@@ -203,13 +203,13 @@
  * Modal Switch Network Message Section/Wrapper
  */
 
-.nws-modal-wrapper .modal .switch-network-message-wrapper .header h2 {
+.nws-modal-wrapper .nws-modal .switch-network-message-wrapper .header h2 {
   font-size: 18px;
   margin-top: 0;
   color: var(--wallet-selector-heading-color, var(--heading-color));
 }
 
-.nws-modal-wrapper .modal .switch-network-message-wrapper .content  p {
+.nws-modal-wrapper .nws-modal .switch-network-message-wrapper .content  p {
   font-size: 14.25px;
 }
 
@@ -217,114 +217,115 @@
  * Modal Ledger Derivation Path Section/Wrapper
  */
 
-.nws-modal-wrapper .modal .derivation-path-wrapper input {
+.nws-modal-wrapper .nws-modal .derivation-path-wrapper input {
   margin-right: 8px;
 }
 
-.nws-modal-wrapper .modal .derivation-path-wrapper input:focus {
+.nws-modal-wrapper .nws-modal .derivation-path-wrapper input:focus {
   border: 2px solid var(--wallet-selector-input-border-color-focus, var(--input-border-color-focus));
 }
 
-.nws-modal-wrapper .modal .derivation-path-wrapper input:focus-visible {
+.nws-modal-wrapper .nws-modal .derivation-path-wrapper input:focus-visible {
   border: none;
   outline: 2px solid var(--wallet-selector-input-border-color-focus, var(--input-border-color-focus));
 }
 
-.nws-modal-wrapper .modal .derivation-path-wrapper .input-error {
+.nws-modal-wrapper .nws-modal .derivation-path-wrapper .input-error {
   border-color: var(--wallet-selector-error, var(--error)) !important;
 }
 
-.nws-modal-wrapper .modal .derivation-path-wrapper .error {
+.nws-modal-wrapper .nws-modal .derivation-path-wrapper .error {
   font-family: inherit;
   color: var(--wallet-selector-error, var(--error));
 }
 
-.nws-modal-wrapper .modal .derivation-path-wrapper .no-accounts-found-wrapper a {
+.nws-modal-wrapper .nws-modal .derivation-path-wrapper .no-accounts-found-wrapper a {
   color: #5f8afa;
   text-decoration: none;
 }
 
-.nws-modal-wrapper .modal .derivation-path-wrapper .no-accounts-found-wrapper .action-buttons {
+.nws-modal-wrapper .nws-modal .derivation-path-wrapper .no-accounts-found-wrapper .action-buttons {
   justify-content: flex-start;
 }
 
-.nws-modal-wrapper .modal .derivation-path-wrapper .enter-derivation-path .view-account {
+.nws-modal-wrapper .nws-modal .derivation-path-wrapper .enter-derivation-path .view-account {
   font-size: 15px;
   color: #5f8afa;
   cursor: pointer;
 }
-.nws-modal-wrapper .modal .derivation-path-wrapper .enter-derivation-path .view-account:hover {
+.nws-modal-wrapper .nws-modal .derivation-path-wrapper .enter-derivation-path .view-account:hover {
   text-decoration: underline;
 }
 
-.nws-modal-wrapper .modal .derivation-path-wrapper .enter-derivation-path .view-account:hover {
+.nws-modal-wrapper .nws-modal .derivation-path-wrapper .enter-derivation-path .view-account:hover {
   text-decoration: underline;
 }
 
-.nws-modal-wrapper .modal .derivation-path-wrapper .enter-derivation-path .error {
+.nws-modal-wrapper .nws-modal .derivation-path-wrapper .enter-derivation-path .error {
   font-size: 12px;
 }
 
-.nws-modal-wrapper .modal .derivation-path-wrapper .action-buttons {
+.nws-modal-wrapper .nws-modal .derivation-path-wrapper .action-buttons {
   margin-top: 20px;
 }
 
-.nws-modal-wrapper .modal .derivation-path-wrapper .action-buttons .right-button:disabled {
+.nws-modal-wrapper .nws-modal .derivation-path-wrapper .action-buttons .right-button:disabled {
   cursor: not-allowed;
   opacity: 0.7;
 }
 
-.nws-modal-wrapper .modal .derivation-path-wrapper .overview-wrapper .overview-header {
+.nws-modal-wrapper .nws-modal .derivation-path-wrapper .overview-wrapper .overview-header {
   padding: 10px;
   border-bottom: 1px solid rgb(216, 216, 216);
   margin-bottom: 10px;
 }
 
-.nws-modal-wrapper .modal .derivation-path-wrapper .overview-wrapper .overview-header h4 {
+.nws-modal-wrapper .nws-modal .derivation-path-wrapper .overview-wrapper .overview-header h4 {
   margin: 0;
+  font-size: 16px;
 }
 
-.nws-modal-wrapper .modal .derivation-path-wrapper .overview-wrapper .overview-header span {
+.nws-modal-wrapper .nws-modal .derivation-path-wrapper .overview-wrapper .overview-header span {
   color: rgb(95, 138, 250);
   cursor: pointer;
 }
 
-.nws-modal-wrapper .modal .derivation-path-wrapper .overview-wrapper .account {
+.nws-modal-wrapper .nws-modal .derivation-path-wrapper .overview-wrapper .account {
   padding: 10px;
   cursor: pointer;
   font-size: 15px;
 }
 
-.nws-modal-wrapper .modal .derivation-path-wrapper .overview-wrapper .action-buttons {
+.nws-modal-wrapper .nws-modal .derivation-path-wrapper .overview-wrapper .action-buttons {
   justify-content: flex-end;
 }
 
-.nws-modal-wrapper .modal .derivation-path-wrapper .enter-custom-account .input-wrapper {
+.nws-modal-wrapper .nws-modal .derivation-path-wrapper .enter-custom-account .input-wrapper {
   display: flex;
   justify-content: center;
 }
 
-.nws-modal-wrapper .modal .derivation-path-wrapper .enter-custom-account input {
+.nws-modal-wrapper .nws-modal .derivation-path-wrapper .enter-custom-account input {
   max-width: 250px;
 }
 
-.nws-modal-wrapper .modal .derivation-path-wrapper .enter-custom-account .action-buttons {
+.nws-modal-wrapper .nws-modal .derivation-path-wrapper .enter-custom-account .action-buttons {
   justify-content: flex-end;
 }
 
 /**
  * Modal Wallet ChooseLedgerAccountForm/Wrapper
  */
-.nws-modal-wrapper .modal .choose-ledger-account-form-wrapper .form-control {
+.nws-modal-wrapper .nws-modal .choose-ledger-account-form-wrapper .nws-form-control {
   margin-bottom: 16px;
   padding: 10px;
   box-shadow: rgb(0 0 0 / 16%) 0 1px 4px;
   color: var(--text-color);
 }
-.nws-modal-wrapper .modal .choose-ledger-account-form-wrapper .form-control label {
+.nws-modal-wrapper .nws-modal .choose-ledger-account-form-wrapper .nws-form-control label {
   color: inherit;
 }
-.nws-modal-wrapper .modal .choose-ledger-account-form-wrapper .form-control select {
+.nws-modal-wrapper .nws-modal .choose-ledger-account-form-wrapper .nws-form-control select {
   padding: 8px;
   font-size: 14px;
   border-radius: 10px;
@@ -335,12 +336,12 @@
   color: inherit;
 }
 
-.nws-modal-wrapper .modal .choose-ledger-account-form-wrapper .form-control select option {
+.nws-modal-wrapper .nws-modal .choose-ledger-account-form-wrapper .nws-form-control select option {
   background-color: var(--content-bg);
 }
 
 
-.nws-modal-wrapper .modal .choose-ledger-account-form-wrapper .action-buttons {
+.nws-modal-wrapper .nws-modal .choose-ledger-account-form-wrapper .action-buttons {
   justify-content: flex-end;
 }
 
@@ -348,16 +349,16 @@
  * Modal Wallet Options Section/Wrapper
  */
 
-.nws-modal-wrapper .modal .wallet-options-wrapper .description {
+.nws-modal-wrapper .nws-modal .wallet-options-wrapper .description {
   margin-top: 0;
   margin-bottom: 20px;
 }
 
-.nws-modal-wrapper .modal .wallet-options-wrapper .options-list li span {
+.nws-modal-wrapper .nws-modal .wallet-options-wrapper .options-list li span {
   font-size: 14px;
 }
 
-.nws-modal-wrapper .modal .wallet-options-wrapper .options-list {
+.nws-modal-wrapper .nws-modal .wallet-options-wrapper .options-list {
   margin: 0;
   list-style-type: none;
   padding: 0;
@@ -366,7 +367,7 @@
   gap: 10px;
 }
 
-.nws-modal-wrapper .modal .wallet-options-wrapper .options-list li {
+.nws-modal-wrapper .nws-modal .wallet-options-wrapper .options-list li {
   display: flex;
   justify-content: center;
   padding: 1em;
@@ -376,13 +377,13 @@
   transition: background-color 0.2s ease-in-out;
 }
 
-.nws-modal-wrapper .modal .wallet-options-wrapper .options-list li .wallet-content {
+.nws-modal-wrapper .nws-modal .wallet-options-wrapper .options-list li .wallet-content {
   display: flex;
   flex-direction: column;
   align-items: center;
 }
 
-.nws-modal-wrapper .modal .wallet-options-wrapper .options-list li .wallet-content .wallet-img-box {
+.nws-modal-wrapper .nws-modal .wallet-options-wrapper .options-list li .wallet-content .wallet-img-box {
   display: flex;
   justify-content: center;
   align-items: center;
@@ -391,33 +392,33 @@
   margin-bottom: 10px;
 }
 
-.nws-modal-wrapper .modal .wallet-options-wrapper .options-list li .wallet-content .wallet-img-box img {
+.nws-modal-wrapper .nws-modal .wallet-options-wrapper .options-list li .wallet-content .wallet-img-box img {
   text-align: center;
   width: 100%;
 }
 
-.nws-modal-wrapper .modal .wallet-options-wrapper .options-list li:hover {
+.nws-modal-wrapper .nws-modal .wallet-options-wrapper .options-list li:hover {
   background-color: var(--wallet-selector-selected-wallet-bg-hover, var(--selected-wallet-bg-hover));
 }
 
-.nws-modal-wrapper .modal .wallet-options-wrapper .options-list li.selected-wallet {
+.nws-modal-wrapper .nws-modal .wallet-options-wrapper .options-list li.selected-wallet {
   background-color: var(--wallet-selector-selected-wallet-bg, var(--selected-wallet-bg));
 }
 
-.nws-modal-wrapper .modal .wallet-options-wrapper .options-list li.deprecated-wallet div {
+.nws-modal-wrapper .nws-modal .wallet-options-wrapper .options-list li.deprecated-wallet div {
   opacity: 50%;
 }
 
-.nws-modal-wrapper .modal .wallet-options-wrapper .options-list li .selected-wallet-text {
+.nws-modal-wrapper .nws-modal .wallet-options-wrapper .options-list li .selected-wallet-text {
   text-align: center;
 }
 
-.nws-modal-wrapper .modal .wallet-options-wrapper .options-list li .selected-wallet-text span {
+.nws-modal-wrapper .nws-modal .wallet-options-wrapper .options-list li .selected-wallet-text span {
   font-size: 14px;
   font-weight: 500;
 }
 
-.nws-modal-wrapper .modal .wallet-options-wrapper .options-list li:hover {
+.nws-modal-wrapper .nws-modal .wallet-options-wrapper .options-list li:hover {
   box-shadow: 0 2px 10px 0 var(--wallet-selector-box-shadow-color, var(--box-shadow-color));
 }
 
@@ -425,34 +426,34 @@
  * Modal Wallet Options Info Section/Wrapper
  */
 
-.nws-modal-wrapper .modal .info {
+.nws-modal-wrapper .nws-modal .info {
   margin-top: 20px;
 }
 
-.nws-modal-wrapper .modal .info span {
+.nws-modal-wrapper .nws-modal .info span {
   font-size: 14px;
   font-weight: 600;
   cursor: pointer;
   transition: all 200ms ease-out;
 }
 
-.nws-modal-wrapper .modal .info .info-description {
+.nws-modal-wrapper .nws-modal .info .info-description {
   max-height: 0;
   transition: all 300ms ease-out;
   overflow: hidden;
 }
 
-.nws-modal-wrapper .modal .info .info-description p {
+.nws-modal-wrapper .nws-modal .info .info-description p {
   font-size: 14px;
   margin-bottom: 0;
 }
 
-.nws-modal-wrapper .modal .info .info-description.show-explanation {
+.nws-modal-wrapper .nws-modal .info .info-description.show-explanation {
   animation: inAnimation 350ms ease-in;
   max-height: 300px;
 }
 
-.nws-modal-wrapper .modal .info .info-description.hide-explanation {
+.nws-modal-wrapper .nws-modal .info .info-description.hide-explanation {
   animation: outAnimation 200ms ease-out;
   animation-fill-mode: forwards;
 }
@@ -495,7 +496,7 @@
  * Modal Wallet Connecting Section/Wrapper
  */
 
-.nws-modal-wrapper .modal .connecting-wrapper .content {
+.nws-modal-wrapper .nws-modal .connecting-wrapper .content {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -543,27 +544,27 @@
 }
 
 @media (max-width: 600px) {
-  .nws-modal-wrapper .modal {
+  .nws-modal-wrapper .nws-modal {
     width: 250px;
   }
 
-  .nws-modal-wrapper .modal .derivation-path-wrapper .derivation-path-list input {
+  .nws-modal-wrapper .nws-modal .derivation-path-wrapper .derivation-path-list input {
     max-width: 140px;
   }
 
-  .nws-modal-wrapper .modal .choose-ledger-account-form-wrapper .form-control {
+  .nws-modal-wrapper .nws-modal .choose-ledger-account-form-wrapper .nws-form-control {
     flex-direction: column;
   }
 
-  .nws-modal-wrapper .modal .choose-ledger-account-form-wrapper .form-control select {
+  .nws-modal-wrapper .nws-modal .choose-ledger-account-form-wrapper .nws-form-control select {
     text-align: center;
   }
 }
 
-.nws-modal-wrapper.dark-theme .modal #near-wallet img,
-.nws-modal-wrapper.dark-theme .modal #math-wallet img,
-.nws-modal-wrapper.dark-theme .modal #ledger img,
-.nws-modal-wrapper.dark-theme .modal .wallet-not-installed-wrapper .math-wallet img {
+.nws-modal-wrapper.dark-theme .nws-modal #near-wallet img,
+.nws-modal-wrapper.dark-theme .nws-modal #math-wallet img,
+.nws-modal-wrapper.dark-theme .nws-modal #ledger img,
+.nws-modal-wrapper.dark-theme .nws-modal .wallet-not-installed-wrapper .math-wallet img {
   filter: invert(1);
 }
 
@@ -572,10 +573,10 @@
 }
 
 @media (prefers-color-scheme: dark) {
-  .nws-modal-wrapper .modal #near-wallet img,
-  .nws-modal-wrapper .modal #math-wallet img,
-  .nws-modal-wrapper .modal #ledger img,
-  .nws-modal-wrapper .modal .wallet-not-installed-wrapper .math-wallet img {
+  .nws-modal-wrapper .nws-modal #near-wallet img,
+  .nws-modal-wrapper .nws-modal #math-wallet img,
+  .nws-modal-wrapper .nws-modal #ledger img,
+  .nws-modal-wrapper .nws-modal .wallet-not-installed-wrapper .math-wallet img {
     filter: invert(1);
   }
 


### PR DESCRIPTION
# Description

This PR addresses the issue when css class names of the `modal-ui` conflict with some class names from the [Bootstrap Framework](https://getbootstrap.com/) this is a continuation of the work started here:  https://github.com/near/wallet-selector/pull/416

This PR renames these css classes:

- `.modal`  to  `.nws-modal`
- `.modal-header`  to  `.nws-modal-header`
- `.modal-body` to `.nws-modal-body`
- `.form-control` to `.nws-form-control`

Closes #415 


# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [x] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
