### PR TITLE
refactor: Removed unused onHide property from modal options

### DIFF
--- a/packages/modal-ui-js/src/lib/modal.types.ts
+++ b/packages/modal-ui-js/src/lib/modal.types.ts
@@ -9,7 +9,6 @@ export interface ModalOptions {
   methodNames?: Array<string>;
   theme?: Theme;
   description?: string;
-  onHide?: (hideReason: "user-triggered" | "wallet-navigation") => void;
 }
 
 export type ModalHideReason = "user-triggered" | "wallet-navigation";

--- a/packages/modal-ui-js/src/lib/render-modal.ts
+++ b/packages/modal-ui-js/src/lib/render-modal.ts
@@ -320,9 +320,7 @@ export function renderModal() {
       }
       modalState.container.children[0].classList.remove("open");
 
-      if (modalState.options.onHide) {
-        modalState.emitter.emit("onHide", { hideReason: "user-triggered" });
-      }
+      modalState.emitter.emit("onHide", { hideReason: "user-triggered" });
     });
 
   // TODO: Better handle `click` event listener for close-button.
@@ -337,9 +335,7 @@ export function renderModal() {
       if (target && target.className === "close-button") {
         modalState.container.children[0].classList.remove("open");
 
-        if (modalState.options.onHide) {
-          modalState.emitter.emit("onHide", { hideReason: "user-triggered" });
-        }
+        modalState.emitter.emit("onHide", { hideReason: "user-triggered" });
       }
     });
     initialRender = false;

--- a/packages/modal-ui/src/lib/modal.types.ts
+++ b/packages/modal-ui/src/lib/modal.types.ts
@@ -7,7 +7,6 @@ export interface ModalOptions {
   methodNames?: Array<string>;
   theme?: Theme;
   description?: string;
-  onHide?: (hideReason: "user-triggered" | "wallet-navigation") => void;
 }
 
 export type ModalHideReason = "user-triggered" | "wallet-navigation";


### PR DESCRIPTION
# Description
Removed unused `onHide` property from modal options.

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [ ] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [x] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
