### PR TITLE
refactor: method name change in WELLDONE Wallet

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ NEAR Wallet Selector makes it easy for users to interact with your dApp by provi
 - [Math Wallet](https://www.npmjs.com/package/@near-wallet-selector/math-wallet) - Injected wallet.
 - [Nightly](https://www.npmjs.com/package/@near-wallet-selector/nightly) - Injected wallet.
 - [Meteor Wallet](https://www.npmjs.com/package/@near-wallet-selector/meteor-wallet) - Injected wallet.
-- [Welldone Wallet](https://www.npmjs.com/package/@near-wallet-selector/welldone-wallet) - Injected wallet.
+- [WELLDONE Wallet](https://www.npmjs.com/package/@near-wallet-selector/welldone-wallet) - Injected wallet.
 - [Coin98 Wallet](https://www.npmjs.com/package/@near-wallet-selector/coin98-wallet) - Injected wallet.
 - [Neth](https://www.npmjs.com/package/@near-wallet-selector/neth) - Injected wallet.
 - [Ledger](https://www.npmjs.com/package/@near-wallet-selector/ledger) - Hardware wallet.

--- a/packages/welldone-wallet/README.md
+++ b/packages/welldone-wallet/README.md
@@ -1,6 +1,6 @@
 # @near-wallet-selector/welldone
 
-This is the [Welldone](https://chrome.google.com/webstore/detail/welldone-wallet-for-multi/bmkakpenjmcpfhhjadflneinmhboecjf) package for NEAR Wallet Selector.
+This is the [WELLDONE](https://chrome.google.com/webstore/detail/welldone-wallet-for-multi/bmkakpenjmcpfhhjadflneinmhboecjf) package for NEAR Wallet Selector.
 
 ## Installation and Usage
 

--- a/packages/welldone-wallet/src/lib/welldone.ts
+++ b/packages/welldone-wallet/src/lib/welldone.ts
@@ -4,7 +4,6 @@ import type {
   WalletModuleFactory,
   InjectedWallet,
   WalletBehaviourFactory,
-  Action,
   FinalExecutionOutcome,
   JsonStorageService,
   Optional,
@@ -12,17 +11,13 @@ import type {
 } from "@near-wallet-selector/core";
 import { waitFor } from "@near-wallet-selector/core";
 import type {
-  SignAndSendTransactionParams,
   ViewAccessKeyParams,
   WalletProvider,
   WelldoneWalletParams,
   WelldoneWalletState,
 } from "./injected-welldone";
 import icon from "./icon";
-import {
-  createAction,
-  signTransactions,
-} from "@near-wallet-selector/wallet-utils";
+import { signTransactions } from "@near-wallet-selector/wallet-utils";
 import isMobile from "is-mobile";
 
 export const STORAGE_ACCOUNT = "account";
@@ -98,41 +93,6 @@ const WelldoneWallet: WalletBehaviourFactory<InjectedWallet> = async ({
     return accessKey;
   };
 
-  const convertActions = (actions: Array<Action>) => {
-    const tempActions: Array<Transactions.Action> = [];
-    actions.forEach((action) => {
-      tempActions.push(createAction(action));
-    });
-    return tempActions;
-  };
-
-  const convertTransaction = (
-    publicKey: string,
-    nonce: number,
-    hash: string,
-    { signerId, receiverId, actions }: SignAndSendTransactionParams
-  ) => {
-    if (!signerId) {
-      throw new Error("SignerId error");
-    }
-
-    if (!receiverId) {
-      throw new Error("ReceiverId error");
-    }
-
-    const recentBlockHash = utils.serialize.base_decode(hash);
-    const transaction = Transactions.createTransaction(
-      signerId,
-      utils.PublicKey.fromString(publicKey),
-      receiverId,
-      nonce,
-      convertActions(actions),
-      recentBlockHash
-    );
-    const bytes = transaction.encode();
-    return Buffer.from(bytes).toString("base64");
-  };
-
   const cleanup = () => {
     if (_state.account) {
       storage.removeItem(STORAGE_ACCOUNT);
@@ -206,26 +166,25 @@ const WelldoneWallet: WalletBehaviourFactory<InjectedWallet> = async ({
         const tx = Transactions.Transaction.decode(Buffer.from(message));
         const serializedTx = Buffer.from(tx.encode()).toString("hex");
         const signed = await _state.wallet.request("near", {
-          method: "dapp:sign",
+          method: "dapp:signTransaction",
           params: ["0x" + serializedTx],
         });
 
         return {
-          signature: Buffer.from(signed.signature.substr(2), "hex"),
-          publicKey: utils.PublicKey.from(signed.publicKey),
+          signature: Buffer.from(signed[0].signature.substr(2), "hex"),
+          publicKey: utils.PublicKey.from(signed[0].publicKey),
         };
       } catch (err) {
-        const decoded = new TextDecoder("utf-8").decode(message);
-
-        const signed = await _state.wallet.request("near", {
-          method: "dapp:sign",
-          params: [decoded],
-        });
-
-        return {
-          signature: Buffer.from(signed.signature.substr(2), "hex"),
-          publicKey: utils.PublicKey.from(signed.publicKey),
-        };
+        throw Error("Invalid message. Only transactions can be signed");
+        // const decoded = new TextDecoder("utf-8").decode(message);
+        // const signed = await _state.wallet.request("near", {
+        //   method: "dapp:sign",
+        //   params: [decoded],
+        // });
+        // return {
+        //   signature: Buffer.from(signed.signature.substr(2), "hex"),
+        //   publicKey: utils.PublicKey.from(signed.publicKey),
+        // };
       }
     },
   };
@@ -298,44 +257,45 @@ const WelldoneWallet: WalletBehaviourFactory<InjectedWallet> = async ({
 
     async verifyOwner({ message }) {
       logger.log("Welldone:verifyOwner", { message });
+      throw new Error(`Method not supported by WELLDONE Wallet`);
 
-      if (!_state.wallet) {
-        throw new Error("Wallet is not installed");
-      }
+      // if (!_state.wallet) {
+      //   throw new Error("Wallet is not installed");
+      // }
 
-      const account = _state.account;
+      // const account = _state.account;
 
-      if (!account) {
-        throw new Error("Wallet not signed in");
-      }
+      // if (!account) {
+      //   throw new Error("Wallet not signed in");
+      // }
 
-      const accountId = account.accountId;
-      const pubKey = utils.PublicKey.fromString(account.publicKey);
-      const block = await _state.wallet.request("near", {
-        method: "block",
-        params: {
-          finality: "final",
-        },
-      });
+      // const accountId = account.accountId;
+      // const pubKey = utils.PublicKey.fromString(account.publicKey);
+      // const block = await _state.wallet.request("near", {
+      //   method: "block",
+      //   params: {
+      //     finality: "final",
+      //   },
+      // });
 
-      const data = {
-        accountId,
-        message,
-        blockId: block.header.hash,
-        publicKey: Buffer.from(pubKey.data).toString("base64"),
-        keyType: pubKey.keyType,
-      };
-      const encoded = JSON.stringify(data);
+      // const data = {
+      //   accountId,
+      //   message,
+      //   blockId: block.header.hash,
+      //   publicKey: Buffer.from(pubKey.data).toString("base64"),
+      //   keyType: pubKey.keyType,
+      // };
+      // const encoded = JSON.stringify(data);
 
-      const signed = await signer.signMessage(
-        new Uint8Array(Buffer.from(encoded)),
-        accountId
-      );
+      // const signed = await signer.signMessage(
+      //   new Uint8Array(Buffer.from(encoded)),
+      //   accountId
+      // );
 
-      return {
-        ...data,
-        signature: Buffer.from(signed.signature).toString("base64"),
-      };
+      // return {
+      //   ...data,
+      //   signature: Buffer.from(signed.signature).toString("base64"),
+      // };
     },
 
     async signAndSendTransaction({ signerId, receiverId, actions }) {
@@ -358,38 +318,18 @@ const WelldoneWallet: WalletBehaviourFactory<InjectedWallet> = async ({
     },
 
     async signAndSendTransactions({ transactions }) {
-      if (!_state.wallet) {
-        throw new Error("Wallet is not installed");
-      }
+      logger.log("signAndSendTransactions", { transactions });
 
-      if (!_state.account) {
-        throw new Error("Wallet not signed in");
-      }
-
-      const accessKey = await _validateAccessKey(_state.account);
-      const publicKey = _state.account.publicKey;
-
-      let nonce = accessKey.nonce;
-
-      const convertedTxs = transactions.map((tx) => {
-        nonce++;
-        return convertTransaction(publicKey, nonce, accessKey.block_hash, tx);
-      });
-
-      const txHashes = await _state.wallet.request("near", {
-        method: "dapp:sendTransaction",
-        params: [...convertedTxs],
-      });
+      const signedTxs = await signTransactions(
+        transformTransactions(transactions),
+        signer,
+        options.network
+      );
 
       const results: Array<FinalExecutionOutcome> = [];
 
-      for (let i = 0; i < txHashes.length; i++) {
-        results.push(
-          await _state.wallet.request("near", {
-            method: "tx",
-            params: [txHashes[i], transactions[i].signerId],
-          })
-        );
+      for (let i = 0; i < signedTxs.length; i++) {
+        results.push(await provider.sendTransaction(signedTxs[i]));
       }
 
       return results;

--- a/packages/welldone-wallet/src/lib/welldone.ts
+++ b/packages/welldone-wallet/src/lib/welldone.ts
@@ -353,7 +353,7 @@ export function setupWelldoneWallet({
       id: "welldone-wallet",
       type: "injected",
       metadata: {
-        name: "Welldone Wallet",
+        name: "WELLDONE Wallet",
         description: "WELLDONE Wallet for Multichains",
         iconUrl,
         downloadUrl:


### PR DESCRIPTION
# Description

WELLDONE Wallet has an update to v0.1.0 , and have some changes in method name. 
* `dapp:sign` -> `dapp:signTransaction`
* currently not support signMessage, so comment the `verifyOwner` code. But we will support `dapp:signMessage` in recent days.
* refactoring `signAndSendTransactions` method to use `signTransactins` function in `packages\wallet-utils\src\lib\sign-transactions.ts` to avoid using helper function.
* rename `Welldone` to `WELLDONE` in some readme files.

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [ ] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [x] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
