### PR TITLE
feat: add account-export for WELLDONE

### DIFF
--- a/packages/welldone-wallet/src/lib/welldone.ts
+++ b/packages/welldone-wallet/src/lib/welldone.ts
@@ -333,25 +333,6 @@ const WelldoneWallet: WalletBehaviourFactory<InjectedWallet> = async ({
     buildImportAccountsUrl() {
       return `https://docs.welldonestudio.io/contribution/202211-batch-import`;
     },
-
-    async importAccountsInSecureContext({ accounts }) {
-      if (!_state.wallet) {
-        throw new Error("Wallet is not installed");
-      }
-      const params: Array<string> = [];
-      // use batch import
-      accounts.forEach(({ privateKey }) => {
-        if (privateKey.slice(0, 8) === "ed25519:") {
-          params.push(privateKey.slice(8));
-        } else {
-          params.push(privateKey);
-        }
-      });
-      await _state.wallet.request("near", {
-        method: "experimental:near:importPrivatekey",
-        params: params,
-      });
-    },
   };
 };
 

--- a/packages/welldone-wallet/src/lib/welldone.ts
+++ b/packages/welldone-wallet/src/lib/welldone.ts
@@ -329,6 +329,29 @@ const WelldoneWallet: WalletBehaviourFactory<InjectedWallet> = async ({
 
       return results;
     },
+
+    buildImportAccountsUrl() {
+      return `https://docs.welldonestudio.io/contribution/202211-batch-import`;
+    },
+
+    async importAccountsInSecureContext({ accounts }) {
+      if (!_state.wallet) {
+        throw new Error("Wallet is not installed");
+      }
+      const params: Array<string> = [];
+      // use batch import
+      accounts.forEach(({ privateKey }) => {
+        if (privateKey.slice(0, 8) === "ed25519:") {
+          params.push(privateKey.slice(8));
+        } else {
+          params.push(privateKey);
+        }
+      });
+      await _state.wallet.request("near", {
+        method: "experimental:near:importPrivatekey",
+        params: params,
+      });
+    },
   };
 };
 
@@ -355,6 +378,7 @@ export function setupWelldoneWallet({
           "https://chrome.google.com/webstore/detail/welldone-wallet/bmkakpenjmcpfhhjadflneinmhboecjf",
         deprecated,
         available: installed,
+        useUrlAccountImport: true,
       },
       init: WelldoneWallet,
     };


### PR DESCRIPTION
# Description

Add support for `buildImportAccountsUrl` in WELLDONE Wallet.
We also implemented the `importAccountsInSecureContext` method, but we decided to use the `buildImportAccountsUrl` for now because there is a little problem when calling the method without creating a wallet. If we solve the problem before the wallet-migration event starts, we plan to use the `importsAccountsInSecureContext` method.

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [ ] FIX - a PR of this type patches a bug.
- [x] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
