### PR TITLE
fix: Set `near-api-js` as peerDependency for `Coin98 Wallet`

### DIFF
--- a/packages/coin98-wallet/package.json
+++ b/packages/coin98-wallet/package.json
@@ -1,4 +1,7 @@
 {
   "name": "@near-wallet-selector/coin98-wallet",
-  "version": "0.0.1"
+  "version": "7.0.3",
+  "peerDependencies": {
+    "near-api-js": "^0.44.2"
+  }
 }


### PR DESCRIPTION
# Description

The reason we need to set `near-api-js` as a **peerDependency** for `Coin98 Wallet` is that there can be issues and version **mismatches** between the version of `near-api-js` in Wallet Selector and in dApps which causes some weird behavior where transactions might fail due to serialization issues.

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [x] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
