### PR TITLE
fix: Fixed verifyOwner function for browser wallets

### DIFF
--- a/packages/core/docs/api/wallet.md
+++ b/packages/core/docs/api/wallet.md
@@ -190,9 +190,7 @@ Returns one or more accounts when signed in. This method can be useful for walle
 **Parameters**
 - `params` (`object`)
   - `message` (`string`): The message requested sign. Defaults to `verify owner` string.
-  - `callbackUrl` (`string?`): Applicable to browser wallets (e.g. MyNearWallet). This is the callback url once the signing is approved. Defaults to `window.location.href`.
-  - `meta` (`string?`): Applicable to browser wallets (e.g. MyNearWallet) extra data that will be passed to the callback url once the signing is approved.
-
+  
 **Returns**
 - `Promise<void | VerifiedOwner>`: Browser wallets won't return the signing outcome as they may need to redirect for signing. For MyNearWallet the outcome is passed to the callback url.
 

--- a/packages/core/src/lib/wallet/wallet.types.ts
+++ b/packages/core/src/lib/wallet/wallet.types.ts
@@ -30,8 +30,6 @@ export interface SignInParams {
 
 export interface VerifyOwnerParams {
   message: string;
-  callbackUrl?: string;
-  meta?: string;
 }
 
 export interface VerifiedOwner {

--- a/packages/my-near-wallet/src/lib/my-near-wallet.ts
+++ b/packages/my-near-wallet/src/lib/my-near-wallet.ts
@@ -72,7 +72,7 @@ const setupWalletState = async (
 const MyNearWallet: WalletBehaviourFactory<
   BrowserWallet,
   { params: MyNearWalletExtraOptions }
-> = async ({ metadata, options, store, params, logger }) => {
+> = async ({ options, store, params, logger, provider }) => {
   const _state = await setupWalletState(params, options.network);
 
   const getAccounts = () => {
@@ -89,7 +89,7 @@ const MyNearWallet: WalletBehaviourFactory<
     transactions: Array<Optional<Transaction, "signerId">>
   ) => {
     const account = _state.wallet.account();
-    const { networkId, signer, provider } = account.connection;
+    const { networkId, signer } = account.connection;
 
     const localKey = await signer.getPublicKey(account.accountId, networkId);
 
@@ -152,7 +152,7 @@ const MyNearWallet: WalletBehaviourFactory<
       return getAccounts();
     },
 
-    async verifyOwner({ message, callbackUrl, meta }) {
+    async verifyOwner({ message }) {
       logger.log("verifyOwner", { message });
 
       const account = _state.wallet.account();
@@ -160,23 +160,35 @@ const MyNearWallet: WalletBehaviourFactory<
       if (!account) {
         throw new Error("Wallet not signed in");
       }
-      const locationUrl =
-        typeof window !== "undefined" ? window.location.href : "";
 
-      const url = callbackUrl || locationUrl;
+      const networkId = options.network.networkId;
+      const accountId = account.accountId;
+      const pubKey = await account.connection.signer.getPublicKey(
+        accountId,
+        networkId
+      );
+      const block = await provider.block({ finality: "final" });
 
-      if (!url) {
-        throw new Error(`The callbackUrl is missing for ${metadata.name}`);
-      }
+      const data = {
+        accountId,
+        message,
+        blockId: block.header.hash,
+        publicKey: Buffer.from(pubKey.data).toString("base64"),
+        keyType: pubKey.keyType,
+      };
+      const encoded = JSON.stringify(data);
 
-      const encodedUrl = encodeURIComponent(url);
-      const extraMeta = meta ? `&meta=${meta}` : "";
-
-      window.location.replace(
-        `${params.walletUrl}/verify-owner?message=${message}&callbackUrl=${encodedUrl}${extraMeta}`
+      const signed = await account.connection.signer.signMessage(
+        new Uint8Array(Buffer.from(encoded)),
+        accountId,
+        networkId
       );
 
-      return;
+      return {
+        ...data,
+        signature: Buffer.from(signed.signature).toString("base64"),
+        keyType: signed.publicKey.keyType,
+      };
     },
 
     async signAndSendTransaction({


### PR DESCRIPTION
# Description
- `verifyOwner` for browser wallets now doesn't redirect to sign. Instead uses the local function call access key to sign and prove ownership.

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [x] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
