### PR TITLE
here-wallet: add signMessage

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@angular/platform-browser": "~14.0.0",
     "@angular/platform-browser-dynamic": "~14.0.0",
     "@angular/router": "~14.0.0",
-    "@here-wallet/core": "^1.1.0",
+    "@here-wallet/core": "^1.2.1",
     "@jscutlery/semver": "^2.27.2",
     "@ledgerhq/hw-transport": "6.27.1",
     "@ledgerhq/hw-transport-webhid": "6.27.1",

--- a/packages/here-wallet/src/lib/selector.ts
+++ b/packages/here-wallet/src/lib/selector.ts
@@ -89,16 +89,14 @@ export const initHereWallet: SelectorInit = async (config) => {
     },
 
     async verifyOwner() {
-      logger.log("HereWallet:verifyOwner");
-      throw new Error("verifyOwner is not support");
+      throw Error(
+        "HereWallet:verifyOwner is deprecated, use signMessage method with impletementation NEP0413 Standart"
+      );
     },
 
-    async signMessage({ signerId, message }) {
-      logger.log("HereWallet:signMessage", { signerId, message });
-      return await here.signMessage({
-        signerId: signerId ?? (await here.getAccountId()),
-        message,
-      });
+    async signMessage(data) {
+      logger.log("HereWallet:signMessage", data);
+      return await here.signMessage(data);
     },
 
     async signAndSendTransactions(data) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2252,10 +2252,10 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@here-wallet/core@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@here-wallet/core/-/core-1.1.0.tgz#330999611e29a83dedc1f1e0e08563dd816ce3ac"
-  integrity sha512-CSAIFzegvFo0gKFPs+ITrGxa/oJkY6Rnfm6ETJe4DkEmX+gPGKyiLHVBalXwBBKH5cASYoxOW94F4HfO21BCQQ==
+"@here-wallet/core@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@here-wallet/core/-/core-1.2.1.tgz#b1dd2ec95c7ffd0a8c4511f3956bf74db869185f"
+  integrity sha512-Ml+Uku7iUuPrQKMS1cRk9KuDNeVn8/kTe6hCveYuNCWUYbBYSDt6kztjo08apJW8UUuVJNDr+vgR2CBWliz79g==
   dependencies:
     sha1 "^1.1.1"
     uuid4 "2.0.3"


### PR DESCRIPTION
Implement signMessage Standart for HERE Wallet
Standart draf: https://github.com/near/NEPs/pull/413

`signMessage` sign hash of `NEP0413:` + `{"message":"hi","nonce":[0,...,31],"receiver":"myapp.com"}` string by full access key and return signature, then verifies the signature and verifies that the public key is indeed the full access key on the blockchain.

If verification fails, the method returns an error.