### PR TITLE
fix: Disable signMessage for near-wallet

### DIFF
--- a/packages/my-near-wallet/src/lib/my-near-wallet.ts
+++ b/packages/my-near-wallet/src/lib/my-near-wallet.ts
@@ -67,7 +67,7 @@ const setupWalletState = async (
 const MyNearWallet: WalletBehaviourFactory<
   BrowserWallet,
   { params: MyNearWalletExtraOptions }
-> = async ({ metadata, options, store, params, logger }) => {
+> = async ({ metadata, options, store, params, logger, id }) => {
   const _state = await setupWalletState(params, options.network);
   const getAccounts = async (): Promise<Array<Account>> => {
     const accountId = _state.wallet.getAccountId();
@@ -162,6 +162,12 @@ const MyNearWallet: WalletBehaviourFactory<
 
     async signMessage({ message, nonce, recipient, callbackUrl, state }) {
       logger.log("sign message", { message });
+
+      if (id !== "my-near-wallet") {
+        throw Error(
+          `The signMessage method is not supported by ${metadata.name}`
+        );
+      }
 
       const locationUrl =
         typeof window !== "undefined" ? window.location.href : "";


### PR DESCRIPTION
# Description

This PR stops/disables the ability to trigger `signMessage` for NEAR Wallet since it's not supported.

This will avoid redirecting to a 404 page in the cases when users sign-in with NEAR Wallet and try the `signMessage`, since `near-wallet` in our side just wraps around the `my-near-wallet` setup it was enabled by default.

Closes: #973 

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [x] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
