### PR TITLE
Add relayerUrl to configuration options

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -48,6 +48,7 @@ const selector = await setupWalletSelector({
 - `randomizeWalletOrder` (`boolean?`): Randomize wallets order in the `More` section of the UI.
 - `allowMultipleSelectors` (`boolean?`): Optionally allow creating new instances of wallet selector.
 - `languageCode` (`string?`): Optionally set specific ISO 639-1 two-letter language code, disables language detection based on the browser's settings.
+- `relayerUrl` (`string?`): Optionally set the URL that meta-transaction enabled wallet modules can use to submit DelegateActions to a relayer
 - `storage` (`StorageService?`): Async storage implementation. Useful when [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) is unavailable. Defaults to `localStorage`.
 - `modules` (`Array<WalletModuleFactory>`): List of wallets to support in your dApp.
 

--- a/packages/core/docs/api/selector.md
+++ b/packages/core/docs/api/selector.md
@@ -13,6 +13,8 @@
 - `optimizeWalletOrder` (`boolean`): Whether wallet order optimization is enabled.
 - `randomizeWalletOrder` (`boolean`): Weather wallet order randomization is enabled.
 - `languageCode` (`string?`): ISO 639-1 two-letter language code.
+- `relayerUrl` (`string?`): The URL where DelegateActions are sent by meta transaction enabled wallet modules.
+
 **Description**
 
 Resolved variation of the options passed to `setupWalletSelector`.

--- a/packages/core/src/lib/options.ts
+++ b/packages/core/src/lib/options.ts
@@ -36,6 +36,7 @@ export const resolveOptions = (params: WalletSelectorParams) => {
     debug: params.debug || false,
     optimizeWalletOrder: params.optimizeWalletOrder === false ? false : true,
     randomizeWalletOrder: params.randomizeWalletOrder || false,
+    relayerUrl: params.relayerUrl || undefined
   };
 
   return {

--- a/packages/core/src/lib/options.ts
+++ b/packages/core/src/lib/options.ts
@@ -36,7 +36,7 @@ export const resolveOptions = (params: WalletSelectorParams) => {
     debug: params.debug || false,
     optimizeWalletOrder: params.optimizeWalletOrder === false ? false : true,
     randomizeWalletOrder: params.randomizeWalletOrder || false,
-    relayerUrl: params.relayerUrl || undefined
+    relayerUrl: params.relayerUrl || undefined,
   };
 
   return {

--- a/packages/core/src/lib/options.types.ts
+++ b/packages/core/src/lib/options.types.ts
@@ -16,5 +16,5 @@ export interface Options {
   debug: boolean;
   optimizeWalletOrder: boolean;
   randomizeWalletOrder: boolean;
-  relayerUrl: string | undefined
+  relayerUrl: string | undefined;
 }

--- a/packages/core/src/lib/options.types.ts
+++ b/packages/core/src/lib/options.types.ts
@@ -16,4 +16,5 @@ export interface Options {
   debug: boolean;
   optimizeWalletOrder: boolean;
   randomizeWalletOrder: boolean;
+  relayerUrl: string | undefined
 }

--- a/packages/core/src/lib/wallet-selector.types.ts
+++ b/packages/core/src/lib/wallet-selector.types.ts
@@ -17,6 +17,7 @@ export interface WalletSelectorParams {
   allowMultipleSelectors?: boolean;
   randomizeWalletOrder?: boolean;
   languageCode?: SupportedLanguage;
+  relayerUrl?: string;
 }
 
 export type WalletSelectorStore = ReadOnlyStore;


### PR DESCRIPTION
# Description

Adds a new option, `relayerUrl`, to the wallet-selector configuration options.  This option is passed down to wallet modules so that wallets that support submitting meta transactions can do so based on its presence.

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [ ] FIX - a PR of this type patches a bug.
- [x] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
