### PR TITLE
Add wallet url to metadata of browser wallets

### DIFF
--- a/packages/core/docs/api/wallet.md
+++ b/packages/core/docs/api/wallet.md
@@ -63,7 +63,7 @@ There are four wallet types:
 
 **Description**
 
-Returns meta information about the wallet such as `name`, `description`, `iconUrl` , `deprecated` and `available` but can include wallet-specific properties such as `downloadUrl` and `useUrlAccountImport` for injected wallets or `contractId` and `runOnStartup` for instant-link wallets.
+Returns meta information about the wallet such as `name`, `description`, `iconUrl` , `deprecated` and `available` but can include wallet-specific properties such as `downloadUrl` and `useUrlAccountImport` for injected wallets or `contractId`,  `runOnStartup` for instant-link wallets and `walletUrl` for browser wallets.
 
 **Example**
 

--- a/packages/core/src/lib/wallet/wallet.types.ts
+++ b/packages/core/src/lib/wallet/wallet.types.ts
@@ -151,7 +151,7 @@ type BaseWallet<
    */
   type: Type;
   /**
-   * Returns meta information about the wallet such as `name`, `description`, `iconUrl`, `deprecated` and `available` but can include wallet-specific properties such as `downloadUrl` and `useUrlAccountImport` for injected wallets or `contractId` and `runOnStartup` for instant-link wallets.
+   * Returns meta information about the wallet such as `name`, `description`, `iconUrl`, `deprecated` and `available` but can include wallet-specific properties such as `downloadUrl` and `useUrlAccountImport` for injected wallets or `contractId`, `runOnStartup` for instant-link wallets and  walletUrl for browser wallets.
    */
   metadata: Metadata;
 } & Behaviour;
@@ -179,6 +179,11 @@ export type BrowserWalletMetadata = BaseWalletMetadata & {
    * Optional for browser wallets (e.g MyNearWallet and HERE Wallet). After failing to sign in where to redirect.
    */
   failureUrl?: string;
+
+  /**
+   * The URL of the wallet exposed in the metadata of the module.
+   */
+  walletUrl: string;
 };
 
 interface BrowserWalletSignInParams extends SignInParams {

--- a/packages/modal-ui-js/src/lib/components/GetAWallet.ts
+++ b/packages/modal-ui-js/src/lib/components/GetAWallet.ts
@@ -1,4 +1,8 @@
-import type { InjectedWallet, ModuleState } from "@near-wallet-selector/core";
+import type {
+  InjectedWallet,
+  ModuleState,
+  BrowserWallet,
+} from "@near-wallet-selector/core";
 import { modalState } from "../modal";
 import { renderWhatIsAWallet } from "./WhatIsAWallet";
 import { translate } from "@near-wallet-selector/core";
@@ -8,27 +12,14 @@ function goToWallet(module: ModuleState) {
     return;
   }
 
-  const { networkId } = modalState.selector.options.network;
   let url = "";
 
   if (module.type === "injected") {
     url = (module as ModuleState<InjectedWallet>).metadata.downloadUrl;
   }
 
-  // TODO: improve links to wallets other than injected type.
-  if (module.id === "my-near-wallet") {
-    const subdomain = networkId === "testnet" ? "testnet" : "app";
-    url = `https://${subdomain}.mynearwallet.com`;
-  }
-
-  if (module.id === "opto-wallet") {
-    const subdomain = networkId === "testnet" ? "app.testnet" : "app";
-    url = `https://${subdomain}.optowallet.com`;
-  }
-
-  if (module.id === "near-wallet") {
-    const subdomain = networkId === "testnet" ? "testnet." : "";
-    url = `https://wallet.${subdomain}near.org`;
+  if (module.type === "browser") {
+    url = (module as ModuleState<BrowserWallet>).metadata.walletUrl;
   }
 
   if ((url === "" && module.type === "bridge") || module.type === "hardware") {

--- a/packages/modal-ui-js/src/lib/components/GetAWallet.ts
+++ b/packages/modal-ui-js/src/lib/components/GetAWallet.ts
@@ -31,10 +31,6 @@ function goToWallet(module: ModuleState) {
     url = `https://wallet.${subdomain}near.org`;
   }
 
-  if (module.id === "here-wallet") {
-    url = "https://herewallet.app/";
-  }
-
   if ((url === "" && module.type === "bridge") || module.type === "hardware") {
     return;
   }

--- a/packages/modal-ui-js/src/lib/components/GetAWallet.ts
+++ b/packages/modal-ui-js/src/lib/components/GetAWallet.ts
@@ -112,6 +112,9 @@ export async function renderGetAWallet() {
   for (let i = 0; i < filteredModules.length; i++) {
     const { type, id } = filteredModules[i];
     const { typeFullName, qrIcon } = getTypeNameAndIcon(id, type);
+    const walletUrl = getWalletUrl(filteredModules[i]);
+
+    console.log({ walletUrl });
 
     document.getElementById("wallets")?.insertAdjacentHTML(
       "beforeend",
@@ -121,7 +124,7 @@ export async function renderGetAWallet() {
       }">
       <div class="small-icon">
       ${
-        qrIcon
+        qrIcon && walletUrl
           ? `
         <svg
           width="18"
@@ -176,7 +179,8 @@ export async function renderGetAWallet() {
             fill="#4C5155"
           />
         </svg>`
-          : `
+          : !qrIcon && walletUrl
+          ? `
         <svg
             width="18"
             height="16"
@@ -203,6 +207,7 @@ export async function renderGetAWallet() {
               stroke-linejoin="round"
             />
           </svg>`
+          : ``
       }
 
       </div>

--- a/packages/modal-ui-js/src/lib/components/GetAWallet.ts
+++ b/packages/modal-ui-js/src/lib/components/GetAWallet.ts
@@ -7,7 +7,7 @@ import { modalState } from "../modal";
 import { renderWhatIsAWallet } from "./WhatIsAWallet";
 import { translate } from "@near-wallet-selector/core";
 
-function goToWallet(module: ModuleState) {
+function getWalletUrl(module: ModuleState) {
   if (!modalState) {
     return;
   }
@@ -22,11 +22,7 @@ function goToWallet(module: ModuleState) {
     url = (module as ModuleState<BrowserWallet>).metadata.walletUrl;
   }
 
-  if ((url === "" && module.type === "bridge") || module.type === "hardware") {
-    return;
-  }
-
-  window.open(url, "_blank");
+  return url;
 }
 
 const getTypeNameAndIcon = (
@@ -235,7 +231,11 @@ export async function renderGetAWallet() {
         if (!module) {
           return;
         }
-        goToWallet(module);
+        const walletUrl = getWalletUrl(module);
+
+        if (walletUrl) {
+          window.open(walletUrl, "_blank");
+        }
       });
     }
   );

--- a/packages/modal-ui/src/lib/components/WalletHome.tsx
+++ b/packages/modal-ui/src/lib/components/WalletHome.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 
 import type {
+  BrowserWallet,
   InjectedWallet,
   ModuleState,
   WalletSelector,
@@ -38,27 +39,14 @@ export const WalletHome: React.FC<WalletHomeProps> = ({
   }, []);
 
   const goToWallet = (module: ModuleState) => {
-    const { networkId } = selector.options.network;
     let url = "";
 
     if (module.type === "injected") {
       url = (module as ModuleState<InjectedWallet>).metadata.downloadUrl;
     }
 
-    // TODO: improve links to wallets other than injected type.
-    if (module.id === "my-near-wallet") {
-      const subdomain = networkId === "testnet" ? "testnet" : "app";
-      url = `https://${subdomain}.mynearwallet.com`;
-    }
-
-    if (module.id === "opto-wallet") {
-      const subdomain = networkId === "testnet" ? "app.testnet" : "app";
-      url = `https://${subdomain}.optowallet.com`;
-    }
-
-    if (module.id === "near-wallet") {
-      const subdomain = networkId === "testnet" ? "testnet." : "";
-      url = `https://wallet.${subdomain}near.org`;
+    if (module.type === "browser") {
+      url = (module as ModuleState<BrowserWallet>).metadata.walletUrl;
     }
 
     if (

--- a/packages/modal-ui/src/lib/components/WalletHome.tsx
+++ b/packages/modal-ui/src/lib/components/WalletHome.tsx
@@ -38,7 +38,7 @@ export const WalletHome: React.FC<WalletHomeProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const goToWallet = (module: ModuleState) => {
+  const getWalletUrl = (module: ModuleState) => {
     let url = "";
 
     if (module.type === "injected") {
@@ -49,14 +49,7 @@ export const WalletHome: React.FC<WalletHomeProps> = ({
       url = (module as ModuleState<BrowserWallet>).metadata.walletUrl;
     }
 
-    if (
-      (url === "" && module.type === "bridge") ||
-      module.type === "hardware"
-    ) {
-      return;
-    }
-
-    window.open(url, "_blank");
+    return url;
   };
 
   const getTypeNameAndIcon = (
@@ -128,13 +121,16 @@ export const WalletHome: React.FC<WalletHomeProps> = ({
             const { iconUrl, name } = module.metadata;
             const { type, id } = module;
             const { typeFullName, qrIcon } = getTypeNameAndIcon(id, type);
+            const walletUrl = getWalletUrl(module);
             return (
               <div
                 tabIndex={0}
                 className={`single-wallet-get ${module.id}`}
                 key={module.id}
                 onClick={() => {
-                  goToWallet(module);
+                  if (walletUrl) {
+                    window.open(walletUrl, "_blank");
+                  }
                 }}
               >
                 <div className={"small-icon"}>

--- a/packages/modal-ui/src/lib/components/WalletHome.tsx
+++ b/packages/modal-ui/src/lib/components/WalletHome.tsx
@@ -61,10 +61,6 @@ export const WalletHome: React.FC<WalletHomeProps> = ({
       url = `https://wallet.${subdomain}near.org`;
     }
 
-    if (module.id === "here-wallet") {
-      url = "https://herewallet.app/";
-    }
-
     if (
       (url === "" && module.type === "bridge") ||
       module.type === "hardware"

--- a/packages/modal-ui/src/lib/components/WalletHome.tsx
+++ b/packages/modal-ui/src/lib/components/WalletHome.tsx
@@ -134,7 +134,7 @@ export const WalletHome: React.FC<WalletHomeProps> = ({
                 }}
               >
                 <div className={"small-icon"}>
-                  {qrIcon && (
+                  {qrIcon && walletUrl && (
                     <svg
                       width="18"
                       height="16"
@@ -189,7 +189,7 @@ export const WalletHome: React.FC<WalletHomeProps> = ({
                       />
                     </svg>
                   )}
-                  {!qrIcon && (
+                  {!qrIcon && walletUrl && (
                     <svg
                       width="18"
                       height="16"

--- a/packages/my-near-wallet/src/lib/my-near-wallet.ts
+++ b/packages/my-near-wallet/src/lib/my-near-wallet.ts
@@ -237,7 +237,7 @@ export function setupMyNearWallet({
   successUrl = "",
   failureUrl = "",
 }: MyNearWalletParams = {}): WalletModuleFactory<BrowserWallet> {
-  return async () => {
+  return async (moduleOptions) => {
     return {
       id: "my-near-wallet",
       type: "browser",
@@ -250,6 +250,7 @@ export function setupMyNearWallet({
         available: true,
         successUrl,
         failureUrl,
+        walletUrl: resolveWalletUrl(moduleOptions.options.network, walletUrl),
       },
       init: (options) => {
         return MyNearWallet({

--- a/packages/opto-wallet/src/lib/opto-wallet.ts
+++ b/packages/opto-wallet/src/lib/opto-wallet.ts
@@ -235,7 +235,7 @@ export function setupOptoWallet({
   iconUrl = icon,
   deprecated = false,
 }: OptoWalletParams = {}): WalletModuleFactory<BrowserWallet> {
-  return async () => {
+  return async (moduleOptions) => {
     if (!window.opto) {
       return null;
     }
@@ -249,6 +249,7 @@ export function setupOptoWallet({
         iconUrl,
         deprecated,
         available: true,
+        walletUrl: resolveWalletUrl(moduleOptions.options.network, walletUrl),
       },
       init: (options) => {
         return OptoWallet({


### PR DESCRIPTION
# Description

- Added `walletUrl` to the `metadata` of Browser Wallets.
- Exposed `walletUrl` for MyNearWallet, Near Wallet and Opto Wallet.
- Refactored `Get Wallets` view to make use of the new `walletUrl` and removed unnecessary checks for these wallets."
- Updated docs.

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [ ] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
