### PR TITLE
Bump peerDep NAJ to 2.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "ethers": "^5.7.2",
     "https-browserify": "^1.0.0",
     "is-mobile": "^3.1.1",
-    "near-api-js": "^2.1.0",
+    "near-api-js": "^2.1.3",
     "near-seed-phrase": "^0.2.0",
     "next": "12.2.3",
     "ngx-deploy-npm": "^4.3.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2728,17 +2728,17 @@
     "@motionone/dom" "^10.15.5"
     tslib "^2.3.1"
 
-"@near-js/accounts@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@near-js/accounts/-/accounts-0.1.0.tgz#3fd44ec290eed196babe31adeac5aea40ccf01dd"
-  integrity sha512-2VCo8qJRkzzw2p7Na/ApMqn18JXBdQQU9jQMWgcYA/U8yw39EsmXoMTUFsfI9vKoQOmeRgxR5efwQn48rtuJNw==
+"@near-js/accounts@0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@near-js/accounts/-/accounts-0.1.3.tgz#273f5ea7c05b0251011abb05485c6557b27e8e48"
+  integrity sha512-rmS1/WwIAWlfSMxHlDN3Q0YLOAscfrU+fkg9PsNI0sdzvdJ+bmiFqAoXi6L3D3KWZemteIudVEXMcegjreHnMg==
   dependencies:
-    "@near-js/crypto" "0.0.3"
-    "@near-js/providers" "0.0.3"
-    "@near-js/signers" "0.0.3"
-    "@near-js/transactions" "0.1.0"
-    "@near-js/types" "0.0.3"
-    "@near-js/utils" "0.0.3"
+    "@near-js/crypto" "0.0.4"
+    "@near-js/providers" "0.0.6"
+    "@near-js/signers" "0.0.4"
+    "@near-js/transactions" "0.2.0"
+    "@near-js/types" "0.0.4"
+    "@near-js/utils" "0.0.4"
     ajv "^8.11.2"
     ajv-formats "^2.1.1"
     bn.js "5.2.1"
@@ -2746,105 +2746,105 @@
     depd "^2.0.0"
     near-abi "0.1.1"
 
-"@near-js/crypto@0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@near-js/crypto/-/crypto-0.0.3.tgz#4a33e526ab5fa75b703427067985694a279ff8bd"
-  integrity sha512-3WC2A1a1cH8Cqrx+0iDjp1ASEEhxN/KHEMENYb0KZH6Hp5bXIY7Akt4quC7JlgJS5ESvEiLa40tS5h0zAhBWGw==
+"@near-js/crypto@0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@near-js/crypto/-/crypto-0.0.4.tgz#7bb991da25f06096de51466c6331cb185314fad8"
+  integrity sha512-2mSIVv6mZway1rQvmkktrXAFoUvy7POjrHNH3LekKZCMCs7qMM/23Hz2+APgxZPqoV2kjarSNOEYJjxO7zQ/rQ==
   dependencies:
-    "@near-js/types" "0.0.3"
+    "@near-js/types" "0.0.4"
     bn.js "5.2.1"
     borsh "^0.7.0"
     tweetnacl "^1.0.1"
 
-"@near-js/keystores-browser@0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@near-js/keystores-browser/-/keystores-browser-0.0.3.tgz#110b847cd9c358076c2401e9462cc1140e12a908"
-  integrity sha512-Ve/JQ1SBxdNk3B49lElJ8Y54AoBY+yOStLvdnUIpe2FBOczzwDCkcnPcMDV0NMwVlHpEnOWICWHbRbAkI5Vs+A==
+"@near-js/keystores-browser@0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@near-js/keystores-browser/-/keystores-browser-0.0.4.tgz#9c1130e2c0becf6bb9cfaaa7594ad38ed25585bd"
+  integrity sha512-bzwClm3jNlWJrb8wqMunP3rrcG1hS3rD58KKhDvHXy8Dtg9VVUgrfr3Csu9oTnjG+rAPZGOynunaoOQVqju/Aw==
   dependencies:
-    "@near-js/crypto" "0.0.3"
-    "@near-js/keystores" "0.0.3"
+    "@near-js/crypto" "0.0.4"
+    "@near-js/keystores" "0.0.4"
 
-"@near-js/keystores-node@0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@near-js/keystores-node/-/keystores-node-0.0.3.tgz#074e0aadb55b2ceda43f4389b253193d7a7d7057"
-  integrity sha512-8Yry0jARK2R2+V4KjEganrnpXhosArwgpyrbvtvptwLLNNFvo/AY1ekGV1EpQ3BVst1qvf5R5TXnIti9OBmEHw==
+"@near-js/keystores-node@0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@near-js/keystores-node/-/keystores-node-0.0.4.tgz#00187deef2d43afeb20c01a0e63ec50af77cfc85"
+  integrity sha512-vOdVhAuQ8BVefEluj+TSNzjXHA/1xjEgK7pwBUA1kgpcY8/hZ0Jj4PcvPD17wQNSyP+NJF5H9ed3pP2h2VH+1A==
   dependencies:
-    "@near-js/crypto" "0.0.3"
-    "@near-js/keystores" "0.0.3"
+    "@near-js/crypto" "0.0.4"
+    "@near-js/keystores" "0.0.4"
 
-"@near-js/keystores@0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@near-js/keystores/-/keystores-0.0.3.tgz#eb1e8e06936da166b5ed8dab3123eaa1bf7a8dab"
-  integrity sha512-mnwLYUt4Td8u1I4QE1FBx2d9hMt3ofiriE93FfOluJ4XiqRqVFakFYiHg6pExg5iEkej/sXugBUFeQ4QizUnew==
+"@near-js/keystores@0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@near-js/keystores/-/keystores-0.0.4.tgz#da03069497bb14741a4d97f7ad4746baf9a09ea7"
+  integrity sha512-+vKafmDpQGrz5py1liot2hYSjPGXwihveeN+BL11aJlLqZnWBgYJUWCXG+uyGjGXZORuy2hzkKK6Hi+lbKOfVA==
   dependencies:
-    "@near-js/crypto" "0.0.3"
-    "@near-js/types" "0.0.3"
+    "@near-js/crypto" "0.0.4"
+    "@near-js/types" "0.0.4"
 
-"@near-js/providers@0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@near-js/providers/-/providers-0.0.3.tgz#95f71f9d81139f9eb54a287f859785d75ed007f3"
-  integrity sha512-NblqLsPfKIWKwQZh+dLZs0nQ+Dx9/MrP1uagRmxZd+aEN/IgYr7Q0mdT77WHQKrsgXiMnipknRZxeoY5bImCuw==
+"@near-js/providers@0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@near-js/providers/-/providers-0.0.6.tgz#47b9632be2ad5c5a5295840eea8fb508d90735ba"
+  integrity sha512-PgWCcgDgCAgnyxq2IPZD2vbpQzXt4XK4cN2SbUZsDwJkBaDQEozXMnyShG/Ie2eRoz5aD9dRHpdLDpTieAw5kA==
   dependencies:
-    "@near-js/transactions" "0.1.0"
-    "@near-js/types" "0.0.3"
-    "@near-js/utils" "0.0.3"
+    "@near-js/transactions" "0.2.0"
+    "@near-js/types" "0.0.4"
+    "@near-js/utils" "0.0.4"
     bn.js "5.2.1"
     borsh "^0.7.0"
     http-errors "^1.7.2"
   optionalDependencies:
     node-fetch "^2.6.1"
 
-"@near-js/signers@0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@near-js/signers/-/signers-0.0.3.tgz#bfc8386613295fc6b51982cf65c79bdc9307aa5e"
-  integrity sha512-u1R+DDIua5PY1PDFnpVYqdMgQ7c4dyeZsfqMjE7CtgzdqupgTYCXzJjBubqMlAyAx843PoXmLt6CSSKcMm0WUA==
+"@near-js/signers@0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@near-js/signers/-/signers-0.0.4.tgz#a1904ccc718d6f87b05cd2e168f33bde0cfb269a"
+  integrity sha512-xCglo3U/WIGsz/izPGFMegS5Q3PxOHYB8a1E7RtVhNm5QdqTlQldLCm/BuMg2G/u1l1ZZ0wdvkqRTG9joauf3Q==
   dependencies:
-    "@near-js/crypto" "0.0.3"
-    "@near-js/keystores" "0.0.3"
+    "@near-js/crypto" "0.0.4"
+    "@near-js/keystores" "0.0.4"
     js-sha256 "^0.9.0"
 
-"@near-js/transactions@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@near-js/transactions/-/transactions-0.1.0.tgz#a03f529da6bb2eaf9dd0590093f2d0763b8ae72a"
-  integrity sha512-OrrDFqhX0rtH+6MV3U3iS+zmzcPQI+L4GJi9na4Uf8FgpaVPF0mtSmVrpUrS5CC3LwWCzcYF833xGYbXOV4Kfg==
+"@near-js/transactions@0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@near-js/transactions/-/transactions-0.2.0.tgz#c23b73d94ebcf8b4cd1b5d2176f620e499a143ca"
+  integrity sha512-ejcYkDz0tdQ40i/7ETV23fL5hp/pIiNXYmh4bNuZ9FjeowBODtlXGLqjG3wZbCygHCirJKilmVi5BtM+rh4ovQ==
   dependencies:
-    "@near-js/crypto" "0.0.3"
-    "@near-js/signers" "0.0.3"
-    "@near-js/types" "0.0.3"
-    "@near-js/utils" "0.0.3"
+    "@near-js/crypto" "0.0.4"
+    "@near-js/signers" "0.0.4"
+    "@near-js/types" "0.0.4"
+    "@near-js/utils" "0.0.4"
     bn.js "5.2.1"
     borsh "^0.7.0"
     js-sha256 "^0.9.0"
 
-"@near-js/types@0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@near-js/types/-/types-0.0.3.tgz#d504222469f4d50a6299c522fb6905ba10905bd6"
-  integrity sha512-gC3iGUT+r2JjVsE31YharT+voat79ToMUMLCGozHjp/R/UW1M2z4hdpqTUoeWUBGBJuVc810gNTneHGx0jvzwQ==
+"@near-js/types@0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@near-js/types/-/types-0.0.4.tgz#d941689df41c850aeeeaeb9d498418acec515404"
+  integrity sha512-8TTMbLMnmyG06R5YKWuS/qFG1tOA3/9lX4NgBqQPsvaWmDsa+D+QwOkrEHDegped0ZHQwcjAXjKML1S1TyGYKg==
   dependencies:
     bn.js "5.2.1"
 
-"@near-js/utils@0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@near-js/utils/-/utils-0.0.3.tgz#5e631f3dbdb7f0c6985bcbef08644db83b519978"
-  integrity sha512-J72n/EL0VfLRRb4xNUF4rmVrdzMkcmkwJOhBZSTWz3PAZ8LqNeU9ZConPfMvEr6lwdaD33ZuVv70DN6IIjPr1A==
+"@near-js/utils@0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@near-js/utils/-/utils-0.0.4.tgz#1a387f81974ebbfa4521c92590232be97e3335dd"
+  integrity sha512-mPUEPJbTCMicGitjEGvQqOe8AS7O4KkRCxqd0xuE/X6gXF1jz1pYMZn4lNUeUz2C84YnVSGLAM0o9zcN6Y4hiA==
   dependencies:
-    "@near-js/types" "0.0.3"
+    "@near-js/types" "0.0.4"
     bn.js "5.2.1"
     depd "^2.0.0"
     mustache "^4.0.0"
 
-"@near-js/wallet-account@0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@near-js/wallet-account/-/wallet-account-0.0.3.tgz#81f6a0fc6d4f4ffcdb2c895186fdd86baf9a7b44"
-  integrity sha512-FD/v0z9HzXfmEerfhRde9HUOojh9IM7nXxCJZm6UF49aA2ztlaqbGvmXSfD+yvf3WG58pC5eUFvDl1sdco8jhQ==
+"@near-js/wallet-account@0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@near-js/wallet-account/-/wallet-account-0.0.6.tgz#478ba16340a55ca2d28f4bf8e2566ee9842e36f1"
+  integrity sha512-oyxQM6tf2WG4it+8IMu0ZQ6pa4OQhF1o+Q33Rb2+4Mb1Fm+L7MO7PJoCPcveCIFYVPOjSVk0oyoz1KbE3y62gA==
   dependencies:
-    "@near-js/accounts" "0.1.0"
-    "@near-js/crypto" "0.0.3"
-    "@near-js/keystores" "0.0.3"
-    "@near-js/signers" "0.0.3"
-    "@near-js/transactions" "0.1.0"
-    "@near-js/types" "0.0.3"
-    "@near-js/utils" "0.0.3"
+    "@near-js/accounts" "0.1.3"
+    "@near-js/crypto" "0.0.4"
+    "@near-js/keystores" "0.0.4"
+    "@near-js/signers" "0.0.4"
+    "@near-js/transactions" "0.2.0"
+    "@near-js/types" "0.0.4"
+    "@near-js/utils" "0.0.4"
     bn.js "5.2.1"
     borsh "^0.7.0"
 
@@ -12453,22 +12453,22 @@ near-api-js@^0.45.1:
     text-encoding-utf-8 "^1.0.2"
     tweetnacl "^1.0.1"
 
-near-api-js@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/near-api-js/-/near-api-js-2.1.0.tgz#dbdef65bbfb735de8f891309e198c27254fbe9c5"
-  integrity sha512-JH+xwBPCo8GZlJoJuStI38nfyBIT21iGXofq/X/ewi2pvMFAgpqCantiGgbm0zujyQLPwQPmA+PMm5VKC8y+nQ==
+near-api-js@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/near-api-js/-/near-api-js-2.1.3.tgz#2e894c90cee33ef0c2101951375d15662753b443"
+  integrity sha512-ggCQE/oGrrbr9dEtXZ9QU7XAf6RgISs+bfD7Q5I2QsQN45XgV85IA4c8KDLzo66u7FTX39gubKz3Ghieo6D7YA==
   dependencies:
-    "@near-js/accounts" "0.1.0"
-    "@near-js/crypto" "0.0.3"
-    "@near-js/keystores" "0.0.3"
-    "@near-js/keystores-browser" "0.0.3"
-    "@near-js/keystores-node" "0.0.3"
-    "@near-js/providers" "0.0.3"
-    "@near-js/signers" "0.0.3"
-    "@near-js/transactions" "0.1.0"
-    "@near-js/types" "0.0.3"
-    "@near-js/utils" "0.0.3"
-    "@near-js/wallet-account" "0.0.3"
+    "@near-js/accounts" "0.1.3"
+    "@near-js/crypto" "0.0.4"
+    "@near-js/keystores" "0.0.4"
+    "@near-js/keystores-browser" "0.0.4"
+    "@near-js/keystores-node" "0.0.4"
+    "@near-js/providers" "0.0.6"
+    "@near-js/signers" "0.0.4"
+    "@near-js/transactions" "0.2.0"
+    "@near-js/types" "0.0.4"
+    "@near-js/utils" "0.0.4"
+    "@near-js/wallet-account" "0.0.6"
     ajv "^8.11.2"
     ajv-formats "^2.1.1"
     bn.js "5.2.1"


### PR DESCRIPTION
Chasing some serialization issues with borsh, and it looks like our yarn.lock here may have been causing 2 different versions of NAJ to load -- this bumps the entry in the yarn.lock to the current version of NAJ