### PR TITLE
feat: [Meteor] Support for verifyOwner method

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@jscutlery/semver": "^2.25.2",
     "@ledgerhq/hw-transport": "6.27.1",
     "@ledgerhq/hw-transport-webhid": "6.27.1",
-    "@meteorwallet/sdk": "0.3.0",
+    "@meteorwallet/sdk": "0.4.0",
     "@nightlylabs/connect-near": "0.0.10",
     "@walletconnect/qrcode-modal": "2.0.0-alpha.20",
     "@walletconnect/sign-client": "^2.0.0-beta.102",

--- a/packages/meteor-wallet/src/lib/meteor-wallet.ts
+++ b/packages/meteor-wallet/src/lib/meteor-wallet.ts
@@ -49,7 +49,7 @@ const setupWalletState = async (
 const createMeteorWalletInjected: WalletBehaviourFactory<
   InjectedWallet,
   { params: MeteorWalletParams_Injected }
-> = async ({ metadata, options, logger, store, params }) => {
+> = async ({ options, logger, store, params }) => {
   const _state = await setupWalletState(params, options.network);
 
   const cleanup = () => {
@@ -159,7 +159,15 @@ const createMeteorWalletInjected: WalletBehaviourFactory<
     async verifyOwner({ message }) {
       logger.log("MeteorWallet:verifyOwner", { message });
 
-      throw new Error(`Method not supported by ${metadata.name}`);
+      const response = await _state.wallet.verifyOwner({
+        message,
+      });
+
+      if (response.success) {
+        return response.payload;
+      } else {
+        throw new Error(`Couldn't verify owner: ${response.message}`);
+      }
     },
 
     async signAndSendTransaction({ signerId, receiverId, actions }) {


### PR DESCRIPTION
# Description

Added support to Meteor Wallet for the `verifyOwner()` method. As recently added in #391 

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [x] FEATURE - a PR of this type introduces a new feature.
<!-- /CHECKLIST_TYPE -->
