### PR TITLE
refactor: Change the logic for waiting about the isSignedIn() in Sender

### DIFF
--- a/packages/sender/src/lib/sender.ts
+++ b/packages/sender/src/lib/sender.ts
@@ -102,6 +102,16 @@ const Sender: WalletBehaviourFactory<InjectedWallet> = async ({
   };
 
   const getAccounts = async (): Promise<Array<Account>> => {
+    // Add extra wait to ensure Sender's sign in status is read from the
+    // browser extension background env.
+    // Check for isSignedIn() in only if selectedWalletId is set.
+    const { selectedWalletId } = store.getState();
+    if (selectedWalletId) {
+      await waitFor(() => !!_state.wallet?.isSignedIn(), {
+        timeout: 1000,
+      }).catch();
+    }
+
     const accountId = _state.wallet.getAccountId();
 
     if (!accountId) {
@@ -321,15 +331,6 @@ export function setupSender({
     }
 
     const installed = await isInstalled();
-
-    // Add extra wait to ensure Sender's sign in status is read from the
-    // browser extension background env.
-    // Check for isSignedIn() in only if extension is installed.
-    if (installed) {
-      await waitFor(() => !!window.near?.isSignedIn(), { timeout: 200 }).catch(
-        () => false
-      );
-    }
 
     return {
       id: "sender",


### PR DESCRIPTION
# Description

This PR changes logic and the waiting time for the `isSignedIn()` for Sender Wallet the details can be found here https://github.com/near/wallet-selector/issues/944#issuecomment-1735551406

- This waiting time gets triggered only when some other extensions mentioned in the above comment block the Sender wallet from somehow updating the `isSignedIn()` state this means if these extensions are not installed or the user is not signed in the wallet selector there will be no waiting time.

Closes: #944 

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [ ] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [x] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
