### PR TITLE
refactor: Remove wallets from default-wallets list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,8 +166,3 @@ Wallets shall checkbox a statement of compliance to be maintained on the walletâ
 
 41. Communication between infrastructure elements should be secured to the maximum extent possible.
     Please link to your the statement on your website or GitHub repo showing a statement of compliance. Please put link below (even if it is a placeholder).
-
-
-# Default Wallet List Criteria:
-
-To be included in the default wallet list, a wallet project must have met the Wallet Product Criteria, the Wallet Security Criteria, and completed an audit.

--- a/README.md
+++ b/README.md
@@ -122,7 +122,6 @@ import { setupWelldoneWallet } from "@near-wallet-selector/welldone-wallet";
 import { setupLedger } from "@near-wallet-selector/ledger";
 import { setupWalletConnect } from "@near-wallet-selector/wallet-connect";
 import { setupNightlyConnect } from "@near-wallet-selector/nightly-connect";
-import { setupDefaultWallets } from "@near-wallet-selector/default-wallets";
 import { setupNearFi } from "@near-wallet-selector/nearfi";
 import { setupCoin98Wallet } from "@near-wallet-selector/coin98-wallet";
 import { setupOptoWallet } from "@near-wallet-selector/opto-wallet";
@@ -133,7 +132,6 @@ import { setupXDEFI } from "@near-wallet-selector/xdefi";
 const selector = await setupWalletSelector({
   network: "testnet",
   modules: [
-    ...(await setupDefaultWallets()),
     setupNearWallet(),
     setupMyNearWallet(),
     setupSender(),

--- a/examples/angular/src/app/pages/wallet-selector-export/wallet-selector-export.component.ts
+++ b/examples/angular/src/app/pages/wallet-selector-export/wallet-selector-export.component.ts
@@ -20,6 +20,8 @@ import { setupWalletConnect } from "@near-wallet-selector/wallet-connect";
 import { setupNightlyConnect } from "@near-wallet-selector/nightly-connect";
 import { Component } from "@angular/core";
 import { setupExportSelectorModal } from "@near-wallet-selector/account-export";
+import { setupMyNearWallet } from "@near-wallet-selector/my-near-wallet";
+import { setupLedger } from "@near-wallet-selector/ledger";
 
 declare global {
   interface Window {
@@ -51,6 +53,8 @@ export class WalletSelectorExportComponent implements OnInit {
       network: "testnet",
       debug: true,
       modules: [
+        setupMyNearWallet(),
+        setupLedger(),
         setupNearWallet(),
         setupSender(),
         setupXDEFI(),

--- a/examples/angular/src/app/pages/wallet-selector-export/wallet-selector-export.component.ts
+++ b/examples/angular/src/app/pages/wallet-selector-export/wallet-selector-export.component.ts
@@ -2,7 +2,6 @@ import type { OnInit } from "@angular/core";
 import type { AccountState, WalletSelector } from "@near-wallet-selector/core";
 import { setupWalletSelector } from "@near-wallet-selector/core";
 import type { WalletSelectorModal } from "@near-wallet-selector/account-export";
-import { setupDefaultWallets } from "@near-wallet-selector/default-wallets";
 import { setupNearWallet } from "@near-wallet-selector/near-wallet";
 import { setupSender } from "@near-wallet-selector/sender";
 import { setupXDEFI } from "@near-wallet-selector/xdefi";
@@ -52,7 +51,6 @@ export class WalletSelectorExportComponent implements OnInit {
       network: "testnet",
       debug: true,
       modules: [
-        ...(await setupDefaultWallets()),
         setupNearWallet(),
         setupSender(),
         setupXDEFI(),

--- a/examples/angular/src/app/pages/wallet-selector/wallet-selector.component.ts
+++ b/examples/angular/src/app/pages/wallet-selector/wallet-selector.component.ts
@@ -3,7 +3,6 @@ import type { AccountState, WalletSelector } from "@near-wallet-selector/core";
 import { setupWalletSelector } from "@near-wallet-selector/core";
 import type { WalletSelectorModal } from "@near-wallet-selector/modal-ui-js";
 import { setupModal } from "@near-wallet-selector/modal-ui-js";
-import { setupDefaultWallets } from "@near-wallet-selector/default-wallets";
 import { setupNearWallet } from "@near-wallet-selector/near-wallet";
 import { setupSender } from "@near-wallet-selector/sender";
 import { setupXDEFI } from "@near-wallet-selector/xdefi";
@@ -53,7 +52,6 @@ export class WalletSelectorComponent implements OnInit {
       network: "testnet",
       debug: true,
       modules: [
-        ...(await setupDefaultWallets()),
         setupNearWallet(),
         setupSender(),
         setupXDEFI(),

--- a/examples/angular/src/app/pages/wallet-selector/wallet-selector.component.ts
+++ b/examples/angular/src/app/pages/wallet-selector/wallet-selector.component.ts
@@ -19,8 +19,10 @@ import { setupOptoWallet } from "@near-wallet-selector/opto-wallet";
 import { setupFinerWallet } from "@near-wallet-selector/finer-wallet";
 import { setupWalletConnect } from "@near-wallet-selector/wallet-connect";
 import { setupNightlyConnect } from "@near-wallet-selector/nightly-connect";
-import { CONTRACT_ID } from "../../../constants";
 import { Component } from "@angular/core";
+import { setupMyNearWallet } from "@near-wallet-selector/my-near-wallet";
+import { setupLedger } from "@near-wallet-selector/ledger";
+import { CONTRACT_ID } from "../../../constants";
 
 declare global {
   interface Window {
@@ -52,6 +54,8 @@ export class WalletSelectorComponent implements OnInit {
       network: "testnet",
       debug: true,
       modules: [
+        setupMyNearWallet(),
+        setupLedger(),
         setupNearWallet(),
         setupSender(),
         setupXDEFI(),

--- a/examples/react/contexts/WalletSelectorContext.tsx
+++ b/examples/react/contexts/WalletSelectorContext.tsx
@@ -1,7 +1,6 @@
 import { setupCoin98Wallet } from "@near-wallet-selector/coin98-wallet";
 import type { AccountState, WalletSelector } from "@near-wallet-selector/core";
 import { setupWalletSelector } from "@near-wallet-selector/core";
-import { setupDefaultWallets } from "@near-wallet-selector/default-wallets";
 import { setupHereWallet } from "@near-wallet-selector/here-wallet";
 import { setupMathWallet } from "@near-wallet-selector/math-wallet";
 import { setupMeteorWallet } from "@near-wallet-selector/meteor-wallet";
@@ -55,7 +54,6 @@ export const WalletSelectorContextProvider: React.FC<{
       network: "testnet",
       debug: true,
       modules: [
-        ...(await setupDefaultWallets()),
         setupNearWallet(),
         setupSender(),
         setupMathWallet(),

--- a/examples/react/contexts/WalletSelectorContext.tsx
+++ b/examples/react/contexts/WalletSelectorContext.tsx
@@ -22,8 +22,10 @@ import { distinctUntilChanged, map } from "rxjs";
 import { setupNeth } from "@near-wallet-selector/neth";
 import { setupOptoWallet } from "@near-wallet-selector/opto-wallet";
 import { setupFinerWallet } from "@near-wallet-selector/finer-wallet";
-import { CONTRACT_ID } from "../constants";
 import { Loading } from "../components/Loading";
+import { setupMyNearWallet } from "@near-wallet-selector/my-near-wallet";
+import { setupLedger } from "@near-wallet-selector/ledger";
+import { CONTRACT_ID } from "../constants";
 
 declare global {
   interface Window {
@@ -54,6 +56,8 @@ export const WalletSelectorContextProvider: React.FC<{
       network: "testnet",
       debug: true,
       modules: [
+        setupMyNearWallet(),
+        setupLedger(),
         setupNearWallet(),
         setupSender(),
         setupMathWallet(),

--- a/examples/react/contexts/WalletSelectorExportContext.tsx
+++ b/examples/react/contexts/WalletSelectorExportContext.tsx
@@ -5,7 +5,6 @@ import { setupWalletSelector } from "@near-wallet-selector/core";
 import type { WalletSelector, AccountState } from "@near-wallet-selector/core";
 import { setupExportSelectorModal } from "@near-wallet-selector/account-export";
 import type { WalletSelectorModal } from "@near-wallet-selector/account-export";
-import { setupDefaultWallets } from "@near-wallet-selector/default-wallets";
 import { setupNearWallet } from "@near-wallet-selector/near-wallet";
 import { setupHereWallet } from "@near-wallet-selector/here-wallet";
 import { setupSender } from "@near-wallet-selector/sender";
@@ -49,7 +48,6 @@ export const ExportAccountSelectorContextProvider: React.FC<{
       network: "testnet",
       debug: true,
       modules: [
-        ...(await setupDefaultWallets()),
         setupNearWallet(),
         setupSender(),
         setupMathWallet(),

--- a/examples/react/contexts/WalletSelectorExportContext.tsx
+++ b/examples/react/contexts/WalletSelectorExportContext.tsx
@@ -18,6 +18,8 @@ import { setupWalletConnect } from "@near-wallet-selector/wallet-connect";
 import { setupCoin98Wallet } from "@near-wallet-selector/coin98-wallet";
 import { setupOptoWallet } from "@near-wallet-selector/opto-wallet";
 import { Loading } from "../components/Loading";
+import { setupMyNearWallet } from "@near-wallet-selector/my-near-wallet";
+import { setupLedger } from "@near-wallet-selector/ledger";
 
 declare global {
   interface Window {
@@ -48,6 +50,8 @@ export const ExportAccountSelectorContextProvider: React.FC<{
       network: "testnet",
       debug: true,
       modules: [
+        setupMyNearWallet(),
+        setupLedger(),
         setupNearWallet(),
         setupSender(),
         setupMathWallet(),

--- a/packages/default-wallets/README.md
+++ b/packages/default-wallets/README.md
@@ -4,9 +4,7 @@ This is the Default Wallets package for NEAR Wallet Selector.
 
 This is the list of default wallets:
 
-- [My NEAR Wallet](https://www.npmjs.com/package/@near-wallet-selector/my-near-wallet) - Browser wallet.
-- [Ledger](https://www.npmjs.com/package/@near-wallet-selector/ledger) - Hardware wallet.
-
+>Note: This package will be deprecated and will not contain any wallets by default starting from next release (current version `v7.6.1`)
 
 ## Installation and Usage
 

--- a/packages/default-wallets/README.md
+++ b/packages/default-wallets/README.md
@@ -4,7 +4,7 @@ This is the Default Wallets package for NEAR Wallet Selector.
 
 This is the list of default wallets:
 
->Note: This package will be deprecated and will not contain any wallets by default starting from next release (current version `v7.6.1`)
+>**Note**: This package does not contain any wallets by default.
 
 ## Installation and Usage
 

--- a/packages/default-wallets/src/lib/default-wallets.ts
+++ b/packages/default-wallets/src/lib/default-wallets.ts
@@ -1,9 +1,7 @@
-import { setupMyNearWallet } from "@near-wallet-selector/my-near-wallet";
-import { setupLedger } from "@near-wallet-selector/ledger";
 import type { WalletModuleFactory } from "@near-wallet-selector/core";
 
 export const setupDefaultWallets = async (): Promise<
   Array<WalletModuleFactory>
 > => {
-  return [setupMyNearWallet(), setupLedger()];
+  return [];
 };


### PR DESCRIPTION
# Description

- Removed the `setupMyNearWallet()` and `setupLedger()` from `@near-wallet-selector/default-wallets`.
- The `@near-wallet-selector/default-wallets` will not return any wallets by default and should probably be deprecated in the next version.
- Removed references of `default-wallets` from the project/repo.

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [ ] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [x] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
