### PR TITLE
fix: [Meteor] allow "signerId" to be optional in transactions

### DIFF
--- a/packages/meteor-wallet/src/lib/meteor-wallet.ts
+++ b/packages/meteor-wallet/src/lib/meteor-wallet.ts
@@ -74,14 +74,6 @@ const createMeteorWalletInjected: WalletBehaviourFactory<
 
     const localKey = await signer.getPublicKey(account.accountId, networkId);
 
-    for (const trx of transactions) {
-      if (trx.signerId !== account.accountId) {
-        throw new Error(
-          `Transaction had a signerId which didn't match the currently logged in account`
-        );
-      }
-    }
-
     return Promise.all(
       transactions.map(async (transaction, index) => {
         const actions = transaction.actions.map((action) =>


### PR DESCRIPTION
# Description

This removes the code in Meteor Wallet's implementation which threw an error when `signerId` wasn't present inside transactions. This matches other wallet implementations- the old code was causing issues with some integrations.

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [x] FIX - a PR of this type patches a bug.
<!-- /CHECKLIST_TYPE -->
