### PR TITLE
ci: Exclude PRs by label from release-drafter notes.

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -19,6 +19,10 @@ categories:
       - 'perf'
       - 'test'
       - 'build'
+
+exclude-labels:
+  - 'skip-changelog'
+
 template: |
   ## Changelog
   $CHANGES


### PR DESCRIPTION
# Description

This PR adds the option to exclude specific PRs from the Draft Release notes.

Label added: 
![image](https://github.com/near/wallet-selector/assets/95851345/c13d7e75-a5ad-4025-9757-8b129639cb85)

Closes: #951 

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [ ] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [x] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
