### PR TITLE
fix: Nightly Connect - proper session persisting

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ const selector = await setupWalletSelector({
       },
     }),
     setupNightlyConnect({
-      url: "wss://ncproxy.nightly.app/app",
+      url: "wss://relay.nightly.app/app",
       appMetadata: {
         additionalInfo: "",
         application: "NEAR Wallet Selector",

--- a/examples/angular/src/app/app.component.ts
+++ b/examples/angular/src/app/app.component.ts
@@ -59,7 +59,7 @@ export class AppComponent implements OnInit {
           },
         }),
         setupNightlyConnect({
-          url: "wss://ncproxy.nightly.app/app",
+          url: "wss://relay.nightly.app/app",
           appMetadata: {
             additionalInfo: "",
             application: "NEAR Wallet Selector",

--- a/examples/react/contexts/WalletSelectorContext.tsx
+++ b/examples/react/contexts/WalletSelectorContext.tsx
@@ -57,7 +57,7 @@ export const WalletSelectorContextProvider: React.FC = ({ children }) => {
           },
         }),
         setupNightlyConnect({
-          url: "wss://ncproxy.nightly.app/app",
+          url: "wss://relay.nightly.app/app",
           appMetadata: {
             additionalInfo: "",
             application: "NEAR Wallet Selector",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@ledgerhq/hw-transport": "6.27.1",
     "@ledgerhq/hw-transport-webhid": "6.27.1",
     "@meteorwallet/sdk": "0.3.0",
-    "@nightlylabs/connect-near": "0.0.9",
+    "@nightlylabs/connect-near": "0.0.10",
     "@walletconnect/qrcode-modal": "2.0.0-alpha.20",
     "@walletconnect/sign-client": "^2.0.0-beta.102",
     "better-sqlite3": "^7.6.2",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@ledgerhq/hw-transport": "6.27.1",
     "@ledgerhq/hw-transport-webhid": "6.27.1",
     "@meteorwallet/sdk": "0.3.0",
-    "@nightlylabs/connect-near": "0.0.8",
+    "@nightlylabs/connect-near": "0.0.9",
     "@walletconnect/qrcode-modal": "2.0.0-alpha.20",
     "@walletconnect/sign-client": "^2.0.0-beta.102",
     "better-sqlite3": "^7.6.2",

--- a/packages/nightly-connect/README.md
+++ b/packages/nightly-connect/README.md
@@ -28,7 +28,7 @@ import { setupWalletSelector } from "@near-wallet-selector/core";
 import { setupNightlyConnect } from "@near-wallet-selector/nightly-connect";
 
 const nightlyConnect = setupNightlyConnect({
-  url: "wss://ncproxy.nightly.app/app",
+  url: "wss://relay.nightly.app/app",
   appMetadata: {
     additionalInfo: "",
     application: "NEAR Wallet Selector",

--- a/packages/nightly-connect/src/lib/nightly-connect.ts
+++ b/packages/nightly-connect/src/lib/nightly-connect.ts
@@ -100,6 +100,9 @@ const NightlyConnect: WalletBehaviourFactory<
   };
 
   const signOut = async () => {
+    clearPersistedSessionId();
+    clearPersistedSessionPublicKey();
+    clearPersistedSessionAccountId();
     _state.client?.ws.close();
   };
 
@@ -159,9 +162,6 @@ const NightlyConnect: WalletBehaviourFactory<
             client.ws.onclose = () => {
               _state.client = null;
               _state.accounts = [];
-              clearPersistedSessionId();
-              clearPersistedSessionPublicKey();
-              clearPersistedSessionAccountId();
               emitter.emit("signedOut", null);
             };
             _state.client = client;

--- a/scripts/nightly-connect-client.ts
+++ b/scripts/nightly-connect-client.ts
@@ -7,8 +7,8 @@ import type { SignTransactionsRequest } from '@nightlylabs/connect-near'
 import { v4 } from 'uuid'
 
 // To run test you need to have running instance of the server
-const CLIENT_ADDRESS = 'wss://ncproxy.nightly.app/client'
-const SESSION_ID = 'nightlyconnect:03e03af0-8800-482e-8266-d22cc7d0d120?network=NEAR'.split(':')[1].split("?")[0]
+const CLIENT_ADDRESS = 'wss://relay.nightly.app/client'
+const SESSION_ID = 'nightlyconnect:1048e538-7702-4457-9f80-e53c7cc90523?network=NEAR'.split(':')[1].split("?")[0]
 
 const alice_ed25519 = new KeyPairEd25519(
   '3zR44QTFXYHPErMnFYZYizFRFmyYajpfH9jLJnm4BQ67ndoQ5PpKsJDcG1BHBhKrat92ospVNfs4SRQ6Z8uXUGiM'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2371,10 +2371,10 @@
   resolved "https://registry.yarnpkg.com/@ngtools/webpack/-/webpack-14.0.6.tgz#a48185b584a528a59ce82217830673268ceee8c2"
   integrity sha512-mSmLqzRKxQgGiOhvJ8guvRLjXoTL17cVSWlL/Cz+Q3xc1bXa7537ZXBTQTEuZVU2ytdkniKc8l1HqXIx0pFNVQ==
 
-"@nightlylabs/connect-near@0.0.9":
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/@nightlylabs/connect-near/-/connect-near-0.0.9.tgz#f469af6a4be72c58e2a791e555eca703f34a89ec"
-  integrity sha512-uFi100leO2v8ejehmo+Jsw957wLNewnqbwFh9MTD7OcfIXW7/fz7/AczacXQzqA6nGAsUn9v2xn5CM1Ufc65kA==
+"@nightlylabs/connect-near@0.0.10":
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/@nightlylabs/connect-near/-/connect-near-0.0.10.tgz#16d163035167c9dd3f865cf63798fab047ab5208"
+  integrity sha512-oZ6hYHjXLvzC1IB/GTXOdUHnfYwOXVBHi2BV24lHmdZ3J/ZJCEFAja/sEnb1gAKZfz69i1/OihtB5BDwDqrOcQ==
   dependencies:
     "@nightlylabs/qr-code" "1.0.21"
     isomorphic-localstorage "0.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2371,22 +2371,22 @@
   resolved "https://registry.yarnpkg.com/@ngtools/webpack/-/webpack-14.0.6.tgz#a48185b584a528a59ce82217830673268ceee8c2"
   integrity sha512-mSmLqzRKxQgGiOhvJ8guvRLjXoTL17cVSWlL/Cz+Q3xc1bXa7537ZXBTQTEuZVU2ytdkniKc8l1HqXIx0pFNVQ==
 
-"@nightlylabs/connect-near@0.0.8":
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/@nightlylabs/connect-near/-/connect-near-0.0.8.tgz#55ed2cc070ee19e34812796f90e139f4291fd728"
-  integrity sha512-1tOIxRgNHcFdPvxPbyzGWCIFXIVx6Xsq2UDdpvGAaPrsGXTBrc/MraYTygtRRpoTUn295/LdyLGmhHZ4gAI1Uw==
+"@nightlylabs/connect-near@0.0.9":
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/@nightlylabs/connect-near/-/connect-near-0.0.9.tgz#f469af6a4be72c58e2a791e555eca703f34a89ec"
+  integrity sha512-uFi100leO2v8ejehmo+Jsw957wLNewnqbwFh9MTD7OcfIXW7/fz7/AczacXQzqA6nGAsUn9v2xn5CM1Ufc65kA==
   dependencies:
-    "@nightlylabs/qr-code" "1.0.20"
+    "@nightlylabs/qr-code" "1.0.21"
     isomorphic-localstorage "0.0.4"
     isomorphic-ws "^4.0.1"
     near-api-js "^0.45.1"
     uuid "^8.3.2"
     ws "^8.8.0"
 
-"@nightlylabs/qr-code@1.0.20":
-  version "1.0.20"
-  resolved "https://registry.yarnpkg.com/@nightlylabs/qr-code/-/qr-code-1.0.20.tgz#627d052117475da6859ace51cd101f4cbce4bf5f"
-  integrity sha512-odaOJBXXugZDPD9aId3SaXN0xXCszWafoGGbVId6FnaODxP34yTCrYkkz6alyKr9RDOpUiCg8hhAFpS81ob1Pw==
+"@nightlylabs/qr-code@1.0.21":
+  version "1.0.21"
+  resolved "https://registry.yarnpkg.com/@nightlylabs/qr-code/-/qr-code-1.0.21.tgz#c35db8befeac81e4c3afa57688c8c65eb1ada150"
+  integrity sha512-W4gOXG8SDQMYX+MLBUWFSZbiTjApY8CW+z0Lu8MZUqW5IwtyGHjZ2GgkwLo/3A9peIWiXrF/2a93E7cCCouzgw==
   dependencies:
     qrcode-generator "^1.4.3"
 


### PR DESCRIPTION
# Description

Changes:
- addition of flow when previous session is persisted by Nightly Connect client (previous session will be remembered when app will be closed and opened one again)
- persisting public key and account id for Nightly Connect session until disconnect

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [x] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
