### PR TITLE
chore: Disable rules from eslintrc.json config for neth-lib.ts file

### DIFF
--- a/packages/neth/.eslintrc.json
+++ b/packages/neth/.eslintrc.json
@@ -13,6 +13,14 @@
     {
       "files": ["*.js", "*.jsx"],
       "rules": {}
+    },
+    {
+      "files": ["neth-lib.ts"],
+      "rules": {
+        "@typescript-eslint/naming-convention": ["off"],
+        "@typescript-eslint/no-use-before-define": ["off"],
+        "@typescript-eslint/no-explicit-any": ["off"]
+      }
     }
   ]
 }

--- a/packages/neth/src/lib/neth-lib.ts
+++ b/packages/neth/src/lib/neth-lib.ts
@@ -1,6 +1,3 @@
-/*eslint @typescript-eslint/no-use-before-define: 1*/
-/*eslint @typescript-eslint/no-explicit-any: 1*/
-/*eslint @typescript-eslint/naming-convention: 1*/
 // @ts-nocheck
 
 import { ethers } from "ethers";


### PR DESCRIPTION
# Description

- This PR just properly disables the eslint rules that are in `neth-lib.ts` at the top of the file, so in the future PR's these warnings would not show:

![image](https://user-images.githubusercontent.com/95851345/230605850-649c6615-4365-4712-bcf5-397b7184f732.png)


# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [ ] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [x] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
