### PR TITLE
refactor: Revert type changes in `WalletSelectorContextValue` interface in react example

### DIFF
--- a/examples/react/components/ExportContent.tsx
+++ b/examples/react/components/ExportContent.tsx
@@ -3,10 +3,10 @@ import { Fragment } from "react";
 import { useExportAccountSelector } from "../contexts/WalletSelectorExportContext";
 
 const ExportContent: NextPage = () => {
-  const { ExportModal } = useExportAccountSelector();
+  const { exportModal } = useExportAccountSelector();
   return (
     <Fragment>
-      <button onClick={() => ExportModal.show()}>Open Modal</button>
+      <button onClick={() => exportModal.show()}>Open Modal</button>
       <p>
         The Export Accounts modal assists users in migrating their accounts to
         any Wallet Selector wallet supporting account imports. Any sensitive

--- a/examples/react/contexts/WalletSelectorContext.tsx
+++ b/examples/react/contexts/WalletSelectorContext.tsx
@@ -42,8 +42,8 @@ declare global {
 }
 
 interface WalletSelectorContextValue {
-  selector: WalletSelector | null;
-  modal: WalletSelectorModal | null;
+  selector: WalletSelector;
+  modal: WalletSelectorModal;
   accounts: Array<AccountState>;
   accountId: string | null;
 }
@@ -155,8 +155,8 @@ export const WalletSelectorContextProvider: React.FC<{
 
   const walletSelectorContextValue = useMemo<WalletSelectorContextValue>(
     () => ({
-      selector,
-      modal,
+      selector: selector!,
+      modal: modal!,
       accounts,
       accountId: accounts.find((account) => account.active)?.accountId || null,
     }),

--- a/examples/react/contexts/WalletSelectorExportContext.tsx
+++ b/examples/react/contexts/WalletSelectorExportContext.tsx
@@ -30,13 +30,13 @@ import { setupLedger } from "@near-wallet-selector/ledger";
 declare global {
   interface Window {
     importSelector: WalletSelector;
-    ExportModal: WalletSelectorModal;
+    exportModal: WalletSelectorModal;
   }
 }
 
 interface ExportAccountSelectorContextValue {
-  importSelector: WalletSelector | null;
-  ExportModal: WalletSelectorModal | null;
+  importSelector: WalletSelector;
+  exportModal: WalletSelectorModal;
   accounts: Array<AccountState>;
   accountId: string | null;
 }
@@ -105,7 +105,7 @@ export const ExportAccountSelectorContextProvider: React.FC<{
     // this is added for debugging purpose only
     // for more information (https://github.com/near/wallet-selector/pull/764#issuecomment-1498073367)
     window.importSelector = _selector;
-    window.ExportModal = _modal;
+    window.exportModal = _modal;
 
     setSelector(_selector);
     setModal(_modal);
@@ -139,8 +139,8 @@ export const ExportAccountSelectorContextProvider: React.FC<{
   const exportWalletSelectorContextValue =
     useMemo<ExportAccountSelectorContextValue>(
       () => ({
-        importSelector,
-        modal,
+        importSelector: importSelector!,
+        exportModal: modal!,
         accounts,
         accountId:
           accounts.find((account) => account.active)?.accountId || null,


### PR DESCRIPTION
# Description

- Removed `null` type from the `modal` and `selector` in `WalletSelectorContextValue` to avoid using the `!` everywhere in child components.

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [ ] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [x] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
