### PR TITLE
Moved instant link wallet signin call after state has been updated

### DIFF
--- a/packages/core/src/lib/services/wallet-modules/wallet-modules.service.ts
+++ b/packages/core/src/lib/services/wallet-modules/wallet-modules.service.ts
@@ -374,19 +374,6 @@ export class WalletModules {
 
     this.modules = modules;
 
-    for (let i = 0; i < this.modules.length; i++) {
-      if (this.modules[i].type === "instant-link") {
-        const wallet = (await this.modules[i].wallet()) as InstantLinkWallet;
-        if (wallet.metadata.runOnStartup) {
-          try {
-            await wallet.signIn({ contractId: wallet.getContractId() });
-          } catch (err) {
-            logger.error("Failed to sign in to wallet. " + err);
-          }
-        }
-      }
-    }
-
     const { accounts, contract, selectedWalletId, recentlySignedInWallets } =
       await this.resolveStorageState();
 
@@ -400,5 +387,22 @@ export class WalletModules {
         recentlySignedInWallets,
       },
     });
+
+    for (let i = 0; i < this.modules.length; i++) {
+      if (this.modules[i].type !== "instant-link") {
+        continue;
+      }
+
+      const wallet = (await this.modules[i].wallet()) as InstantLinkWallet;
+      if (!wallet.metadata.runOnStartup) {
+        continue;
+      }
+
+      try {
+        await wallet.signIn({ contractId: wallet.getContractId() });
+      } catch (err) {
+        logger.error("Failed to sign in to wallet. " + err);
+      }
+    }
   }
 }


### PR DESCRIPTION
# Description
Instant link wallets didn't have access to the store because the store update was happening after instant link `signIn()` method was called.

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [ ] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
