### PR TITLE
Change Bundler To Rollup Support (esm and cjs)

### DIFF
--- a/examples/angular/src/styles.scss
+++ b/examples/angular/src/styles.scss
@@ -4,7 +4,7 @@
   box-sizing: border-box;
 }
 
-@import "../../../dist/packages/modal-ui-js/packages/modal-ui-js/src/lib/styles.css";
+@import "../../../dist/packages/modal-ui-js/styles.css";
 
 html {
   --bg: #fff;

--- a/packages/modal-ui-js/project.json
+++ b/packages/modal-ui-js/project.json
@@ -4,14 +4,16 @@
   "projectType": "library",
   "targets": {
     "build": {
-      "executor": "@nrwl/js:tsc",
-      "outputs": [
-        "{options.outputPath}"
-      ],
+      "executor": "@nrwl/web:rollup",
+      "outputs": ["{options.outputPath}"],
       "options": {
         "outputPath": "dist/packages/modal-ui-js",
-        "main": "packages/modal-ui-js/src/index.ts",
         "tsConfig": "packages/modal-ui-js/tsconfig.lib.json",
+        "project": "packages/modal-ui-js/package.json",
+        "entryFile": "packages/modal-ui-js/src/index.ts",
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "compiler": "babel",
+        "format": ["esm", "cjs"],
         "assets": [
           {
             "glob": "packages/modal-ui-js/README.md",

--- a/packages/modal-ui-js/tsconfig.json
+++ b/packages/modal-ui-js/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "commonjs",
+    "allowJs": true,
+    "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,


### PR DESCRIPTION
# Description

- Changed bundler to rollup to support ESM and CJS for `modal-ui-js` .

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [ ] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [x] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
