### PR TITLE
feat: Add support for signMessage in WalletConnect

### DIFF
--- a/packages/wallet-connect/src/lib/wallet-connect.ts
+++ b/packages/wallet-connect/src/lib/wallet-connect.ts
@@ -562,8 +562,6 @@ const WalletConnect: WalletBehaviourFactory<
 
       const chainId = getChainId();
 
-      console.log({ session: _state.session });
-
       if (!_state.session) {
         _state.session = await _state.client.connect(
           {
@@ -588,7 +586,7 @@ const WalletConnect: WalletBehaviourFactory<
         nonce,
         recipient,
         callbackUrl,
-        accountId: account?.accountId ?? undefined,
+        accountId: account?.accountId,
       });
     },
 

--- a/packages/wallet-connect/src/lib/wallet-connect.ts
+++ b/packages/wallet-connect/src/lib/wallet-connect.ts
@@ -497,29 +497,25 @@ const WalletConnect: WalletBehaviourFactory<
 
   return {
     async signIn({ contractId, methodNames = [], qrCodeModal = true }) {
-      const existingAccounts = await getAccounts();
-
-      if (existingAccounts.length) {
-        return existingAccounts;
-      }
-
       try {
         const chainId = getChainId();
 
-        _state.session = await _state.client.connect(
-          {
-            requiredNamespaces: {
-              near: {
-                chains: [getChainId()],
-                methods: WC_METHODS,
-                events: WC_EVENTS,
+        if (!_state.session) {
+          _state.session = await _state.client.connect(
+            {
+              requiredNamespaces: {
+                near: {
+                  chains: [getChainId()],
+                  methods: WC_METHODS,
+                  events: WC_EVENTS,
+                },
               },
             },
-          },
-          qrCodeModal,
-          params.projectId,
-          chainId
-        );
+            qrCodeModal,
+            params.projectId,
+            chainId
+          );
+        }
 
         await requestSignIn({ receiverId: contractId, methodNames });
 


### PR DESCRIPTION
# Description

This PR adds support for `signMessage` to WalletConnect

The functionality can be tested against this PR on the WalletConnect examples:
https://github.com/WalletConnect/web-examples/pull/310

Wallet Example:
https://react-wallet.walletconnect.com/walletconnect


### Test signMessage locally:

Pull changes from wallet-selector:
```bash
git pull
```

Switch to this PR's branch

```bash
git switch add-sign-message-to-walletconnect
# or
git checkout add-sign-message-to-walletconnect

# then
yarn && yarn build:all && yarn nx serve react
```

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [ ] FIX - a PR of this type patches a bug.
- [x] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
