### PR TITLE
chore: Bump version for ngx-deploy-npm from 4.3.10 to 7.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "near-api-js": "^2.1.3",
     "near-seed-phrase": "^0.2.0",
     "next": "13.3.0",
-    "ngx-deploy-npm": "^4.3.10",
+    "ngx-deploy-npm": "^7.0.1",
     "qrcode": "^1.5.3",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/packages/account-export/project.json
+++ b/packages/account-export/project.json
@@ -42,6 +42,12 @@
         "lintFilePatterns": ["packages/account-export/**/*.{ts,tsx,js,jsx}"]
       }
     },
+    "deploy": {
+      "executor": "ngx-deploy-npm:deploy",
+      "options": {
+        "access": "public"
+      }
+    },
     "test": {
       "executor": "@nx/jest:jest",
       "outputs": ["{workspaceRoot}/coverage/packages/account-export"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -3525,17 +3525,6 @@
   dependencies:
     "@nx/cypress" "16.0.0"
 
-"@nrwl/devkit@15.2.3":
-  version "15.2.3"
-  resolved "https://registry.yarnpkg.com/@nrwl/devkit/-/devkit-15.2.3.tgz#70b4e914c4cd19cd1ba99389499ba854985a821e"
-  integrity sha512-3IZVahO6vvEFxp0N7mEO34ZnYT+8FaObyYI/2XVYZ0eDCAMihn2IIUMj+M42vAXPOJpctdghSKXovQDuHO031w==
-  dependencies:
-    "@phenomnomnominal/tsquery" "4.1.1"
-    ejs "^3.1.7"
-    ignore "^5.0.4"
-    semver "7.3.4"
-    tslib "^2.3.0"
-
 "@nrwl/devkit@16.0.0":
   version "16.0.0"
   resolved "https://registry.yarnpkg.com/@nrwl/devkit/-/devkit-16.0.0.tgz#b816891053e5efa3e2b51f3dfa285e8c9b78bb93"
@@ -4064,13 +4053,6 @@
   dependencies:
     node-addon-api "^3.2.1"
     node-gyp-build "^4.3.0"
-
-"@phenomnomnominal/tsquery@4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@phenomnomnominal/tsquery/-/tsquery-4.1.1.tgz#42971b83590e9d853d024ddb04a18085a36518df"
-  integrity sha512-jjMmK1tnZbm1Jq5a7fBliM4gQwjxMU7TFoRNwIyzwlO+eHPRCFv/Nv+H/Gi1jc3WR7QURG8D5d0Tn12YGrUqBQ==
-  dependencies:
-    esquery "^1.0.1"
 
 "@phenomnomnominal/tsquery@~5.0.1":
   version "5.0.1"
@@ -9558,7 +9540,7 @@ esprima@^4.0.0, esprima@^4.0.1, esprima@~4.0.0:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-esquery@^1.0.1, esquery@^1.4.0:
+esquery@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.0.tgz#2148ffc38b82e8c7057dfed48425b3e61f0f24a5"
   integrity sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==
@@ -13725,12 +13707,10 @@ next@13.3.0:
     "@next/swc-win32-ia32-msvc" "13.3.0"
     "@next/swc-win32-x64-msvc" "13.3.0"
 
-ngx-deploy-npm@^4.3.10:
-  version "4.3.10"
-  resolved "https://registry.yarnpkg.com/ngx-deploy-npm/-/ngx-deploy-npm-4.3.10.tgz#e1d150512c9196e5a70f0f2d1e9f0d8666bc622b"
-  integrity sha512-6cLM1z0h6VD5SYH9fJSeslvTSKTkaySsH63k2AouXnAXsHQe4eFrdkmfMAZoVwUZHyaNIBOKMUcTvotgMwQnug==
-  dependencies:
-    "@nrwl/devkit" "15.2.3"
+ngx-deploy-npm@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/ngx-deploy-npm/-/ngx-deploy-npm-7.0.1.tgz#de6d3864d4ddf9db6c2641b4f948f8cd7acb4c43"
+  integrity sha512-YQmYx8ZxnhsGdpLMocIsmvVdV/bnsPNNOZALjJxNyfYomLpJ+OIlMPCVUM3QWA7Lxw8P9GZ+yITeavoBInEkBA==
 
 nice-napi@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
# Description

- Bumped version for `ngx-deploy-npm` and added the `deploy` script for `account-export` package.

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [ ] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [x] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
