### PR TITLE
Add `signMessage` method to Wallet Selector

### DIFF
--- a/packages/coin98-wallet/src/lib/coin98-wallet.ts
+++ b/packages/coin98-wallet/src/lib/coin98-wallet.ts
@@ -173,6 +173,13 @@ const Coin98Wallet: WalletBehaviourFactory<InjectedWallet> = async ({
 
       return results;
     },
+    async signMessage({ message, receiver, nonce }) {
+      logger.log("Coin98Wallet:signMessage", { message, receiver, nonce });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
+
+      return await _state.wallet.near.signMessage({ message, receiver, nonce });
+    },
   };
 };
 

--- a/packages/coin98-wallet/src/lib/injected-coin98-wallet.ts
+++ b/packages/coin98-wallet/src/lib/injected-coin98-wallet.ts
@@ -1,4 +1,8 @@
 import type { Signer } from "near-api-js/lib/signer";
+import type {
+  SignedMessage,
+  SignMessageParams,
+} from "@near-wallet-selector/core";
 
 interface IConnectParams {
   prefix: string;
@@ -10,6 +14,7 @@ interface ICoin98Near {
   signer: Signer;
   connect: (params: IConnectParams) => Promise<string>;
   disconnect: () => Promise<void>;
+  signMessage: (params: SignMessageParams) => Promise<SignedMessage>;
 }
 
 export interface InjectedCoin98 {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -61,6 +61,8 @@ export type {
   DeleteKeyAction,
   DeleteAccountAction,
   AddKeyPermission,
+  SignMessageParams,
+  SignedMessage,
 } from "./lib/wallet";
 
 export type { FinalExecutionOutcome } from "near-api-js/lib/providers";

--- a/packages/core/src/lib/wallet/wallet.types.ts
+++ b/packages/core/src/lib/wallet/wallet.types.ts
@@ -50,7 +50,7 @@ export interface SignMessageParams {
   callbackUrl?: string;
 }
 
-interface SignedMessage {
+export interface SignedMessage {
   accountId: string;
   publicKey: string;
   signature: string;

--- a/packages/core/src/lib/wallet/wallet.types.ts
+++ b/packages/core/src/lib/wallet/wallet.types.ts
@@ -43,6 +43,19 @@ export interface VerifiedOwner {
   keyType: utils.key_pair.KeyType;
 }
 
+export interface SignMessageParams {
+  message: string;
+  receiver: string;
+  nonce: Buffer;
+  callbackUrl?: string;
+}
+
+interface SignedMessage {
+  accountId: string;
+  publicKey: string;
+  signature: string;
+}
+
 interface SignAndSendTransactionParams {
   signerId?: string;
   receiverId?: string;
@@ -64,6 +77,7 @@ interface BaseWalletBehaviour {
   signAndSendTransactions(
     params: SignAndSendTransactionsParams
   ): Promise<Array<providers.FinalExecutionOutcome>>;
+  signMessage(params: SignMessageParams): Promise<SignedMessage | void>;
 }
 
 type BaseWallet<

--- a/packages/here-wallet/src/lib/here-wallet.ts
+++ b/packages/here-wallet/src/lib/here-wallet.ts
@@ -22,7 +22,7 @@ export type HereWallet = BrowserWallet & {
 export const initHereWallet: WalletBehaviourFactory<
   HereWallet,
   { configuration: HereConfiguration }
-> = async ({ store, logger, options, configuration }) => {
+> = async ({ store, logger, options, configuration, metadata }) => {
   const _state = await setupWalletState(configuration, options.network);
 
   const getAccounts = () => {
@@ -117,6 +117,16 @@ export const initHereWallet: WalletBehaviourFactory<
         transactions: await transformTransactions(_state, transactions),
         callbackUrl,
       });
+    },
+    async signMessage({ message, receiver, nonce, callbackUrl }) {
+      logger.log("HEREWallet:signMessage", {
+        message,
+        receiver,
+        nonce,
+        callbackUrl,
+      });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
     },
   };
 };

--- a/packages/ledger/src/lib/ledger.ts
+++ b/packages/ledger/src/lib/ledger.ts
@@ -275,6 +275,11 @@ const Ledger: WalletBehaviourFactory<HardwareWallet> = async ({
 
       return await _state.client.getPublicKey({ derivationPath });
     },
+    async signMessage({ message, receiver, nonce }) {
+      logger.log("Ledger:signMessage", { message, receiver, nonce });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
+    },
   };
 };
 

--- a/packages/math-wallet/src/lib/injected-math-wallet.ts
+++ b/packages/math-wallet/src/lib/injected-math-wallet.ts
@@ -1,4 +1,8 @@
 import type { Signer } from "near-api-js/lib/signer";
+import type {
+  SignedMessage,
+  SignMessageParams,
+} from "@near-wallet-selector/core";
 
 interface LoginParams {
   contractId?: string;
@@ -35,4 +39,5 @@ export interface InjectedMathWallet {
   signer: MathSigner;
   login: (param: LoginParams) => Promise<MathAccount>;
   logout: () => Promise<boolean>;
+  signMessage: (params: SignMessageParams) => Promise<SignedMessage>;
 }

--- a/packages/math-wallet/src/lib/math-wallet.ts
+++ b/packages/math-wallet/src/lib/math-wallet.ts
@@ -177,6 +177,13 @@ const MathWallet: WalletBehaviourFactory<InjectedWallet> = async ({
 
       return results;
     },
+    async signMessage({ message, receiver, nonce }) {
+      logger.log("MathWallet:signMessage", { message, receiver, nonce });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
+
+      return await _state.wallet.signMessage({ message, receiver, nonce });
+    },
   };
 };
 

--- a/packages/meteor-wallet/src/lib/meteor-wallet.ts
+++ b/packages/meteor-wallet/src/lib/meteor-wallet.ts
@@ -50,7 +50,7 @@ const setupWalletState = async (
 const createMeteorWalletInjected: WalletBehaviourFactory<
   InjectedWallet,
   { params: MeteorWalletParams_Injected }
-> = async ({ options, logger, store, params }) => {
+> = async ({ options, logger, store, params, metadata }) => {
   const _state = await setupWalletState(params, options.network);
 
   const getAccounts = () => {
@@ -194,6 +194,11 @@ const createMeteorWalletInjected: WalletBehaviourFactory<
       return _state.wallet.requestSignTransactions({
         transactions: await transformTransactions(transactions),
       });
+    },
+    async signMessage({ message, receiver, nonce }) {
+      logger.log("MeteorWallet:signMessage", { message, receiver, nonce });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
     },
   };
 };

--- a/packages/my-near-wallet/src/lib/my-near-wallet.ts
+++ b/packages/my-near-wallet/src/lib/my-near-wallet.ts
@@ -223,6 +223,16 @@ const MyNearWallet: WalletBehaviourFactory<
     buildImportAccountsUrl() {
       return `${resolveWalletUrl(options.network)}/batch-import`;
     },
+    async signMessage({ message, receiver, nonce, callbackUrl }) {
+      logger.log("MyNearWallet:signMessage", {
+        message,
+        receiver,
+        nonce,
+        callbackUrl,
+      });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
+    },
   };
 };
 

--- a/packages/nearfi/src/lib/injected-nearfi.ts
+++ b/packages/nearfi/src/lib/injected-nearfi.ts
@@ -2,6 +2,10 @@
 
 // Empty string if we haven't signed in before.
 import type { providers } from "near-api-js";
+import type {
+  SignedMessage,
+  SignMessageParams,
+} from "@near-wallet-selector/core";
 
 interface AccessKey {
   publicKey: {
@@ -138,4 +142,5 @@ export interface InjectedNearFi {
   ) => Promise<SignAndSendTransactionsResponse>;
   log: (...msg: Array<unknown>) => void;
   resolveSignInState: () => Promise<unknown>;
+  signMessage: (params: SignMessageParams) => Promise<SignedMessage>;
 }

--- a/packages/nearfi/src/lib/nearfi.ts
+++ b/packages/nearfi/src/lib/nearfi.ts
@@ -223,6 +223,13 @@ const NearFi: WalletBehaviourFactory<InjectedWallet> = async ({
           return res.response;
         });
     },
+    async signMessage({ message, receiver, nonce }) {
+      logger.log("NearFi:signMessage", { message, receiver, nonce });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
+
+      return await _state.wallet.signMessage({ message, receiver, nonce });
+    },
   };
 };
 

--- a/packages/neth/src/lib/neth.ts
+++ b/packages/neth/src/lib/neth.ts
@@ -162,6 +162,12 @@ const Neth: WalletBehaviourFactory<InjectedWallet> = async ({
 
     signAndSendTransactions: async ({ transactions }) =>
       signTransactions(transactions),
+
+    async signMessage({ message, receiver, nonce }) {
+      logger.log("NETH:signMessage", { message, receiver, nonce });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
+    },
   };
 };
 

--- a/packages/nightly-connect/src/lib/nightly-connect.ts
+++ b/packages/nightly-connect/src/lib/nightly-connect.ts
@@ -252,6 +252,11 @@ const NightlyConnect: WalletBehaviourFactory<
 
       return results;
     },
+    async signMessage({ message, receiver, nonce }) {
+      logger.log("NightlyConnect:signMessage", { message, receiver, nonce });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
+    },
   };
 };
 

--- a/packages/nightly/src/lib/injected-nightly.ts
+++ b/packages/nightly/src/lib/injected-nightly.ts
@@ -3,6 +3,10 @@ import type {
   Transaction as NearTransaction,
 } from "near-api-js/lib/transaction";
 import type { PublicKey as NearPublicKey } from "near-api-js/lib/utils";
+import type {
+  SignedMessage,
+  SignMessageParams,
+} from "@near-wallet-selector/core";
 interface NightlyAccount {
   accountId: string;
   publicKey: NearPublicKey;
@@ -21,6 +25,7 @@ export interface NearNightly {
     eagerConnect?: boolean
   ) => Promise<NightlyAccount>;
   disconnect: () => Promise<void>;
+  signMessage: (params: SignMessageParams) => Promise<SignedMessage>;
 }
 export interface InjectedNightly {
   near: NearNightly;

--- a/packages/nightly/src/lib/nightly.ts
+++ b/packages/nightly/src/lib/nightly.ts
@@ -188,6 +188,13 @@ const Nightly: WalletBehaviourFactory<InjectedWallet> = async ({
 
       return results;
     },
+    async signMessage({ message, receiver, nonce }) {
+      logger.log("Nightly:signMessage", { message, receiver, nonce });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
+
+      return await _state.wallet.signMessage({ message, receiver, nonce });
+    },
   };
 };
 

--- a/packages/opto-wallet/src/lib/opto-wallet.ts
+++ b/packages/opto-wallet/src/lib/opto-wallet.ts
@@ -218,6 +218,16 @@ const OptoWallet: WalletBehaviourFactory<
         callbackUrl,
       });
     },
+    async signMessage({ message, receiver, nonce, callbackUrl }) {
+      logger.log("OptoWallet:signMessage", {
+        message,
+        receiver,
+        nonce,
+        callbackUrl,
+      });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
+    },
   };
 };
 

--- a/packages/sender/src/lib/injected-sender.ts
+++ b/packages/sender/src/lib/injected-sender.ts
@@ -2,6 +2,10 @@
 
 // Empty string if we haven't signed in before.
 import type { Account, providers } from "near-api-js";
+import type {
+  SignedMessage,
+  SignMessageParams,
+} from "@near-wallet-selector/core";
 
 interface AccessKey {
   publicKey: {
@@ -143,4 +147,5 @@ export interface InjectedSender {
   requestSignTransactions: (
     params: RequestSignTransactionsParams
   ) => Promise<SignAndSendTransactionsResponse>;
+  signMessage: (params: SignMessageParams) => Promise<SignedMessage>;
 }

--- a/packages/sender/src/lib/sender.ts
+++ b/packages/sender/src/lib/sender.ts
@@ -278,6 +278,13 @@ const Sender: WalletBehaviourFactory<InjectedWallet> = async ({
           return res.response;
         });
     },
+    async signMessage({ message, receiver, nonce }) {
+      logger.log("Sender:signMessage", { message, receiver, nonce });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
+
+      return await _state.wallet.signMessage({ message, receiver, nonce });
+    },
   };
 };
 

--- a/packages/wallet-connect/src/lib/wallet-connect.ts
+++ b/packages/wallet-connect/src/lib/wallet-connect.ts
@@ -106,7 +106,16 @@ const setupWalletConnectState = async (
 const WalletConnect: WalletBehaviourFactory<
   BridgeWallet,
   { params: WalletConnectExtraOptions }
-> = async ({ id, options, store, params, provider, emitter, logger }) => {
+> = async ({
+  id,
+  options,
+  store,
+  params,
+  provider,
+  emitter,
+  logger,
+  metadata,
+}) => {
   const _state = await setupWalletConnectState(id, params, emitter);
 
   const getChainId = () => {
@@ -590,6 +599,12 @@ const WalletConnect: WalletBehaviourFactory<
 
         return results;
       }
+    },
+    async signMessage({ message, receiver, nonce }) {
+      logger.log("WalletConnect:signMessage", { message, receiver, nonce });
+
+      //TODO: Update web-examples of WalletConnect and this package to support signMessage.
+      throw new Error(`Method not supported by ${metadata.name}`);
     },
   };
 };

--- a/packages/welldone-wallet/src/lib/welldone.ts
+++ b/packages/welldone-wallet/src/lib/welldone.ts
@@ -58,6 +58,7 @@ const WelldoneWallet: WalletBehaviourFactory<InjectedWallet> = async ({
   logger,
   storage,
   provider,
+  metadata,
 }) => {
   const _state = await setupWalletState(storage);
 
@@ -393,6 +394,11 @@ const WelldoneWallet: WalletBehaviourFactory<InjectedWallet> = async ({
       }
 
       return results;
+    },
+    async signMessage({ message, receiver, nonce }) {
+      logger.log("WELLDONEWallet:signMessage", { message, receiver, nonce });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
     },
   };
 };


### PR DESCRIPTION
# Description

- Added and exported interfaces for `signMessage` in `core` package.
- Added `signMessage` method in `BaseWalletBehaviour`
- Added `signMessage` method to all wallets (currently it only throws until wallets add the implementation).

The work on this PR is based on the NEP: https://github.com/near/NEPs/pull/413/

Remaining work:

- [ ] Update examples to call and test `signMessage`.
- [ ] Verify the signMessage response in examples (closes: https://github.com/near/wallet-selector/issues/434).
- [ ] Update WalletConnect examples to include the `signMessage` function too.
- [ ] Once the NEP is merged reach out to Wallet builders to add support for `signMessage` in their wallets.

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [ ] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
