### PR TITLE
docs: Added additional jsdoc descriptions and missing doc

### DIFF
--- a/packages/core/docs/api/selector.md
+++ b/packages/core/docs/api/selector.md
@@ -13,6 +13,7 @@
 - `debug` (`boolean`): Whether internal logging is enabled.
 - `optimizeWalletOrder` (`boolean`): Whether wallet order optimization is enabled.
 - `randomizeWalletOrder` (`boolean`): Weather wallet order randomization is enabled.
+- `allowMultipleSelectors` (`boolean?`): Wether to allow multiple wallet selector instances to be created.
 - `languageCode` (`string?`): ISO 639-1 two-letter language code.
 - `relayerUrl` (`string?`): The URL where DelegateActions are sent by meta transaction enabled wallet modules.
 

--- a/packages/core/src/lib/wallet-selector.types.ts
+++ b/packages/core/src/lib/wallet-selector.types.ts
@@ -9,14 +9,41 @@ import type { Subscription, StorageService } from "./services";
 import type { SupportedLanguage } from "./translate/translate";
 
 export interface WalletSelectorParams {
+  /**
+   * Resolved network configuration.
+   */
   network: NetworkId | Network;
+  /**
+   * List of wallet module factory functions
+   */
   modules: Array<WalletModuleFactory>;
+  /**
+   * Custom storage service
+   */
   storage?: StorageService;
+  /**
+   * Whether internal logging is enabled.
+   */
   debug?: boolean;
+  /**
+   * Whether wallet order optimization is enabled.
+   */
   optimizeWalletOrder?: boolean;
+  /**
+   * Wether to allow multiple wallet selector instances to be created.
+   */
   allowMultipleSelectors?: boolean;
+  /**
+   * Weather wallet order randomization is enabled.
+   */
   randomizeWalletOrder?: boolean;
+  /**
+   * ISO 639-1 two-letter language code.
+   */
   languageCode?: SupportedLanguage;
+  /**
+   * The URL where DelegateActions are sent by meta transaction enabled wallet modules.
+   */
   relayerUrl?: string;
 }
 


### PR DESCRIPTION
# Description
- Added `WalletSelectorParams` jsdoc descriptions
- Added `allowMultipleSelectors` missing doc

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [ ] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [x] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
