### PR TITLE
feat: Optionally allow creating new wallet selector instances.

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -45,6 +45,7 @@ const selector = await setupWalletSelector({
   - `indexerUrl` (`string`): Custom URL for the Indexer service.
 - `debug` (`boolean?`): Enable internal logging for debugging purposes. Defaults to `false`.
 - `optimizeWalletOrder` (`boolean?`): Enable automatic wallet order. Reorders last signed in wallet on top, then installed wallets over not installed and deprecated wallets.
+- `allowMultipleSelectors` (`boolean?`): Optionally allow creating new instances of wallet selector.
 - `storage` (`StorageService?`): Async storage implementation. Useful when [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) is unavailable. Defaults to `localStorage`.
 - `modules` (`Array<WalletModuleFactory>`): List of wallets to support in your dApp.
 

--- a/packages/core/src/lib/wallet-selector.types.ts
+++ b/packages/core/src/lib/wallet-selector.types.ts
@@ -13,6 +13,7 @@ export interface WalletSelectorParams {
   storage?: StorageService;
   debug?: boolean;
   optimizeWalletOrder?: boolean;
+  allowMultipleSelectors?: boolean;
 }
 
 export type WalletSelectorStore = ReadOnlyStore;


### PR DESCRIPTION
# Description

- Optionally pass the `allowMultipleSelectors` option in `setupWalletSelector`.

```ts
await setupWalletSelector({
      allowMultipleSelectors: true, // Wallet selector will not act as singleton, a new instance of the selector will be returned.
      network: "testnet",
      debug: true,
      modules: [setupNearWallet()],
    })
```

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [ ] FIX - a PR of this type patches a bug.
- [x] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
