### PR TITLE
Add script to update the type field path

### DIFF
--- a/scripts/update-package-json.js
+++ b/scripts/update-package-json.js
@@ -1,0 +1,43 @@
+const fs = require('fs').promises;
+const path = require('path');
+
+const packagesDirectory = path.join(__dirname, '../dist/packages');
+
+// Replace double backslashes with forward slashes in a path
+const fixPath = path => path.replace(/\\/g, '/').replace(/\/\//g, '/');
+
+// Update types field in package.json
+async function updatePackageJSONTypeField(packageName) {
+  const packagePath = path.join(packagesDirectory, packageName);
+  const packageJsonPath = path.join(packagePath, 'package.json');
+
+  try {
+    const packageJsonContent = await fs.readFile(packageJsonPath, 'utf8');
+    const packageJson = JSON.parse(packageJsonContent);
+
+    if (packageJson.types) {
+      packageJson.types = fixPath(packageJson.types);
+      await fs.writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2));
+      console.log(`Updated package.json for ${packageName}`);
+    } else {
+      console.log(`No 'types' field found in package.json for ${packageName}`);
+    }
+  } catch (error) {
+    console.error(`Error updating package.json for ${packageName}:`, error);
+  }
+}
+
+// Update all packages
+async function updateAllPackagesTypeField() {
+  try {
+    const packageNames = await fs.readdir(packagesDirectory);
+
+    for (const packageName of packageNames) {
+      await updatePackageJSONTypeField(packageName);
+    }
+  } catch (error) {
+    console.error('Error reading packages directory:', error);
+  }
+}
+
+updateAllPackagesTypeField();


### PR DESCRIPTION
# Description

There's a bug in NX `@nx/rollup:rollup` bundler on Windows OS which sets the path for types to "types": "./src\\index.d.ts"
instead of "./src/index.d.ts" and some bundlers like Parcel in dApps fail.

This script updates types property in all packages and replaces `\\` with `/`.
From "./src\\index.d.ts"  to  "./src/index.d.ts" .

Update types property by using the command: `node scripts/update-package-json.js`

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [ ] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
