### PR TITLE
fix: Fix overview account list UI for Ledger

### DIFF
--- a/packages/modal-ui/src/lib/components/DerivationPath.tsx
+++ b/packages/modal-ui/src/lib/components/DerivationPath.tsx
@@ -133,6 +133,7 @@ export const DerivationPath: React.FC<DerivationPathProps> = ({
       setAccounts(resolvedAccounts);
 
       if (!multipleAccounts) {
+        setSelectedAccounts(resolvedAccounts);
         setRoute("OverviewAccounts");
       } else {
         setHeaderTitle(translate("modal.ledger.selectYourAccounts"));


### PR DESCRIPTION
# Description

- Fixed the bug in the ledger in the Overview Account List view of `modal-ui` to immediately populate the `selectedAccounts` when only one account is found.

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [x] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
