### PR TITLE
fix: Update generateSecretKey from account-export package

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "core-js": "^3.6.5",
     "crypto-browserify": "^3.12.0",
     "ethers": "^5.7.2",
-    "generate-password": "^1.7.0",
     "is-mobile": "^3.1.1",
     "near-api-js": "^1.1.0",
     "near-seed-phrase": "^0.2.0",

--- a/packages/account-export/src/lib/helpers/importAccount.spec.ts
+++ b/packages/account-export/src/lib/helpers/importAccount.spec.ts
@@ -1,6 +1,10 @@
 import type { AccountImportData } from "@near-wallet-selector/core";
 
-import { encryptAccountData, decryptAccountData } from "./importAccount";
+import {
+  encryptAccountData,
+  decryptAccountData,
+  generateSecretKey,
+} from "./importAccount";
 
 describe("import account utils", () => {
   const accountData: Array<AccountImportData> = [
@@ -14,8 +18,7 @@ describe("import account utils", () => {
     },
   ];
   it("encryption and decryption accountData", () => {
-    const secretKey = "mE@~H?QyyC8fpy,PC7sv#//w5W4SFfYO";
-
+    const secretKey = generateSecretKey();
     const ciphertext = encryptAccountData({ accountData, secretKey });
     const decryptedAccountData = decryptAccountData({ ciphertext, secretKey });
 
@@ -30,7 +33,7 @@ describe("import account utils", () => {
   });
 
   it("Fail to decryptAccountData if secretKey is missing", () => {
-    const secretKey = "mE@~H?QyyC8fpy,PC7sv#//w5W4SFfYO";
+    const secretKey = generateSecretKey();
     const invalidSecretKey = "";
     const ciphertext = encryptAccountData({ accountData, secretKey });
     expect(() =>
@@ -42,7 +45,7 @@ describe("import account utils", () => {
   });
 
   it("Fail to decryptAccountData if cipher text is missing", () => {
-    const secretKey = "mE@~H?QyyC8fpy,PC7sv#//w5W4SFfYO";
+    const secretKey = generateSecretKey();
     const ciphertext = "";
     expect(() =>
       decryptAccountData({

--- a/packages/account-export/src/lib/helpers/importAccount.ts
+++ b/packages/account-export/src/lib/helpers/importAccount.ts
@@ -1,4 +1,3 @@
-import generator from "generate-password";
 import nacl from "tweetnacl";
 import {
   decodeUTF8,
@@ -74,12 +73,7 @@ export const decryptAccountData = ({
   }
 };
 
-export const generateSecretKey = (): string =>
-  generator.generate({
-    length: nacl.secretbox.keyLength,
-    numbers: true,
-    strict: true,
-    lowercase: true,
-    uppercase: true,
-    symbols: true,
-  });
+export const generateSecretKey = (): string => {
+  const random = nacl.randomBytes(nacl.secretbox.keyLength);
+  return encodeBase64(random).substring(0, 32);
+};

--- a/packages/account-export/src/lib/helpers/importAccount.ts
+++ b/packages/account-export/src/lib/helpers/importAccount.ts
@@ -74,6 +74,6 @@ export const decryptAccountData = ({
 };
 
 export const generateSecretKey = (): string => {
-  const random = nacl.randomBytes(nacl.secretbox.keyLength);
-  return encodeBase64(random).substring(0, 32);
+  const random = nacl.randomBytes(24);
+  return encodeBase64(random);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9063,11 +9063,6 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
-generate-password@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/generate-password/-/generate-password-1.7.0.tgz#00ba4eb1e71f89a72307b0d6604ee0d4e7f5770c"
-  integrity sha512-WPCtlfy0jexf7W5IbwxGUgpIDvsZIohbI2DAq2Q6TSlKKis+G4GT9sxvPxrZUGL8kP6WUXMWNqYnxY6DDKAdFA==
-
 generic-names@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/generic-names/-/generic-names-4.0.0.tgz#0bd8a2fd23fe8ea16cbd0a279acd69c06933d9a3"


### PR DESCRIPTION
# Description

Fixes #680 

This PR contains implementation for changing `generateSecretKey` interface of account-export.
1. Removed  `generate-password` package
2. Update `generateSecretKey` to use `tweetnacl.randomBytes`
3. Minor update on `importAccount.spec` tests

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [x] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
