### PR TITLE
feat: Add optional `onHide` callback method in modal options

### DIFF
--- a/examples/angular/src/app/app.component.ts
+++ b/examples/angular/src/app/app.component.ts
@@ -91,7 +91,12 @@ export class AppComponent implements OnInit {
       ],
     });
 
-    const _modal = setupModal(_selector, { contractId: CONTRACT_ID });
+    const _modal = setupModal(_selector, {
+      contractId: CONTRACT_ID,
+      onHide: (hideReason) => {
+        console.log("The reason for hiding modal: ", hideReason);
+      },
+    });
     const state = _selector.store.getState();
 
     this.accounts = state.accounts;

--- a/examples/react/contexts/WalletSelectorContext.tsx
+++ b/examples/react/contexts/WalletSelectorContext.tsx
@@ -93,7 +93,7 @@ export const WalletSelectorContextProvider: React.FC<{
     });
     const _modal = setupModal(_selector, {
       contractId: CONTRACT_ID,
-      onHide: (hideReason: string) => {
+      onHide: (hideReason) => {
         console.log("the reason for hidding modal...", hideReason);
       },
     });

--- a/examples/react/contexts/WalletSelectorContext.tsx
+++ b/examples/react/contexts/WalletSelectorContext.tsx
@@ -91,7 +91,12 @@ export const WalletSelectorContextProvider: React.FC<{
         }),
       ],
     });
-    const _modal = setupModal(_selector, { contractId: CONTRACT_ID });
+    const _modal = setupModal(_selector, {
+      contractId: CONTRACT_ID,
+      onHide: (hideReason: string) => {
+        console.log("the reason for hidding modal...", hideReason);
+      },
+    });
     const state = _selector.store.getState();
     setAccounts(state.accounts);
 

--- a/packages/here-wallet/src/lib/index.ts
+++ b/packages/here-wallet/src/lib/index.ts
@@ -24,7 +24,7 @@ export function setupHereWallet({
       id: "here-wallet",
       type: "injected",
       metadata: {
-        name: "Here Wallet (mobile)",
+        name: "Here Wallet",
         description: "Mobile wallet for NEAR Protocol",
         downloadUrl: "",
         iconUrl,

--- a/packages/modal-ui-js/README.md
+++ b/packages/modal-ui-js/README.md
@@ -39,6 +39,8 @@ modal.show();
 - `methodNames` (`Array<string>?`): Specify limited access to particular methods on the Smart Contract.
 - `theme` (`Theme?`): Specify light/dark theme for UI. Defaults to the browser configuration when omitted or set to 'auto'. This can be either `light`, `dark` or `auto`.
 - `description` (`string?`): Define a custom description in the UI.
+- `onHide` (`(hideReason) => {}?`): Callback method triggered when close button is clicked in the UI.
+
 
 ## Styles & Customizing CSS
 

--- a/packages/modal-ui-js/src/lib/components/GetAWallet.ts
+++ b/packages/modal-ui-js/src/lib/components/GetAWallet.ts
@@ -55,6 +55,13 @@ const getTypeNameAndIcon = (
         };
       }
 
+      if (walletId === "here-wallet") {
+        return {
+          typeFullName: "Mobile Wallet",
+          qrIcon: true,
+        };
+      }
+
       return {
         typeFullName: "Wallet Extension",
         qrIcon: false,

--- a/packages/modal-ui-js/src/lib/modal.types.ts
+++ b/packages/modal-ui-js/src/lib/modal.types.ts
@@ -8,6 +8,7 @@ export interface ModalOptions {
   methodNames?: Array<string>;
   theme?: Theme;
   description?: string;
+  onHide?: (hideReason: "user-triggered" | "wallet-navigation") => void;
 }
 
 export interface WalletSelectorModal {

--- a/packages/modal-ui-js/src/lib/render-modal.ts
+++ b/packages/modal-ui-js/src/lib/render-modal.ts
@@ -19,7 +19,7 @@ import { translate } from "@near-wallet-selector/core";
 export type HardwareWalletAccountState = HardwareWalletAccount & {
   selected: boolean;
 };
-let renderCount = 0;
+let initialRender = true;
 
 const getAccountIds = async (publicKey: string): Promise<Array<string>> => {
   if (!modalState) {
@@ -307,7 +307,7 @@ export function renderModal() {
     });
 
   // TODO: Better handle `click` event listener for close-button.
-  if (renderCount === 0) {
+  if (initialRender) {
     document.addEventListener("click", (e) => {
       if (!modalState) {
         return;
@@ -323,6 +323,6 @@ export function renderModal() {
         }
       }
     });
-    renderCount++;
+    initialRender = false;
   }
 }

--- a/packages/modal-ui-js/src/lib/render-modal.ts
+++ b/packages/modal-ui-js/src/lib/render-modal.ts
@@ -19,6 +19,7 @@ import { translate } from "@near-wallet-selector/core";
 export type HardwareWalletAccountState = HardwareWalletAccount & {
   selected: boolean;
 };
+let renderCount = 0;
 
 const getAccountIds = async (publicKey: string): Promise<Array<string>> => {
   if (!modalState) {
@@ -299,17 +300,29 @@ export function renderModal() {
         return;
       }
       modalState.container.children[0].classList.remove("open");
+
+      if (modalState.options.onHide) {
+        modalState.options.onHide("user-triggered");
+      }
     });
 
-  document.addEventListener("click", (e) => {
-    if (!modalState) {
-      return;
-    }
+  // TODO: Better handle `click` event listener for close-button.
+  if (renderCount === 0) {
+    document.addEventListener("click", (e) => {
+      if (!modalState) {
+        return;
+      }
 
-    const target = e.target as HTMLElement;
+      const target = e.target as HTMLElement;
 
-    if (target && target.className === "close-button") {
-      modalState.container.children[0].classList.remove("open");
-    }
-  });
+      if (target && target.className === "close-button") {
+        modalState.container.children[0].classList.remove("open");
+
+        if (modalState.options.onHide) {
+          modalState.options.onHide("user-triggered");
+        }
+      }
+    });
+    renderCount++;
+  }
 }

--- a/packages/modal-ui/README.md
+++ b/packages/modal-ui/README.md
@@ -39,6 +39,7 @@ modal.show();
 - `methodNames` (`Array<string>?`): Specify limited access to particular methods on the Smart Contract.
 - `theme` (`Theme?`): Specify light/dark theme for UI. Defaults to the browser configuration when omitted or set to 'auto'. This can be either `light`, `dark` or `auto`.
 - `description` (`string?`): Define a custom description in the UI.
+- `onHide` (`(hideReason) => {}?`): Callback method triggered when close button is clicked in the UI.
 
 ## Styles & Customizing CSS
 

--- a/packages/modal-ui/src/lib/components/Modal.tsx
+++ b/packages/modal-ui/src/lib/components/Modal.tsx
@@ -90,8 +90,7 @@ export const Modal: React.FC<ModalProps> = ({
       });
 
       if (isOnHide === true && options.onHide) {
-        /*// @ts-ignore*/
-        options.onHide("wallet-navigation");
+        options.onHide("user-triggered");
       }
       hide();
     },

--- a/packages/modal-ui/src/lib/components/Modal.tsx
+++ b/packages/modal-ui/src/lib/components/Modal.tsx
@@ -82,13 +82,21 @@ export const Modal: React.FC<ModalProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const handleDismissClick = useCallback(() => {
-    setAlertMessage(null);
-    setRoute({
-      name: "WalletHome",
-    });
-    hide();
-  }, [hide]);
+  const handleDismissClick = useCallback(
+    (isOnHide?: boolean) => {
+      setAlertMessage(null);
+      setRoute({
+        name: "WalletHome",
+      });
+
+      if (isOnHide === true && options.onHide) {
+        /*// @ts-ignore*/
+        options.onHide("wallet-navigation");
+      }
+      hide();
+    },
+    [hide]
+  );
 
   useEffect(() => {
     const close = (e: KeyboardEvent) => {
@@ -227,6 +235,7 @@ export const Modal: React.FC<ModalProps> = ({
         visible ? "open" : ""
       }`}
     >
+      {/*// @ts-ignore*/}
       <div className="nws-modal-overlay" onClick={handleDismissClick} />
       <div className="nws-modal">
         <div className="modal-left">
@@ -255,7 +264,7 @@ export const Modal: React.FC<ModalProps> = ({
                     name: "WalletHome",
                   });
                 }}
-                onCloseModal={handleDismissClick}
+                onCloseModal={() => handleDismissClick(true)}
               />
             )}
             {route.name === "DerivationPath" && (
@@ -283,7 +292,7 @@ export const Modal: React.FC<ModalProps> = ({
                     },
                   });
                 }}
-                onCloseModal={handleDismissClick}
+                onCloseModal={() => handleDismissClick(true)}
               />
             )}
             {route.name === "WalletNetworkChanged" && (
@@ -294,7 +303,7 @@ export const Modal: React.FC<ModalProps> = ({
                     name: "WalletHome",
                   })
                 }
-                onCloseModal={handleDismissClick}
+                onCloseModal={() => handleDismissClick(true)}
               />
             )}
             {route.name === "WalletNotInstalled" && (
@@ -305,7 +314,7 @@ export const Modal: React.FC<ModalProps> = ({
                     name: "WalletHome",
                   });
                 }}
-                onCloseModal={handleDismissClick}
+                onCloseModal={() => handleDismissClick(true)}
               />
             )}
             {route.name === "WalletConnecting" && (
@@ -316,19 +325,19 @@ export const Modal: React.FC<ModalProps> = ({
                     name: "WalletHome",
                   });
                 }}
-                onCloseModal={handleDismissClick}
+                onCloseModal={() => handleDismissClick(true)}
               />
             )}
             {route.name === "WalletHome" && (
               <WalletHome
                 selector={selector}
-                onCloseModal={handleDismissClick}
+                onCloseModal={() => handleDismissClick(true)}
               />
             )}
             {route.name === "WalletConnected" && (
               <WalletConnected
                 module={selectedWallet!}
-                onCloseModal={handleDismissClick}
+                onCloseModal={() => handleDismissClick(true)}
               />
             )}
 
@@ -337,7 +346,7 @@ export const Modal: React.FC<ModalProps> = ({
                 handleOpenDefaultModal={() => {
                   handleWalletClick(selectedWallet!, true);
                 }}
-                onCloseModal={handleDismissClick}
+                onCloseModal={() => handleDismissClick(true)}
                 uri={bridgeWalletUri}
                 wallet={selectedWallet!}
               />

--- a/packages/modal-ui/src/lib/components/WalletHome.tsx
+++ b/packages/modal-ui/src/lib/components/WalletHome.tsx
@@ -88,6 +88,13 @@ export const WalletHome: React.FC<WalletHomeProps> = ({
           };
         }
 
+        if (walletId === "here-wallet") {
+          return {
+            typeFullName: "Mobile Wallet",
+            qrIcon: true,
+          };
+        }
+
         return {
           typeFullName: "Wallet Extension",
           qrIcon: false,

--- a/packages/modal-ui/src/lib/modal.types.ts
+++ b/packages/modal-ui/src/lib/modal.types.ts
@@ -5,6 +5,7 @@ export interface ModalOptions {
   methodNames?: Array<string>;
   theme?: Theme;
   description?: string;
+  onHide?: (hideReason: "user-triggered' | 'wallet-navigation") => void;
 }
 
 export interface WalletSelectorModal {

--- a/packages/modal-ui/src/lib/modal.types.ts
+++ b/packages/modal-ui/src/lib/modal.types.ts
@@ -5,7 +5,7 @@ export interface ModalOptions {
   methodNames?: Array<string>;
   theme?: Theme;
   description?: string;
-  onHide?: (hideReason: "user-triggered' | 'wallet-navigation") => void;
+  onHide?: (hideReason: "user-triggered" | "wallet-navigation") => void;
 }
 
 export interface WalletSelectorModal {


### PR DESCRIPTION
# Description

- Added optional `onHide` callback method to ModalOptions.
- The method gets triggered only when user clicks the close button or the overlay.

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [ ] FIX - a PR of this type patches a bug.
- [x] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
