### PR TITLE
chore: Bump near-api-js version to v1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "crypto-browserify": "^3.12.0",
     "ethers": "^5.7.2",
     "is-mobile": "^3.1.1",
-    "near-api-js": "^0.44.2",
+    "near-api-js": "^1.1.0",
     "near-seed-phrase": "^0.2.0",
     "next": "12.2.3",
     "ngx-deploy-npm": "^4.3.1",

--- a/packages/coin98-wallet/package.json
+++ b/packages/coin98-wallet/package.json
@@ -2,6 +2,6 @@
   "name": "@near-wallet-selector/coin98-wallet",
   "version": "7.2.0",
   "peerDependencies": {
-    "near-api-js": "^0.44.2"
+    "near-api-js": "^0.44.2 || ^1.0.0"
   }
 }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -8,10 +8,10 @@ The easiest way to use this package is to install it from the NPM registry, this
 
 ```bash
 # Using Yarn
-yarn add near-api-js@^0.44.2
+yarn add near-api-js
 
 # Using NPM.
-npm install near-api-js@^0.44.2
+npm install near-api-js
 ```
 
 ```bash

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,6 @@
   "name": "@near-wallet-selector/core",
   "version": "7.2.0",
   "peerDependencies": {
-    "near-api-js": "^0.44.2"
+    "near-api-js": "^0.44.2 || ^1.0.0"
   }
 }

--- a/packages/default-wallets/README.md
+++ b/packages/default-wallets/README.md
@@ -14,10 +14,10 @@ The easiest way to use this package is to install it from the NPM registry, this
 
 ```bash
 # Using Yarn
-yarn add near-api-js@^0.44.2
+yarn add near-api-js
 
 # Using NPM.
-npm install near-api-js@^0.44.2
+npm install near-api-js
 ```
 ```bash
 # Using Yarn

--- a/packages/here-wallet/README.md
+++ b/packages/here-wallet/README.md
@@ -8,10 +8,10 @@ The easiest way to use this package is to install it from the NPM registry, this
 
 ```bash
 # Using Yarn
-yarn add near-api-js@^0.44.2
+yarn add near-api-js
 
 # Using NPM.
-npm install near-api-js@^0.44.2
+npm install near-api-js
 ```
 ```bash
 # Using Yarn

--- a/packages/here-wallet/package.json
+++ b/packages/here-wallet/package.json
@@ -2,6 +2,6 @@
   "name": "@near-wallet-selector/here-wallet",
   "version": "7.2.0",
   "peerDependencies": {
-    "near-api-js": "^0.44.2"
+    "near-api-js": "^0.44.2 || ^1.0.0"
   }
 }

--- a/packages/ledger/README.md
+++ b/packages/ledger/README.md
@@ -8,10 +8,10 @@ The easiest way to use this package is to install it from the NPM registry, this
 
 ```bash
 # Using Yarn
-yarn add near-api-js@^0.44.2
+yarn add near-api-js
 
 # Using NPM.
-npm install near-api-js@^0.44.2
+npm install near-api-js
 ```
 ```bash
 # Using Yarn

--- a/packages/ledger/package.json
+++ b/packages/ledger/package.json
@@ -2,6 +2,6 @@
   "name": "@near-wallet-selector/ledger",
   "version": "7.2.0",
   "peerDependencies": {
-    "near-api-js": "^0.44.2"
+    "near-api-js": "^0.44.2 || ^1.0.0"
   }
 }

--- a/packages/ledger/src/lib/ledger.spec.ts
+++ b/packages/ledger/src/lib/ledger.spec.ts
@@ -5,6 +5,7 @@ import { mockWallet } from "../../../core/src/lib/testUtils";
 import type { HardwareWallet, Transaction } from "../../../core/src/lib/wallet";
 import type { ProviderService } from "../../../core/src/lib/services";
 import type { LedgerClient } from "./ledger-client";
+import { BN } from "bn.js";
 
 const createLedgerWallet = async () => {
   const publicKey = "GF7tLvSzcxX4EtrMFtGvGTb2yUj2DhL8hWzc97BwUkyC";
@@ -44,7 +45,7 @@ const createLedgerWallet = async () => {
   });
 
   provider.viewAccessKey.mockResolvedValue({
-    nonce: 0,
+    nonce: new BN(0),
     permission: "FullAccess",
     block_height: 0,
     block_hash: "block_hash",

--- a/packages/math-wallet/README.md
+++ b/packages/math-wallet/README.md
@@ -8,10 +8,10 @@ The easiest way to use this package is to install it from the NPM registry, this
 
 ```bash
 # Using Yarn
-yarn add near-api-js@^0.44.2
+yarn add near-api-js
 
 # Using NPM.
-npm install near-api-js@^0.44.2
+npm install near-api-js
 ```
 
 ```bash

--- a/packages/math-wallet/package.json
+++ b/packages/math-wallet/package.json
@@ -2,6 +2,6 @@
   "name": "@near-wallet-selector/math-wallet",
   "version": "7.2.0",
   "peerDependencies": {
-    "near-api-js": "^0.44.2"
+    "near-api-js": "^0.44.2 || ^1.0.0"
   }
 }

--- a/packages/meteor-wallet/README.md
+++ b/packages/meteor-wallet/README.md
@@ -8,10 +8,10 @@ The easiest way to use this package is to install it from the NPM registry, this
 
 ```bash
 # Using Yarn
-yarn add near-api-js@^0.44.2
+yarn add near-api-js
 
 # Using NPM.
-npm install near-api-js@^0.44.2
+npm install near-api-js
 ```
 ```bash
 # Using Yarn

--- a/packages/meteor-wallet/package.json
+++ b/packages/meteor-wallet/package.json
@@ -2,6 +2,6 @@
   "name": "@near-wallet-selector/meteor-wallet",
   "version": "7.2.0",
   "peerDependencies": {
-    "near-api-js": "^0.44.2"
+    "near-api-js": "^0.44.2 || ^1.0.0"
   }
 }

--- a/packages/my-near-wallet/README.md
+++ b/packages/my-near-wallet/README.md
@@ -8,10 +8,10 @@ This is the [My NEAR Wallet](https://mynearwallet.com/) package for NEAR Wallet 
 The easiest way to use this package is to install it from the NPM registry, this package requires `near-api-js` v0.44.2 or above:
 ```bash
 # Using Yarn
-yarn add near-api-js@^0.44.2
+yarn add near-api-js
 
 # Using NPM.
-npm install near-api-js@^0.44.2
+npm install near-api-js
 ```
 ```bash
 # Using Yarn

--- a/packages/my-near-wallet/package.json
+++ b/packages/my-near-wallet/package.json
@@ -2,6 +2,6 @@
   "name": "@near-wallet-selector/my-near-wallet",
   "version": "7.2.0",
   "peerDependencies": {
-    "near-api-js": "^0.44.2"
+    "near-api-js": "^0.44.2 || ^1.0.0"
   }
 }

--- a/packages/nearfi/README.md
+++ b/packages/nearfi/README.md
@@ -8,10 +8,10 @@ The easiest way to use this package is to install it from the NPM registry, this
 
 ```bash
 # Using Yarn
-yarn add near-api-js@^0.44.2
+yarn add near-api-js
 
 # Using NPM.
-npm install near-api-js@^0.44.2
+npm install near-api-js
 ```
 
 ```bash

--- a/packages/nearfi/package.json
+++ b/packages/nearfi/package.json
@@ -2,6 +2,6 @@
   "name": "@near-wallet-selector/nearfi",
   "version": "7.2.0",
   "peerDependencies": {
-    "near-api-js": "^0.44.2"
+    "near-api-js": "^0.44.2 || ^1.0.0"
   }
 }

--- a/packages/neth/README.md
+++ b/packages/neth/README.md
@@ -8,10 +8,10 @@ The easiest way to use this package is to install it from the NPM registry, this
 
 ```bash
 # Using Yarn
-yarn add near-api-js@^0.44.2
+yarn add near-api-js
 
 # Using NPM.
-npm install near-api-js@^0.44.2
+npm install near-api-js
 ```
 ```bash
 # Using Yarn

--- a/packages/neth/package.json
+++ b/packages/neth/package.json
@@ -4,6 +4,6 @@
   "description": "control NEAR accounts with ETH accounts",
   "author": "mattlockyer",
   "peerDependencies": {
-    "near-api-js": "^0.44.2"
+    "near-api-js": "^0.44.2 || ^1.0.0"
   }
 }

--- a/packages/nightly-connect/README.md
+++ b/packages/nightly-connect/README.md
@@ -8,10 +8,10 @@ The easiest way to use this package is to install it from the NPM registry, this
 
 ```bash
 # Using Yarn
-yarn add near-api-js@^0.44.2
+yarn add near-api-js
 
 # Using NPM.
-npm install near-api-js@^0.44.2
+npm install near-api-js
 ```
 
 ```bash

--- a/packages/nightly-connect/package.json
+++ b/packages/nightly-connect/package.json
@@ -2,6 +2,6 @@
   "name": "@near-wallet-selector/nightly-connect",
   "version": "7.2.0",
   "peerDependencies": {
-    "near-api-js": "^0.44.2"
+    "near-api-js": "^0.44.2 || ^1.0.0"
   }
 }

--- a/packages/nightly-connect/src/lib/nightly-connect.ts
+++ b/packages/nightly-connect/src/lib/nightly-connect.ts
@@ -85,6 +85,7 @@ const NightlyConnect: WalletBehaviourFactory<
 
       try {
         const tx = nearTransactions.Transaction.decode(Buffer.from(message));
+        // @ts-ignore
         const signedTx = await _state.client!.signTransaction(tx);
 
         return {

--- a/packages/nightly/README.md
+++ b/packages/nightly/README.md
@@ -9,10 +9,10 @@ The easiest way to use this package is to install it from the NPM registry, this
 
 ```bash
 # Using Yarn
-yarn add near-api-js@^0.44.2
+yarn add near-api-js
 
 # Using NPM.
-npm install near-api-js@^0.44.2
+npm install near-api-js
 ```
 
 ```bash

--- a/packages/nightly/package.json
+++ b/packages/nightly/package.json
@@ -2,6 +2,6 @@
   "name": "@near-wallet-selector/nightly",
   "version": "7.2.0",
   "peerDependencies": {
-    "near-api-js": "^0.44.2"
+    "near-api-js": "^0.44.2 || ^1.0.0"
   }
 }

--- a/packages/opto-wallet/README.md
+++ b/packages/opto-wallet/README.md
@@ -8,10 +8,10 @@ The easiest way to use this package is to install it from the NPM registry, this
 
 ```bash
 # Using Yarn
-yarn add near-api-js@^0.44.2
+yarn add near-api-js
 
 # Using NPM.
-npm install near-api-js@^0.44.2
+npm install near-api-js
 ```
 ```bash
 # Using Yarn

--- a/packages/opto-wallet/package.json
+++ b/packages/opto-wallet/package.json
@@ -2,6 +2,6 @@
   "name": "@near-wallet-selector/opto-wallet",
   "version": "7.2.0",
   "peerDependencies": {
-    "near-api-js": "^0.44.2"
+    "near-api-js": "^0.44.2 || ^1.0.0"
   }
 }

--- a/packages/sender/README.md
+++ b/packages/sender/README.md
@@ -8,10 +8,10 @@ The easiest way to use this package is to install it from the NPM registry, this
 
 ```bash
 # Using Yarn
-yarn add near-api-js@^0.44.2
+yarn add near-api-js
 
 # Using NPM.
-npm install near-api-js@^0.44.2
+npm install near-api-js
 ```
 ```bash
 # Using Yarn

--- a/packages/sender/package.json
+++ b/packages/sender/package.json
@@ -2,6 +2,6 @@
   "name": "@near-wallet-selector/sender",
   "version": "7.2.0",
   "peerDependencies": {
-    "near-api-js": "^0.44.2"
+    "near-api-js": "^0.44.2 || ^1.0.0"
   }
 }

--- a/packages/wallet-connect/README.md
+++ b/packages/wallet-connect/README.md
@@ -8,10 +8,10 @@ The easiest way to use this package is to install it from the NPM registry, this
 
 ```bash
 # Using Yarn
-yarn add near-api-js@^0.44.2
+yarn add near-api-js
 
 # Using NPM.
-npm install near-api-js@^0.44.2
+npm install near-api-js
 ```
 ```bash
 # Using Yarn

--- a/packages/wallet-connect/package.json
+++ b/packages/wallet-connect/package.json
@@ -2,6 +2,6 @@
   "name": "@near-wallet-selector/wallet-connect",
   "version": "7.2.0",
   "peerDependencies": {
-    "near-api-js": "^0.44.2"
+    "near-api-js": "^0.44.2 || ^1.0.0"
   }
 }

--- a/packages/wallet-connect/src/lib/wallet-connect.ts
+++ b/packages/wallet-connect/src/lib/wallet-connect.ts
@@ -5,7 +5,7 @@ import {
   transactions as nearTransactions,
   utils,
 } from "near-api-js";
-import type { AccessKeyView } from "near-api-js/lib/providers/provider";
+import type { AccessKeyViewRaw } from "near-api-js/lib/providers/provider";
 import type { SignClientTypes, SessionTypes } from "@walletconnect/types";
 import type {
   WalletModuleFactory,
@@ -138,7 +138,7 @@ const WalletConnect: WalletBehaviourFactory<
 
   const validateAccessKey = (
     transaction: Transaction,
-    accessKey: AccessKeyView
+    accessKey: AccessKeyViewRaw
   ) => {
     if (accessKey.permission === "FullAccess") {
       return accessKey;
@@ -183,7 +183,7 @@ const WalletConnect: WalletBehaviourFactory<
         throw new Error("No public key found");
       }
 
-      const accessKey = await provider.query<AccessKeyView>({
+      const accessKey = await provider.query<AccessKeyViewRaw>({
         request_type: "view_access_key",
         finality: "final",
         account_id: transaction.signerId,
@@ -248,7 +248,7 @@ const WalletConnect: WalletBehaviourFactory<
 
     const [block, accessKey] = await Promise.all([
       provider.block({ finality: "final" }),
-      provider.query<AccessKeyView>({
+      provider.query<AccessKeyViewRaw>({
         request_type: "view_access_key",
         finality: "final",
         account_id: transaction.signerId,
@@ -299,7 +299,7 @@ const WalletConnect: WalletBehaviourFactory<
         throw new Error("Invalid signer id");
       }
 
-      const accessKey = await provider.query<AccessKeyView>({
+      const accessKey = await provider.query<AccessKeyViewRaw>({
         request_type: "view_access_key",
         finality: "final",
         account_id: transaction.signerId,

--- a/packages/wallet-utils/README.md
+++ b/packages/wallet-utils/README.md
@@ -8,10 +8,10 @@ The easiest way to use this package is to install it from the NPM registry, this
 
 ```bash
 # Using Yarn
-yarn add near-api-js@^0.44.2
+yarn add near-api-js
 
 # Using NPM.
-npm install near-api-js@^0.44.2
+npm install near-api-js
 ```
 
 ```bash

--- a/packages/wallet-utils/package.json
+++ b/packages/wallet-utils/package.json
@@ -2,6 +2,6 @@
   "name": "@near-wallet-selector/wallet-utils",
   "version": "7.2.0",
   "peerDependencies": {
-    "near-api-js": "^0.44.2"
+    "near-api-js": "^0.44.2 || ^1.0.0"
   }
 }

--- a/packages/wallet-utils/src/lib/sign-transactions.ts
+++ b/packages/wallet-utils/src/lib/sign-transactions.ts
@@ -5,7 +5,7 @@ import {
   providers,
 } from "near-api-js";
 import type { Network, Transaction } from "@near-wallet-selector/core";
-import type { AccessKeyView } from "near-api-js/lib/providers/provider";
+import type { AccessKeyViewRaw } from "near-api-js/lib/providers/provider";
 import { createAction } from "./create-action";
 
 export const signTransactions = async (
@@ -27,7 +27,7 @@ export const signTransactions = async (
 
     const [block, accessKey] = await Promise.all([
       provider.block({ finality: "final" }),
-      provider.query<AccessKeyView>({
+      provider.query<AccessKeyViewRaw>({
         request_type: "view_access_key",
         finality: "final",
         account_id: transactions[i].signerId,

--- a/packages/welldone-wallet/README.md
+++ b/packages/welldone-wallet/README.md
@@ -8,10 +8,10 @@ The easiest way to use this package is to install it from the NPM registry, this
 
 ```bash
 # Using Yarn
-yarn add near-api-js@^0.44.2
+yarn add near-api-js
 
 # Using NPM.
-npm install near-api-js@^0.44.2
+npm install near-api-js
 ```
 ```bash
 # Using Yarn

--- a/packages/welldone-wallet/package.json
+++ b/packages/welldone-wallet/package.json
@@ -2,6 +2,6 @@
   "name": "@near-wallet-selector/welldone-wallet",
   "version": "7.2.0",
   "peerDependencies": {
-    "near-api-js": "^0.44.2"
+    "near-api-js": "^0.44.2 || ^1.0.0"
   }
 }

--- a/scripts/nightly-connect-client.ts
+++ b/scripts/nightly-connect-client.ts
@@ -45,6 +45,7 @@ const main = async () => {
       // Send signed transaction
       await client.resolveSignTransaction({
         requestId: signRequest.id,
+        // @ts-ignore
         signedTransactions: [signedTx]
       })
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -5894,15 +5894,15 @@ bn.js@5.2.0:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.0.tgz#358860674396c6997771a9d051fcc1b57d4ae002"
   integrity sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==
 
+bn.js@5.2.1, bn.js@^5.0.0, bn.js@^5.1.1, bn.js@^5.2.0, bn.js@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.1.tgz#0bc527a6a0d18d0aa8d5b0538ce4a77dccfa7b70"
+  integrity sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==
+
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.9:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
   integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
-
-bn.js@^5.0.0, bn.js@^5.1.1, bn.js@^5.2.0, bn.js@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.1.tgz#0bc527a6a0d18d0aa8d5b0538ce4a77dccfa7b70"
-  integrity sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==
 
 body-parser@1.20.0:
   version "1.20.0"
@@ -5936,15 +5936,6 @@ boolbase@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
-
-borsh@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/borsh/-/borsh-0.6.0.tgz#a7c9eeca6a31ca9e0607cb49f329cb659eb791e1"
-  integrity sha512-sl5k89ViqsThXQpYa9XDtz1sBl3l1lI313cFUY1HKr+wvMILnb+58xpkqTNrYbelh99dY7K8usxoCusQmqix9Q==
-  dependencies:
-    bn.js "^5.2.0"
-    bs58 "^4.0.0"
-    text-encoding-utf-8 "^1.0.2"
 
 borsh@^0.7.0:
   version "0.7.0"
@@ -11983,13 +11974,13 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-near-api-js@^0.44.2:
-  version "0.44.2"
-  resolved "https://registry.yarnpkg.com/near-api-js/-/near-api-js-0.44.2.tgz#e451f68f2c56bd885c7b918db5818a3e6e9423d0"
-  integrity sha512-eMnc4V+geggapEUa3nU2p8HSHn/njtloI4P2mceHQWO8vDE1NGpnAw8FuTBrLmXSgIv9m6oocgFc9t3VNf5zwg==
+near-api-js@^0.45.1:
+  version "0.45.1"
+  resolved "https://registry.yarnpkg.com/near-api-js/-/near-api-js-0.45.1.tgz#0f0a4b378758a2f1b32555399d7356da73d0ef27"
+  integrity sha512-QyPO/vjvMFlcMO1DCpsqzmnSqPIyHsjK1Qi4B5ZR1cJCIWMkqugDF/TDf8FVQ85pmlcYeYwfiTqKanKz+3IG0A==
   dependencies:
     bn.js "5.2.0"
-    borsh "^0.6.0"
+    borsh "^0.7.0"
     bs58 "^4.0.0"
     depd "^2.0.0"
     error-polyfill "^0.1.3"
@@ -12000,12 +11991,12 @@ near-api-js@^0.44.2:
     text-encoding-utf-8 "^1.0.2"
     tweetnacl "^1.0.1"
 
-near-api-js@^0.45.1:
-  version "0.45.1"
-  resolved "https://registry.yarnpkg.com/near-api-js/-/near-api-js-0.45.1.tgz#0f0a4b378758a2f1b32555399d7356da73d0ef27"
-  integrity sha512-QyPO/vjvMFlcMO1DCpsqzmnSqPIyHsjK1Qi4B5ZR1cJCIWMkqugDF/TDf8FVQ85pmlcYeYwfiTqKanKz+3IG0A==
+near-api-js@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/near-api-js/-/near-api-js-1.1.0.tgz#907e807f052c1f043c6fbf28f61872de3c02235a"
+  integrity sha512-qYKv1mYsaDZc2uYndhS+ttDhR9+60qFc+ZjD6lWsAxr3ZskMjRwPffDGQZYhC7BRDQMe1HEbk6d5mf+TVm0Lqg==
   dependencies:
-    bn.js "5.2.0"
+    bn.js "5.2.1"
     borsh "^0.7.0"
     bs58 "^4.0.0"
     depd "^2.0.0"


### PR DESCRIPTION
# Description

- Bumped `near-api-js` to v1.1.0
- Fixed breaking changes mainly replaced `AccessKeyView` with `AccessKeyViewRaw` interface.
- Updated the range of `near-api-js` peerDependency in all packages from `^0.44.2` to `^0.44.2 || ^1.0.0`

To check which versions this new range includes you use this tool: https://semver.npmjs.com/

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [ ] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [x] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
