### PR TITLE
fix: Check whether getPublicKey is available in sender.

### DIFF
--- a/packages/modal-ui/src/lib/components/Modal.tsx
+++ b/packages/modal-ui/src/lib/components/Modal.tsx
@@ -109,7 +109,7 @@ export const Modal: React.FC<ModalProps> = ({
       }
       hide();
     },
-    [hide]
+    [hide, emitter]
   );
 
   useEffect(() => {

--- a/packages/modal-ui/src/lib/components/WalletConnected.tsx
+++ b/packages/modal-ui/src/lib/components/WalletConnected.tsx
@@ -15,7 +15,7 @@ export const WalletConnected: React.FC<WalletConnectedProps> = ({
   return (
     <Fragment>
       <div className="nws-modal-header">
-        <h3 className="middleTitle"></h3>
+        <h3 className="middleTitle">{``}</h3>
         <CloseButton onClick={onCloseModal} />
       </div>
       <div className="connecting-wrapper">

--- a/packages/sender/src/lib/sender.ts
+++ b/packages/sender/src/lib/sender.ts
@@ -112,17 +112,20 @@ const Sender: WalletBehaviourFactory<InjectedWallet> = async ({
 
     const account = _state.wallet.account();
 
+    // When wallet is locked signer is empty an object {}.
+    if (!account!.connection.signer.getPublicKey) {
+      return [{ accountId, publicKey: undefined }];
+    }
+
+    const publicKey = await account!.connection.signer.getPublicKey(
+      account!.accountId,
+      options.network.networkId
+    );
+
     return [
       {
         accountId,
-        publicKey: account
-          ? (
-              await account.connection.signer.getPublicKey(
-                account.accountId,
-                options.network.networkId
-              )
-            ).toString()
-          : undefined,
+        publicKey: publicKey ? publicKey.toString() : undefined,
       },
     ];
   };


### PR DESCRIPTION
# Description

- Fixed eslint warnings on modal-ui.
- Avoid throwing an error when `getPublicKey` is not available in the `signer` of the Sender wallet.
- Fixes the case when the user is logged in but the wallet gets locked then the user gets signed out on the next page refresh, trying to sign in again would show the below error:

![sender](https://user-images.githubusercontent.com/95851345/219065364-f2023e66-43b9-4e9f-bec9-d7606d52bcf6.png)

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [x] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
