### PR TITLE
fix: Avoid deleting LAK on signOut from local keystore

### DIFF
--- a/packages/here-wallet/src/lib/here-wallet.ts
+++ b/packages/here-wallet/src/lib/here-wallet.ts
@@ -24,7 +24,6 @@ export const initHereWallet: WalletBehaviourFactory<
   { configuration: HereConfiguration }
 > = async ({ store, logger, options, configuration }) => {
   const _state = await setupWalletState(configuration, options.network);
-  const cleanup = () => _state.keyStore.clear();
 
   const getAccounts = () => {
     const accountId: string | null = _state.wallet.getAccountId();
@@ -61,8 +60,6 @@ export const initHereWallet: WalletBehaviourFactory<
       if (_state.wallet.isSignedIn()) {
         _state.wallet.signOut();
       }
-
-      cleanup();
     },
 
     async getAccounts() {

--- a/packages/here-wallet/src/lib/utils.ts
+++ b/packages/here-wallet/src/lib/utils.ts
@@ -44,11 +44,6 @@ const setupWalletState = async (
 
   const wallet = new WalletConnection(near, "here_app");
 
-  // Cleanup up any pending keys (cancelled logins).
-  if (!wallet.isSignedIn()) {
-    await keyStore.clear();
-  }
-
   return { wallet, keyStore };
 };
 

--- a/packages/meteor-wallet/src/lib/meteor-wallet.ts
+++ b/packages/meteor-wallet/src/lib/meteor-wallet.ts
@@ -52,10 +52,6 @@ const createMeteorWalletInjected: WalletBehaviourFactory<
 > = async ({ options, logger, store, params }) => {
   const _state = await setupWalletState(params, options.network);
 
-  const cleanup = () => {
-    _state.keyStore.clear();
-  };
-
   const getAccounts = () => {
     const accountId = _state.wallet.getAccountId();
 
@@ -132,8 +128,6 @@ const createMeteorWalletInjected: WalletBehaviourFactory<
       if (_state.wallet.isSignedIn()) {
         await _state.wallet.signOut();
       }
-
-      cleanup();
     },
 
     async isSignedIn() {

--- a/packages/my-near-wallet/src/lib/my-near-wallet.ts
+++ b/packages/my-near-wallet/src/lib/my-near-wallet.ts
@@ -61,11 +61,6 @@ const setupWalletState = async (
 
   const wallet = new WalletConnection(near, "near_app");
 
-  // Cleanup up any pending keys (cancelled logins).
-  if (!wallet.isSignedIn()) {
-    await keyStore.clear();
-  }
-
   return {
     wallet,
     keyStore,
@@ -77,10 +72,6 @@ const MyNearWallet: WalletBehaviourFactory<
   { params: MyNearWalletExtraOptions }
 > = async ({ metadata, options, store, params, logger }) => {
   const _state = await setupWalletState(params, options.network);
-
-  const cleanup = () => {
-    _state.keyStore.clear();
-  };
 
   const getAccounts = () => {
     const accountId: string | null = _state.wallet.getAccountId();
@@ -148,8 +139,6 @@ const MyNearWallet: WalletBehaviourFactory<
       if (_state.wallet.isSignedIn()) {
         _state.wallet.signOut();
       }
-
-      cleanup();
     },
 
     async getAccounts() {

--- a/packages/wallet-connect/src/lib/wallet-connect.ts
+++ b/packages/wallet-connect/src/lib/wallet-connect.ts
@@ -135,8 +135,6 @@ const WalletConnect: WalletBehaviourFactory<
 
     _state.subscriptions = [];
     _state.session = null;
-
-    await _state.keystore.clear();
   };
 
   const validateAccessKey = (
@@ -413,12 +411,6 @@ const WalletConnect: WalletBehaviourFactory<
         },
       },
     });
-
-    for (let i = 0; i < limitedAccessAccounts.length; i += 1) {
-      const { accountId } = limitedAccessAccounts[i];
-
-      await _state.keystore.removeKey(options.network.networkId, accountId);
-    }
   };
 
   const signOut = async () => {


### PR DESCRIPTION
# Description

- This PR removes the `cleanup()` method or the calls to `keystore.clear()` method, now LAK is kept in the local storage after signOut too.

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [x] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
