### PR TITLE
chore: Bump @walletconnect/types from 2.5.2 to 2.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "@types/w3c-web-usb": "^1.0.5",
     "@typescript-eslint/eslint-plugin": "5.13.0",
     "@typescript-eslint/parser": "5.13.0",
-    "@walletconnect/types": "^2.5.2",
+    "@walletconnect/types": "^2.7.2",
     "babel-jest": "27.2.3",
     "cypress": "^9.1.0",
     "eslint": "~8.15.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5159,7 +5159,7 @@
   dependencies:
     tslib "1.14.1"
 
-"@walletconnect/types@2.7.2", "@walletconnect/types@^2.5.2":
+"@walletconnect/types@2.7.2", "@walletconnect/types@^2.7.2":
   version "2.7.2"
   resolved "https://registry.yarnpkg.com/@walletconnect/types/-/types-2.7.2.tgz#508d1755110864dee294f955e09b7da3f8ee0064"
   integrity sha512-1O2UefakZpT0ErRfEAXY7Ls3qdUrKDky/DsK088xR6klyfkQOx+aSVH0fJYLhmnqPTuvp3lrqNbsDc0s6/6nvg==


### PR DESCRIPTION
# Description

- Bumped this dependency manally since dependabot got "confused" once the `@walletconnect/sign-client` was merged and the other original PR was closed https://github.com/near/wallet-selector/pull/795

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [ ] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [x] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
