### PR TITLE
feat: Add EventEmitter and listen to events through modal instance

### DIFF
--- a/examples/angular/src/app/app.component.ts
+++ b/examples/angular/src/app/app.component.ts
@@ -95,9 +95,6 @@ export class AppComponent implements OnInit {
 
     const _modal = setupModal(_selector, {
       contractId: CONTRACT_ID,
-      onHide: (hideReason) => {
-        console.log("The reason for hiding modal: ", hideReason);
-      },
     });
     const state = _selector.store.getState();
 

--- a/examples/angular/src/app/components/content/content.component.ts
+++ b/examples/angular/src/app/components/content/content.component.ts
@@ -147,6 +147,10 @@ export class ContentComponent implements OnInit, OnDestroy {
           this.account = account;
         });
       });
+
+    this.modal.on("onHide", ({ hideReason }) => {
+      console.log(`The reason for hiding the modal ${hideReason}`);
+    });
   }
 
   async addMessages(message: string, donation: string, multiple: boolean) {

--- a/examples/react/contexts/WalletSelectorContext.tsx
+++ b/examples/react/contexts/WalletSelectorContext.tsx
@@ -95,9 +95,6 @@ export const WalletSelectorContextProvider: React.FC<{
     });
     const _modal = setupModal(_selector, {
       contractId: CONTRACT_ID,
-      onHide: (hideReason) => {
-        console.log("the reason for hidding modal...", hideReason);
-      },
     });
     const state = _selector.store.getState();
     setAccounts(state.accounts);

--- a/examples/react/contexts/WalletSelectorContext.tsx
+++ b/examples/react/contexts/WalletSelectorContext.tsx
@@ -132,7 +132,14 @@ export const WalletSelectorContextProvider: React.FC<{
         setAccounts(nextAccounts);
       });
 
-    return () => subscription.unsubscribe();
+    const onHideSubscription = modal!.on("onHide", ({ hideReason }) => {
+      console.log(`The reason for hiding the modal ${hideReason}`);
+    });
+
+    return () => {
+      subscription.unsubscribe();
+      onHideSubscription.remove();
+    };
   }, [selector]);
 
   if (!selector || !modal) {

--- a/examples/react/contexts/WalletSelectorExportContext.tsx
+++ b/examples/react/contexts/WalletSelectorExportContext.tsx
@@ -4,7 +4,7 @@ import { map, distinctUntilChanged } from "rxjs";
 import { setupWalletSelector } from "@near-wallet-selector/core";
 import type { WalletSelector, AccountState } from "@near-wallet-selector/core";
 import { setupExportSelectorModal } from "@near-wallet-selector/account-export";
-import type { WalletSelectorModal } from "@near-wallet-selector/modal-ui";
+import type { WalletSelectorModal } from "@near-wallet-selector/account-export";
 import { setupDefaultWallets } from "@near-wallet-selector/default-wallets";
 import { setupNearWallet } from "@near-wallet-selector/near-wallet";
 import { setupHereWallet } from "@near-wallet-selector/here-wallet";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,9 @@ export type {
   JsonStorageService,
   EventEmitterService,
 } from "./lib/services";
+
+export { EventEmitter } from "./lib/services";
+
 export type { Optional } from "./lib/utils.types";
 
 export type {

--- a/packages/modal-ui-js/README.md
+++ b/packages/modal-ui-js/README.md
@@ -39,7 +39,6 @@ modal.show();
 - `methodNames` (`Array<string>?`): Specify limited access to particular methods on the Smart Contract.
 - `theme` (`Theme?`): Specify light/dark theme for UI. Defaults to the browser configuration when omitted or set to 'auto'. This can be either `light`, `dark` or `auto`.
 - `description` (`string?`): Define a custom description in the UI.
-- `onHide` (`(hideReason) => {}?`): Callback method triggered when close button is clicked in the UI.
 
 
 ## Styles & Customizing CSS

--- a/packages/modal-ui-js/docs/api/modal.md
+++ b/packages/modal-ui-js/docs/api/modal.md
@@ -98,6 +98,6 @@ const handleModalClosed = ({
   console.log(`The reason for hiding the modal ${hideReason}`);
 }
 
-selector.on("onHide", handleModalClosed);
-selector.off("onHide", handleModalClosed);
+modal.on("onHide", handleModalClosed);
+modal.off("onHide", handleModalClosed);
 ```

--- a/packages/modal-ui-js/docs/api/modal.md
+++ b/packages/modal-ui-js/docs/api/modal.md
@@ -39,3 +39,65 @@ Closes the modal.
 ```ts
 modal.hide();
 ```
+
+
+### `.on(event, callback)`
+
+**Parameters**
+
+- `event` (`string`): Name of the event. This can be: `onHide`.
+- `callback` (`Function`): Handler to be triggered when the `event` fires.
+
+**Returns**
+
+- `Subscription`
+
+**Description**
+
+Attach an event handler to important events.
+
+**Example**
+
+```ts
+const subscription = modal.on("onHide", ({ hideReason }) => {
+  console.log(`The reason for hiding the modal ${hideReason}`);
+});
+
+// Unsubscribe.
+subscription.remove();
+```
+
+### `.off(event, callback)`
+
+**Parameters**
+
+- `event` (`string`): Name of the event. This can be: `onHide`.
+- `callback` (`Function`): Original handler passed to `.on(event, callback)`.
+
+**Returns**
+
+- `void`
+
+**Description**
+
+Removes the event handler attached to the given `event`.
+
+**Example**
+
+The `onHide` event can be triggered in different scenarios:
+- When user clicks the X button on the UI the event is emitted with the `user-triggered` reason.
+- When user presses the ESC key the event is emitted with the `user-triggered` reason.
+- When user clicks the overlay outside the modal the event is emitted with the `user-triggered` reason.
+- The modal is closed after a successful sign-in in this case the event is emitted with the `wallet-navigation` reason.
+
+```ts
+const handleModalClosed = ({
+  hideReason
+}: ModalEvents["onHide"]) => {
+  // hideReason is a string `user-triggered` or `wallet-navigation`  
+  console.log(`The reason for hiding the modal ${hideReason}`);
+}
+
+selector.on("onHide", handleModalClosed);
+selector.off("onHide", handleModalClosed);
+```

--- a/packages/modal-ui-js/src/index.ts
+++ b/packages/modal-ui-js/src/index.ts
@@ -4,4 +4,5 @@ export type {
   WalletSelectorModal,
   ModalOptions,
   Theme,
+  ModalEvents,
 } from "./lib/modal.types";

--- a/packages/modal-ui-js/src/lib/components/LedgerAccountsOverviewList.ts
+++ b/packages/modal-ui-js/src/lib/components/LedgerAccountsOverviewList.ts
@@ -82,6 +82,7 @@ export async function renderLedgerAccountsOverviewList(
         });
 
         modalState.container.children[0].classList.remove("open");
+        modalState.emitter.emit("onHide", { hideReason: "wallet-navigation" });
       } catch (err) {
         await renderWalletConnectionFailed(module, err as Error);
       }

--- a/packages/modal-ui-js/src/lib/modal.types.ts
+++ b/packages/modal-ui-js/src/lib/modal.types.ts
@@ -1,5 +1,6 @@
 import type { Wallet } from "@near-wallet-selector/core";
 import type { ModuleState } from "@near-wallet-selector/core";
+import type { Subscription } from "@near-wallet-selector/core";
 
 export type Theme = "dark" | "light" | "auto";
 
@@ -11,9 +12,24 @@ export interface ModalOptions {
   onHide?: (hideReason: "user-triggered" | "wallet-navigation") => void;
 }
 
+export type ModalHideReason = "user-triggered" | "wallet-navigation";
+
+export type ModalEvents = {
+  onHide: { hideReason: ModalHideReason };
+};
+
 export interface WalletSelectorModal {
   show(): void;
   hide(): void;
+  on<EventName extends keyof ModalEvents>(
+    eventName: EventName,
+    callback: (event: ModalEvents[EventName]) => void
+  ): Subscription;
+
+  off<EventName extends keyof ModalEvents>(
+    eventName: EventName,
+    callback: (event: ModalEvents[EventName]) => void
+  ): void;
 }
 
 type AlertMessageModalRouteParams = {

--- a/packages/modal-ui-js/src/lib/render-modal.ts
+++ b/packages/modal-ui-js/src/lib/render-modal.ts
@@ -132,6 +132,7 @@ export async function connectToWallet(
 
       subscription.remove();
       modalState.container.children[0].classList.remove("open");
+      modalState.emitter.emit("onHide", { hideReason: "wallet-navigation" });
       return;
     }
 
@@ -144,6 +145,7 @@ export async function connectToWallet(
       });
 
       modalState.container.children[0].classList.remove("open");
+      modalState.emitter.emit("onHide", { hideReason: "wallet-navigation" });
 
       return;
     }
@@ -154,6 +156,7 @@ export async function connectToWallet(
     });
 
     modalState.container.children[0].classList.remove("open");
+    modalState.emitter.emit("onHide", { hideReason: "wallet-navigation" });
   } catch (err) {
     const { name } = module.metadata;
     const message = err instanceof Error ? err.message : "Something went wrong";
@@ -302,7 +305,7 @@ export function renderModal() {
       modalState.container.children[0].classList.remove("open");
 
       if (modalState.options.onHide) {
-        modalState.options.onHide("user-triggered");
+        modalState.emitter.emit("onHide", { hideReason: "user-triggered" });
       }
     });
 
@@ -319,7 +322,7 @@ export function renderModal() {
         modalState.container.children[0].classList.remove("open");
 
         if (modalState.options.onHide) {
-          modalState.options.onHide("user-triggered");
+          modalState.emitter.emit("onHide", { hideReason: "user-triggered" });
         }
       }
     });

--- a/packages/modal-ui/README.md
+++ b/packages/modal-ui/README.md
@@ -39,7 +39,6 @@ modal.show();
 - `methodNames` (`Array<string>?`): Specify limited access to particular methods on the Smart Contract.
 - `theme` (`Theme?`): Specify light/dark theme for UI. Defaults to the browser configuration when omitted or set to 'auto'. This can be either `light`, `dark` or `auto`.
 - `description` (`string?`): Define a custom description in the UI.
-- `onHide` (`(hideReason) => {}?`): Callback method triggered when close button is clicked in the UI.
 
 ## Styles & Customizing CSS
 

--- a/packages/modal-ui/docs/api/modal.md
+++ b/packages/modal-ui/docs/api/modal.md
@@ -39,3 +39,64 @@ Closes the modal.
 ```ts
 modal.hide();
 ```
+
+### `.on(event, callback)`
+
+**Parameters**
+
+- `event` (`string`): Name of the event. This can be: `onHide`.
+- `callback` (`Function`): Handler to be triggered when the `event` fires.
+
+**Returns**
+
+- `Subscription`
+
+**Description**
+
+Attach an event handler to important events.
+
+**Example**
+
+```ts
+const subscription = modal.on("onHide", ({ hideReason }) => {
+  console.log(`The reason for hiding the modal ${hideReason}`);
+});
+
+// Unsubscribe.
+subscription.remove();
+```
+
+### `.off(event, callback)`
+
+**Parameters**
+
+- `event` (`string`): Name of the event. This can be: `onHide`.
+- `callback` (`Function`): Original handler passed to `.on(event, callback)`.
+
+**Returns**
+
+- `void`
+
+**Description**
+
+Removes the event handler attached to the given `event`.
+
+**Example**
+
+The `onHide` event can be triggered in different scenarios:
+- When user clicks the X button on the UI the event is emitted with the `user-triggered` reason.
+- When user presses the ESC key the event is emitted with the `user-triggered` reason.
+- When user clicks the overlay outside the modal the event is emitted with the `user-triggered` reason.
+- The modal is closed after a successful sign-in in this case the event is emitted with the `wallet-navigation` reason.
+
+```ts
+const handleModalClosed = ({
+  hideReason
+}: ModalEvents["onHide"]) => {
+  // hideReason is a string `user-triggered` or `wallet-navigation`  
+  console.log(`The reason for hiding the modal ${hideReason}`);
+}
+
+selector.on("onHide", handleModalClosed);
+selector.off("onHide", handleModalClosed);
+```

--- a/packages/modal-ui/docs/api/modal.md
+++ b/packages/modal-ui/docs/api/modal.md
@@ -97,6 +97,6 @@ const handleModalClosed = ({
   console.log(`The reason for hiding the modal ${hideReason}`);
 }
 
-selector.on("onHide", handleModalClosed);
-selector.off("onHide", handleModalClosed);
+modal.on("onHide", handleModalClosed);
+modal.off("onHide", handleModalClosed);
 ```

--- a/packages/modal-ui/src/index.ts
+++ b/packages/modal-ui/src/index.ts
@@ -4,4 +4,5 @@ export type {
   WalletSelectorModal,
   ModalOptions,
   Theme,
+  ModalEvents,
 } from "./lib/modal.types";

--- a/packages/modal-ui/src/lib/components/Modal.tsx
+++ b/packages/modal-ui/src/lib/components/Modal.tsx
@@ -292,7 +292,7 @@ export const Modal: React.FC<ModalProps> = ({
                 selector={selector}
                 options={options}
                 onConnected={() => {
-                  handleDismissClick({});
+                  handleDismissClick({ hideReason: "wallet-navigation" });
                 }}
                 params={route.params}
                 onBack={() =>

--- a/packages/modal-ui/src/lib/components/Modal.tsx
+++ b/packages/modal-ui/src/lib/components/Modal.tsx
@@ -1,7 +1,16 @@
 import React, { useCallback, useEffect, useState } from "react";
-import type { ModuleState, WalletSelector } from "@near-wallet-selector/core";
+import type {
+  EventEmitterService,
+  ModuleState,
+  WalletSelector,
+} from "@near-wallet-selector/core";
 
-import type { ModalOptions, Theme } from "../modal.types";
+import type {
+  ModalEvents,
+  ModalHideReason,
+  ModalOptions,
+  Theme,
+} from "../modal.types";
 import type { ModalRoute } from "./Modal.types";
 import { WalletNetworkChanged } from "./WalletNetworkChanged";
 import { WalletOptions } from "./WalletOptions";
@@ -20,6 +29,7 @@ interface ModalProps {
   options: ModalOptions;
   visible: boolean;
   hide: () => void;
+  emitter: EventEmitterService<ModalEvents>;
 }
 
 const getThemeClass = (theme?: Theme) => {
@@ -38,6 +48,7 @@ export const Modal: React.FC<ModalProps> = ({
   options,
   visible,
   hide,
+  emitter,
 }) => {
   const [route, setRoute] = useState<ModalRoute>({
     name: "WalletHome",
@@ -70,7 +81,7 @@ export const Modal: React.FC<ModalProps> = ({
     const subscription = selector.on("networkChanged", ({ networkId }) => {
       // Switched back to the correct network.
       if (networkId === selector.options.network.networkId) {
-        return handleDismissClick();
+        return handleDismissClick({});
       }
 
       setRoute({
@@ -83,14 +94,18 @@ export const Modal: React.FC<ModalProps> = ({
   }, []);
 
   const handleDismissClick = useCallback(
-    (isOnHide?: boolean) => {
+    ({ hideReason }: { hideReason?: ModalHideReason }) => {
       setAlertMessage(null);
       setRoute({
         name: "WalletHome",
       });
 
-      if (isOnHide === true && options.onHide) {
-        options.onHide("user-triggered");
+      if (hideReason === "user-triggered") {
+        emitter.emit("onHide", { hideReason });
+      }
+
+      if (hideReason === "wallet-navigation") {
+        emitter.emit("onHide", { hideReason });
       }
       hide();
     },
@@ -100,7 +115,7 @@ export const Modal: React.FC<ModalProps> = ({
   useEffect(() => {
     const close = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
-        handleDismissClick();
+        handleDismissClick({ hideReason: "user-triggered" });
       }
     };
     window.addEventListener("keydown", close);
@@ -185,7 +200,7 @@ export const Modal: React.FC<ModalProps> = ({
         });
 
         subscription.remove();
-        handleDismissClick();
+        handleDismissClick({});
         return;
       }
 
@@ -197,7 +212,7 @@ export const Modal: React.FC<ModalProps> = ({
           failureUrl: wallet.metadata.failureUrl,
         });
 
-        handleDismissClick();
+        handleDismissClick({});
 
         return;
       }
@@ -207,7 +222,7 @@ export const Modal: React.FC<ModalProps> = ({
         methodNames: options.methodNames,
       });
 
-      handleDismissClick();
+      handleDismissClick({});
     } catch (err) {
       const { name } = module.metadata;
 
@@ -234,8 +249,12 @@ export const Modal: React.FC<ModalProps> = ({
         visible ? "open" : ""
       }`}
     >
-      {/*// @ts-ignore*/}
-      <div className="nws-modal-overlay" onClick={handleDismissClick} />
+      <div
+        className="nws-modal-overlay"
+        onClick={() => {
+          handleDismissClick({ hideReason: "user-triggered" });
+        }}
+      />
       <div className="nws-modal">
         <div className="modal-left">
           <div className="modal-left-title">
@@ -263,14 +282,18 @@ export const Modal: React.FC<ModalProps> = ({
                     name: "WalletHome",
                   });
                 }}
-                onCloseModal={() => handleDismissClick(true)}
+                onCloseModal={() =>
+                  handleDismissClick({ hideReason: "user-triggered" })
+                }
               />
             )}
             {route.name === "DerivationPath" && (
               <DerivationPath
                 selector={selector}
                 options={options}
-                onConnected={handleDismissClick}
+                onConnected={() => {
+                  handleDismissClick({});
+                }}
                 params={route.params}
                 onBack={() =>
                   setRoute({
@@ -291,7 +314,9 @@ export const Modal: React.FC<ModalProps> = ({
                     },
                   });
                 }}
-                onCloseModal={() => handleDismissClick(true)}
+                onCloseModal={() =>
+                  handleDismissClick({ hideReason: "user-triggered" })
+                }
               />
             )}
             {route.name === "WalletNetworkChanged" && (
@@ -302,7 +327,9 @@ export const Modal: React.FC<ModalProps> = ({
                     name: "WalletHome",
                   })
                 }
-                onCloseModal={() => handleDismissClick(true)}
+                onCloseModal={() =>
+                  handleDismissClick({ hideReason: "user-triggered" })
+                }
               />
             )}
             {route.name === "WalletNotInstalled" && (
@@ -313,7 +340,9 @@ export const Modal: React.FC<ModalProps> = ({
                     name: "WalletHome",
                   });
                 }}
-                onCloseModal={() => handleDismissClick(true)}
+                onCloseModal={() =>
+                  handleDismissClick({ hideReason: "user-triggered" })
+                }
               />
             )}
             {route.name === "WalletConnecting" && (
@@ -324,19 +353,25 @@ export const Modal: React.FC<ModalProps> = ({
                     name: "WalletHome",
                   });
                 }}
-                onCloseModal={() => handleDismissClick(true)}
+                onCloseModal={() =>
+                  handleDismissClick({ hideReason: "user-triggered" })
+                }
               />
             )}
             {route.name === "WalletHome" && (
               <WalletHome
                 selector={selector}
-                onCloseModal={() => handleDismissClick(true)}
+                onCloseModal={() =>
+                  handleDismissClick({ hideReason: "user-triggered" })
+                }
               />
             )}
             {route.name === "WalletConnected" && (
               <WalletConnected
                 module={selectedWallet!}
-                onCloseModal={() => handleDismissClick(true)}
+                onCloseModal={() =>
+                  handleDismissClick({ hideReason: "user-triggered" })
+                }
               />
             )}
 
@@ -345,7 +380,9 @@ export const Modal: React.FC<ModalProps> = ({
                 handleOpenDefaultModal={() => {
                   handleWalletClick(selectedWallet!, true);
                 }}
-                onCloseModal={() => handleDismissClick(true)}
+                onCloseModal={() =>
+                  handleDismissClick({ hideReason: "user-triggered" })
+                }
                 uri={bridgeWalletUri}
                 wallet={selectedWallet!}
               />

--- a/packages/modal-ui/src/lib/components/Modal.tsx
+++ b/packages/modal-ui/src/lib/components/Modal.tsx
@@ -200,7 +200,7 @@ export const Modal: React.FC<ModalProps> = ({
         });
 
         subscription.remove();
-        handleDismissClick({});
+        handleDismissClick({ hideReason: "wallet-navigation" });
         return;
       }
 
@@ -212,7 +212,7 @@ export const Modal: React.FC<ModalProps> = ({
           failureUrl: wallet.metadata.failureUrl,
         });
 
-        handleDismissClick({});
+        handleDismissClick({ hideReason: "wallet-navigation" });
 
         return;
       }
@@ -222,7 +222,7 @@ export const Modal: React.FC<ModalProps> = ({
         methodNames: options.methodNames,
       });
 
-      handleDismissClick({});
+      handleDismissClick({ hideReason: "wallet-navigation" });
     } catch (err) {
       const { name } = module.metadata;
 

--- a/packages/modal-ui/src/lib/modal.tsx
+++ b/packages/modal-ui/src/lib/modal.tsx
@@ -4,6 +4,8 @@ import type { WalletSelector } from "@near-wallet-selector/core";
 
 import type { WalletSelectorModal, ModalOptions } from "./modal.types";
 import { Modal } from "./components/Modal";
+import { EventEmitter } from "@near-wallet-selector/core";
+import type { ModalEvents } from "./modal.types";
 
 const MODAL_ELEMENT_ID = "near-wallet-selector-modal";
 
@@ -21,6 +23,7 @@ export const setupModal = (
 
   const container = document.getElementById(MODAL_ELEMENT_ID);
   const root = createRoot(container!);
+  const emitter = new EventEmitter<ModalEvents>();
 
   const render = (visible = false) => {
     root.render(
@@ -29,6 +32,7 @@ export const setupModal = (
         options={options}
         visible={visible}
         hide={() => render(false)}
+        emitter={emitter}
       />
     );
   };
@@ -40,6 +44,12 @@ export const setupModal = (
       },
       hide: () => {
         render(false);
+      },
+      on: (eventName, callback) => {
+        return emitter.on(eventName, callback);
+      },
+      off: (eventName, callback) => {
+        emitter.off(eventName, callback);
       },
     };
   }

--- a/packages/modal-ui/src/lib/modal.types.ts
+++ b/packages/modal-ui/src/lib/modal.types.ts
@@ -1,3 +1,5 @@
+import type { Subscription } from "@near-wallet-selector/core";
+
 export type Theme = "dark" | "light" | "auto";
 
 export interface ModalOptions {
@@ -8,7 +10,22 @@ export interface ModalOptions {
   onHide?: (hideReason: "user-triggered" | "wallet-navigation") => void;
 }
 
+export type ModalHideReason = "user-triggered" | "wallet-navigation";
+
+export type ModalEvents = {
+  onHide: { hideReason: ModalHideReason };
+};
+
 export interface WalletSelectorModal {
   show(): void;
   hide(): void;
+  on<EventName extends keyof ModalEvents>(
+    eventName: EventName,
+    callback: (event: ModalEvents[EventName]) => void
+  ): Subscription;
+
+  off<EventName extends keyof ModalEvents>(
+    eventName: EventName,
+    callback: (event: ModalEvents[EventName]) => void
+  ): void;
 }


### PR DESCRIPTION
# Description

- This PR is to address the #661 issue.
- Added `EventEmitter` and internally emitting `onHide` event with the reason being either `user-triggered` or `wallet-navigation`
- Ability to listen to the event by `modal.on("onHide", ({ hideReason }) => { console.log(hideReason) })`
- Removed references of the old `onHide` callback through the ModalOptions to avoid confusion and since we're not invoking that method anymore.

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [ ] FIX - a PR of this type patches a bug.
- [x] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
