### PR TITLE
herewallet: add buildImportAccountsUrl

### DIFF
--- a/packages/here-wallet/src/lib/index.ts
+++ b/packages/here-wallet/src/lib/index.ts
@@ -26,7 +26,8 @@ export function setupHereWallet({
       metadata: {
         name: "Here Wallet",
         description: "Mobile wallet for NEAR Protocol",
-        downloadUrl: "",
+        useUrlAccountImport: true,
+        downloadUrl: "https://herewallet.app",
         iconUrl,
         deprecated,
         available: true,

--- a/packages/here-wallet/src/lib/selector.ts
+++ b/packages/here-wallet/src/lib/selector.ts
@@ -39,6 +39,10 @@ export const initHereWallet: SelectorInit = async (config) => {
       return here.networkId;
     },
 
+    buildImportAccountsUrl() {
+      return `https://my.herewallet.app/import?network=${options.network.networkId}`;
+    },
+
     async account(id) {
       logger.log("HereWallet:account");
       return await here.account(id);


### PR DESCRIPTION

At the moment, this functionality is available in the testflight. We plan to release support for this feature to the upstore as soon as possible.

Testflight: https://testflight.apple.com/join

demo from development mode

https://user-images.githubusercontent.com/14349805/218285030-7a0e9799-b99f-4f82-9f19-4cf240cf1737.mp4

