### PR TITLE
fix: add Korean to the LanguageSelector

### DIFF
--- a/packages/modal-ui/src/lib/components/LanguageSelector.tsx
+++ b/packages/modal-ui/src/lib/components/LanguageSelector.tsx
@@ -21,6 +21,7 @@ export const LanguageSelector: React.FC<LanguageSelectorProps> = ({
       <input type="radio" value="fr" name="language" /> French
       <input type="radio" value="de" name="language" /> German
       <input type="radio" value="bg" name="language" /> Bulgarian
+      <input type="radio" value="ko" name="language" /> Korean
     </div>
   );
 };


### PR DESCRIPTION
# Description

While adding the Bulgarian translation I noticed Korean is missing from the LanguageSelectorComponent Maybe a guide of few lines on the README for translation contributors will help

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [x] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
