### PR TITLE
fix: Make methods and events configurable on setupWalletConnect options.

### DIFF
--- a/examples/angular/src/app/pages/wallet-selector/wallet-selector.component.ts
+++ b/examples/angular/src/app/pages/wallet-selector/wallet-selector.component.ts
@@ -74,6 +74,15 @@ export class WalletSelectorComponent implements OnInit {
         }),
         setupWalletConnect({
           projectId: "c8cb6204543639c31aef44ea4837a554", // Replace this with your own projectId form WalletConnect.
+          // Overrides the default methods on wallet-connect.ts
+          // the near_signMessage and near_verifyOwner are missing here.
+          methods: [
+            "near_signIn",
+            "near_signOut",
+            "near_getAccounts",
+            "near_signTransaction",
+            "near_signTransactions",
+          ],
           metadata: {
             name: "NEAR Wallet Selector",
             description: "Example dApp used by NEAR Wallet Selector",

--- a/packages/modal-ui-js/src/lib/render-modal.ts
+++ b/packages/modal-ui-js/src/lib/render-modal.ts
@@ -160,7 +160,10 @@ export async function connectToWallet(
     modalState.emitter.emit("onHide", { hideReason: "wallet-navigation" });
   } catch (err) {
     const { name } = module.metadata;
-    const message = err instanceof Error ? err.message : "Something went wrong";
+    const message =
+      err && typeof err === "object" && "message" in err
+        ? (err as { message: string }).message
+        : "Something went wrong";
 
     await renderWalletConnectionFailed(
       module,

--- a/packages/modal-ui/src/lib/components/DerivationPath.tsx
+++ b/packages/modal-ui/src/lib/components/DerivationPath.tsx
@@ -144,7 +144,9 @@ export const DerivationPath: React.FC<DerivationPathProps> = ({
     } catch (err) {
       setConnecting(false);
       const message =
-        err instanceof Error ? err.message : "Something went wrong";
+        err && typeof err === "object" && "message" in err
+          ? (err as { message: string }).message
+          : "Something went wrong";
 
       onError(message, wallet);
     } finally {
@@ -174,7 +176,9 @@ export const DerivationPath: React.FC<DerivationPathProps> = ({
     } catch (err) {
       setConnecting(false);
       const message =
-        err instanceof Error ? err.message : "Something went wrong";
+        err && typeof err === "object" && "message" in err
+          ? (err as { message: string }).message
+          : "Something went wrong";
       onError(message, hardwareWallet!);
     } finally {
       setConnecting(false);

--- a/packages/modal-ui/src/lib/components/Modal.tsx
+++ b/packages/modal-ui/src/lib/components/Modal.tsx
@@ -227,7 +227,9 @@ export const Modal: React.FC<ModalProps> = ({
       const { name } = module.metadata;
 
       const message =
-        err instanceof Error ? err.message : "Something went wrong";
+        err && typeof err === "object" && "message" in err
+          ? (err as { message: string }).message
+          : "Something went wrong";
 
       setAlertMessage(`Failed to sign in with ${name}: ${message}`);
       setRoute({

--- a/packages/wallet-connect/README.md
+++ b/packages/wallet-connect/README.md
@@ -37,6 +37,17 @@ const walletConnect = setupWalletConnect({
   },
   chainId: "near:testnet",
   iconUrl: "https://<Wallet Icon URL Here>",
+  // methods option is optional, by default all are included if not provided here
+  // use only to override the default setting.
+  methods: [
+    "near_signIn",
+    "near_signOut",
+    "near_getAccounts",
+    "near_signTransaction",
+    "near_signTransactions",
+    "near_verifyOwner",
+    "near_signMessage",
+  ]
 });
 
 const selector = await setupWalletSelector({
@@ -58,6 +69,22 @@ Project ID is required for wallet connect, please obtain it from [walletconnect.
 - `relayUrl` (`string?`): Relay URL for requests. Defaults to `"wss://relay.walletconnect.com"`.
 - `iconUrl` (`string?`): Image URL for the icon shown in the modal. This can also be a relative path or base64 encoded image. Defaults to `./assets/wallet-connect-icon.png`.
 - `deprecated`: (`boolean?`): Deprecated is optional. Default is `false`.
+- `methods`: (`Array<string>?`): Methods is optional overrides default WC_METHODS. Defaults to `undefined`.
+- `events`: (`Array<string>?`): Events is optional overrides default WC_EVENTS. Defaults to `undefined`.
+
+## Supported methods
+- `near_signIn`
+- `near_signOut`
+- `near_getAccounts`
+- `near_signTransaction`
+- `near_signTransactions`
+- `near_verifyOwner`
+- `near_signMessage`
+
+## Supported events
+
+- `chainChanged`
+- `accountsChanged`
 
 ## Assets
 

--- a/packages/wallet-connect/README.md
+++ b/packages/wallet-connect/README.md
@@ -37,8 +37,9 @@ const walletConnect = setupWalletConnect({
   },
   chainId: "near:testnet",
   iconUrl: "https://<Wallet Icon URL Here>",
-  // methods option is optional, by default all are included if not provided here
-  // use only to override the default setting.
+  // Please note that the 'methods' option is discretionary;
+  // if omitted, all methods are included by default.
+  // Use it solely to override the default configuration.
   methods: [
     "near_signIn",
     "near_signOut",

--- a/packages/wallet-connect/src/lib/wallet-connect.ts
+++ b/packages/wallet-connect/src/lib/wallet-connect.ts
@@ -28,6 +28,8 @@ export interface WalletConnectParams {
   iconUrl?: string;
   chainId?: string;
   deprecated?: boolean;
+  methods?: Array<string>;
+  events?: Array<string>;
 }
 
 interface WalletConnectExtraOptions {
@@ -35,6 +37,8 @@ interface WalletConnectExtraOptions {
   projectId: string;
   metadata: SignClientTypes.Metadata;
   relayUrl: string;
+  methods?: Array<string>;
+  events?: Array<string>;
 }
 
 interface LimitedAccessKeyPair {
@@ -64,6 +68,8 @@ interface ConnectParams {
   chainId: string;
   qrCodeModal: boolean;
   projectId: string;
+  methods?: Array<string>;
+  events?: Array<string>;
 }
 
 const WC_METHODS = [
@@ -114,14 +120,16 @@ const connect = async ({
   chainId,
   qrCodeModal,
   projectId,
+  methods,
+  events,
 }: ConnectParams) => {
   return await state.client.connect(
     {
       requiredNamespaces: {
         near: {
           chains: [chainId],
-          methods: WC_METHODS,
-          events: WC_EVENTS,
+          methods: methods || WC_METHODS,
+          events: events || WC_EVENTS,
         },
       },
     },
@@ -544,6 +552,8 @@ const WalletConnect: WalletBehaviourFactory<
           chainId,
           qrCodeModal,
           projectId: params.projectId,
+          methods: params.methods,
+          events: params.events,
         });
 
         await requestSignIn({ receiverId: contractId, methodNames });
@@ -697,6 +707,8 @@ export function setupWalletConnect({
   relayUrl = "wss://relay.walletconnect.com",
   iconUrl = icon,
   deprecated = false,
+  methods,
+  events,
 }: WalletConnectParams): WalletModuleFactory<BridgeWallet> {
   return async () => {
     return {
@@ -717,6 +729,8 @@ export function setupWalletConnect({
             metadata,
             relayUrl,
             chainId,
+            methods,
+            events,
           },
         });
       },


### PR DESCRIPTION
# Description

Closes: #1060 

- Made `methods` and `events` configurable from `setupWalletconnect`.
- Overrided default WC `methods` in angular example.
- Updated docs
- Improved error messages on `modal-ui` and `modal-ui-js`

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [x] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
