### PR TITLE
Revert "chore(deps): bump rxjs from 7.6.0 to 7.8.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "react-dom": "18.2.0",
     "react-qr-code": "^2.0.11",
     "regenerator-runtime": "0.13.11",
-    "rxjs": "^7.8.0",
+    "rxjs": "^7.5.7",
     "stream-browserify": "^3.0.0",
     "tslib": "^2.3.0",
     "tweetnacl": "^1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14424,17 +14424,10 @@ rxjs@6, rxjs@6.6.7, rxjs@^6.5.4:
   dependencies:
     tslib "^1.9.0"
 
-rxjs@7.6.0:
+rxjs@7.6.0, rxjs@^7.5.1, rxjs@^7.5.5, rxjs@^7.5.7:
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.6.0.tgz#361da5362b6ddaa691a2de0b4f2d32028f1eb5a2"
   integrity sha512-DDa7d8TFNUalGC9VqXvQ1euWNN7sc63TrUCuM9J998+ViviahMIjKSOU7rfcgFOF+FCD71BhDRv4hrFz+ImDLQ==
-  dependencies:
-    tslib "^2.1.0"
-
-rxjs@^7.5.1, rxjs@^7.5.5, rxjs@^7.8.0:
-  version "7.8.0"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.0.tgz#90a938862a82888ff4c7359811a595e14e1e09a4"
-  integrity sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==
   dependencies:
     tslib "^2.1.0"
 


### PR DESCRIPTION
Reverts near/wallet-selector#675