### PR TITLE
feat: Updated the onComplete props structure on export account

### DIFF
--- a/examples/react/contexts/WalletSelectorExportContext.tsx
+++ b/examples/react/contexts/WalletSelectorExportContext.tsx
@@ -95,8 +95,10 @@ export const ExportAccountSelectorContextProvider: React.FC<{
      */
     const _modal = setupExportSelectorModal(_selector, {
       accounts: [],
-      onComplete: (completedAccounts) => {
-        console.log("Transfer Completed: ", completedAccounts);
+      onComplete: (completeProps) => {
+        console.log(
+          `${completeProps.accounts} exported to ${completeProps.walletName}`
+        );
       },
     });
     const state = _selector.store.getState();

--- a/packages/account-export/src/lib/components/ExportAccount.tsx
+++ b/packages/account-export/src/lib/components/ExportAccount.tsx
@@ -24,6 +24,10 @@ import { Complete } from "./Complete";
 
 import { encryptAccountData } from "../helpers";
 
+type CompleteProps = {
+  accounts: Array<string>;
+  walletName: string;
+};
 interface ExportAccountProps {
   alertMessage: string | null;
   module?: ModuleState;
@@ -33,7 +37,7 @@ interface ExportAccountProps {
   accounts: Array<AccountImportData>;
   selector: WalletSelector;
   wallet: ModuleState<Wallet>;
-  onComplete?: (accounts: Array<string>) => void;
+  onComplete?: (object: CompleteProps) => void;
 }
 
 const EXPORT_ACCOUNT_STEPS = {
@@ -300,7 +304,10 @@ export const ExportAccount: React.FC<ExportAccountProps> = ({
 
   const onTransferComplete = () => {
     if (onComplete) {
-      onComplete(selectedAccounts);
+      onComplete({
+        accounts: selectedAccounts,
+        walletName: module?.metadata.name || "Unknown",
+      });
     }
   };
 

--- a/packages/account-export/src/lib/index.types.ts
+++ b/packages/account-export/src/lib/index.types.ts
@@ -5,11 +5,16 @@ import type {
 
 export type Theme = "dark" | "light" | "auto";
 
+type ExportSelectorOnCompleteParams = {
+  accounts: Array<string>;
+  walletName: string;
+};
+
 export interface ExportSelectorOptions {
   theme?: Theme;
   description?: string;
   accounts: Array<AccountImportData>;
-  onComplete?: (accounts: Array<string>) => void;
+  onComplete?: (completeProps: ExportSelectorOnCompleteParams) => void;
 }
 
 export interface WalletSelectorModal {


### PR DESCRIPTION
# Description

This PR contains minor change on the structure of onComplete props from 
Array<string> to { accounts: Array<string> , walletName string}

As outcome, console.log on example should be similar to:
<img width="1017" alt="image" src="https://github.com/near/wallet-selector/assets/6027014/4d97f5de-6daf-4c3c-ae29-9ea2b8c68d47">


# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [ ] FIX - a PR of this type patches a bug.
- [x] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
