### PR TITLE
feat: Update HERE Wallet  and add topLevelInjected

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@angular/platform-browser": "15.2.9",
     "@angular/platform-browser-dynamic": "15.2.9",
     "@angular/router": "15.2.9",
-    "@here-wallet/core": "^1.5.1",
+    "@here-wallet/core": "^1.6.6",
     "@jscutlery/semver": "3.1.0",
     "@ledgerhq/hw-transport": "6.30.3",
     "@ledgerhq/hw-transport-webhid": "6.28.3",

--- a/packages/core/docs/api/wallet.md
+++ b/packages/core/docs/api/wallet.md
@@ -63,7 +63,16 @@ There are four wallet types:
 
 **Description**
 
-Returns meta information about the wallet such as `name`, `description`, `iconUrl` , `deprecated` and `available` but can include wallet-specific properties such as `downloadUrl` and `useUrlAccountImport` for injected wallets or `contractId`,  `runOnStartup` for instant-link wallets and `walletUrl` for browser wallets.
+Returns meta information about the wallet such as `name`, `description`, `iconUrl` , `deprecated` and `available` but can include wallet-specific properties such as `downloadUrl`, `useUrlAccountImport` and `topLevelInjected` for injected wallets or `contractId`,  `runOnStartup` for instant-link wallets and `walletUrl` for browser wallets.
+
+- `name`: Displayed in modal-ui as wallet name
+- `description`: Displayed in modal-ui as wallet description
+- `iconUrl`: Displayed in modal-ui as wallet icon
+- `deprecated`: Makes the wallet unselectable via modal-ui
+- `available`: Makes the wallet unselectable via modal-ui, use if the wallet cannot be selected in the user's environment.
+- `downloadUrl`: Link to download injected wallet, available via modal-ui
+- `useUrlAccountImport`: If `true`, then this injected wallet supports @account-export api and will be available in the account export modal window
+- `topLevelInjected`: If the value `true` is passed for an injected wallet, modal-ui will call the signIn method of this wallet immediately upon initializing setupModal. This will allow wallet applications that open the dApp in the internal browser to immediately log in with the user's wallet.
 
 **Example**
 

--- a/packages/core/src/lib/wallet/wallet.types.ts
+++ b/packages/core/src/lib/wallet/wallet.types.ts
@@ -258,6 +258,7 @@ export type BrowserWallet = BaseWallet<
 
 export type InjectedWalletMetadata = BaseWalletMetadata & {
   downloadUrl: string;
+  topLevelInjected?: boolean;
   useUrlAccountImport?: boolean;
 };
 

--- a/packages/here-wallet/src/lib/index.ts
+++ b/packages/here-wallet/src/lib/index.ts
@@ -1,4 +1,4 @@
-import type { HereProvider, HereStrategy } from "@here-wallet/core";
+import { waitInjectedHereWallet, type HereProvider, type HereStrategy } from "@here-wallet/core";
 import type { WalletModuleFactory } from "@near-wallet-selector/core";
 import type { HereWallet } from "./types";
 import { initHereWallet } from "./selector";
@@ -20,6 +20,8 @@ export function setupHereWallet({
   defaultProvider,
 }: Options = {}): WalletModuleFactory<HereWallet> {
   return async () => {
+    const isInjected = await waitInjectedHereWallet;
+
     return {
       id: "here-wallet",
       type: "injected",
@@ -28,6 +30,7 @@ export function setupHereWallet({
         description: "Mobile wallet for NEAR Protocol",
         useUrlAccountImport: true,
         downloadUrl: "https://herewallet.app",
+        topLevelInjected: isInjected != null,
         iconUrl,
         deprecated,
         available: true,

--- a/packages/here-wallet/src/lib/index.ts
+++ b/packages/here-wallet/src/lib/index.ts
@@ -1,4 +1,8 @@
-import { waitInjectedHereWallet, type HereProvider, type HereStrategy } from "@here-wallet/core";
+import {
+  waitInjectedHereWallet,
+  type HereProvider,
+  type HereStrategy,
+} from "@here-wallet/core";
 import type { WalletModuleFactory } from "@near-wallet-selector/core";
 import type { HereWallet } from "./types";
 import { initHereWallet } from "./selector";

--- a/packages/here-wallet/src/lib/selector.ts
+++ b/packages/here-wallet/src/lib/selector.ts
@@ -5,8 +5,9 @@ import type BN from "bn.js";
 import type { SelectorInit } from "./types";
 
 export const initHereWallet: SelectorInit = async (config) => {
-  const { store, logger, emitter, options, defaultProvider, defaultStrategy } = config;
-    
+  const { store, logger, emitter, options, defaultProvider, defaultStrategy } =
+    config;
+
   const here = new HereWallet({
     networkId: options.network.networkId as NetworkId,
     nodeUrl: options.network.nodeUrl,

--- a/packages/here-wallet/src/lib/selector.ts
+++ b/packages/here-wallet/src/lib/selector.ts
@@ -1,13 +1,12 @@
 import type { NetworkId } from "@near-wallet-selector/core";
-import { HereWallet } from "@here-wallet/core";
+import { HereWallet, waitInjectedHereWallet } from "@here-wallet/core";
 import type BN from "bn.js";
 
 import type { SelectorInit } from "./types";
 
 export const initHereWallet: SelectorInit = async (config) => {
-  const { store, logger, emitter, options, defaultProvider, defaultStrategy } =
-    config;
-
+  const { store, logger, emitter, options, defaultProvider, defaultStrategy } = config;
+    
   const here = new HereWallet({
     networkId: options.network.networkId as NetworkId,
     nodeUrl: options.network.nodeUrl,
@@ -66,8 +65,11 @@ export const initHereWallet: SelectorInit = async (config) => {
     async signIn(data) {
       logger.log("HereWallet:signIn");
 
-      const contractId = data.contractId !== "" ? data.contractId : undefined;
-      await here.signIn({ ...data, contractId: contractId });
+      const isInjected = await waitInjectedHereWallet;
+      if (!isInjected) {
+        const contractId = data.contractId !== "" ? data.contractId : undefined;
+        await here.signIn({ ...data, contractId: contractId });
+      }
 
       emitter.emit("signedIn", {
         contractId: data.contractId,
@@ -101,12 +103,8 @@ export const initHereWallet: SelectorInit = async (config) => {
       logger.log("HereWallet:signAndSendTransaction", data);
 
       const { contract } = store.getState();
-      if (!here.isSignedIn || !contract) {
-        throw new Error("Wallet not signed in");
-      }
-
       return await here.signAndSendTransaction({
-        receiverId: contract.contractId,
+        receiverId: contract?.contractId,
         ...data,
       });
     },

--- a/packages/modal-ui-js/src/lib/modal.ts
+++ b/packages/modal-ui-js/src/lib/modal.ts
@@ -54,19 +54,23 @@ export const setupModal = (
 ): WalletSelectorModal => {
   const emitter = new EventEmitter<ModalEvents>();
 
-  selector.store.getState().modules.forEach(async module => {
-    if ('topLevelInjected' in module.metadata) {
-      if (!module.metadata.topLevelInjected) return;
+  selector.store.getState().modules.forEach(async (module) => {
+    if ("topLevelInjected" in module.metadata) {
+      if (!module.metadata.topLevelInjected) {
+        return;
+      }
 
       const wallet = await module.wallet();
-      if (wallet.type !== 'injected') return;
+      if (wallet.type !== "injected") {
+        return;
+      }
 
-      await wallet.signIn({ 
+      await wallet.signIn({
         contractId: options.contractId,
-        methodNames: options.methodNames 
-      })
+        methodNames: options.methodNames,
+      });
     }
-  })
+  });
 
   modalState = {
     container: document.getElementById(MODAL_ELEMENT_ID)!,

--- a/packages/modal-ui-js/src/lib/modal.ts
+++ b/packages/modal-ui-js/src/lib/modal.ts
@@ -54,6 +54,20 @@ export const setupModal = (
 ): WalletSelectorModal => {
   const emitter = new EventEmitter<ModalEvents>();
 
+  selector.store.getState().modules.forEach(async module => {
+    if ('topLevelInjected' in module.metadata) {
+      if (!module.metadata.topLevelInjected) return;
+
+      const wallet = await module.wallet();
+      if (wallet.type !== 'injected') return;
+
+      await wallet.signIn({ 
+        contractId: options.contractId,
+        methodNames: options.methodNames 
+      })
+    }
+  })
+
   modalState = {
     container: document.getElementById(MODAL_ELEMENT_ID)!,
     selector,

--- a/packages/modal-ui/src/lib/modal.tsx
+++ b/packages/modal-ui/src/lib/modal.tsx
@@ -34,19 +34,23 @@ export const setupModal = (
 
   const emitter = new EventEmitter<ModalEvents>();
 
-  selector.store.getState().modules.forEach(async module => {
-    if ('topLevelInjected' in module.metadata) {
-      if (!module.metadata.topLevelInjected) return;
+  selector.store.getState().modules.forEach(async (module) => {
+    if ("topLevelInjected" in module.metadata) {
+      if (!module.metadata.topLevelInjected) {
+        return;
+      }
 
       const wallet = await module.wallet();
-      if (wallet.type !== 'injected') return;
+      if (wallet.type !== "injected") {
+        return;
+      }
 
-      await wallet.signIn({ 
+      await wallet.signIn({
         contractId: options.contractId,
-        methodNames: options.methodNames 
-      })
+        methodNames: options.methodNames,
+      });
     }
-  })
+  });
 
   const render = (visible = false) => {
     root!.render(

--- a/packages/modal-ui/src/lib/modal.tsx
+++ b/packages/modal-ui/src/lib/modal.tsx
@@ -34,6 +34,20 @@ export const setupModal = (
 
   const emitter = new EventEmitter<ModalEvents>();
 
+  selector.store.getState().modules.forEach(async module => {
+    if ('topLevelInjected' in module.metadata) {
+      if (!module.metadata.topLevelInjected) return;
+
+      const wallet = await module.wallet();
+      if (wallet.type !== 'injected') return;
+
+      await wallet.signIn({ 
+        contractId: options.contractId,
+        methodNames: options.methodNames 
+      })
+    }
+  })
+
   const render = (visible = false) => {
     root!.render(
       <Modal

--- a/yarn.lock
+++ b/yarn.lock
@@ -2816,11 +2816,12 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@here-wallet/core@^1.5.1":
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/@here-wallet/core/-/core-1.5.1.tgz#618db9de547bfaed5229100002357663fcee5d77"
-  integrity sha512-gCzB27k0QfviyJQUhxqX3kAH3g3mRHb6B5RJdUhX9tTsLlPW6AMV/PJiYBudPCt0EeyeyU4i8kEh223ACHXOjw==
+"@here-wallet/core@^1.6.6":
+  version "1.6.6"
+  resolved "https://registry.yarnpkg.com/@here-wallet/core/-/core-1.6.6.tgz#db31fcd048c4977da3bc6923fcf25113a32b5a49"
+  integrity sha512-avh/PRNl3CbgrcbqIezVrNPAa4fqKvonl/mguSoUAfTwfA5jWnfq81Udd8QzOAIzBIGx5gSabzEkh9CRDH7yDA==
   dependencies:
+    near-api-js "^3.0.1"
     sha1 "^1.1.1"
     uuid4 "2.0.3"
 
@@ -3650,6 +3651,25 @@
     depd "^2.0.0"
     near-abi "0.1.1"
 
+"@near-js/accounts@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@near-js/accounts/-/accounts-1.0.2.tgz#5bcb6df9985ec451b35e8c2e22ad8113ef523692"
+  integrity sha512-KpyY9r+f55vJ0XCk17vyHeiiNbsmKY9T3ztXKLWQEr661XWJKyetQUBb3dyehf6DHXXnlxwwQNdYDK8d0x1nOQ==
+  dependencies:
+    "@near-js/crypto" "1.2.0"
+    "@near-js/providers" "0.0.10"
+    "@near-js/signers" "0.1.0"
+    "@near-js/transactions" "1.1.0"
+    "@near-js/types" "0.0.4"
+    "@near-js/utils" "0.0.5"
+    ajv "8.11.2"
+    ajv-formats "2.1.1"
+    bn.js "5.2.1"
+    borsh "1.0.0"
+    depd "2.0.0"
+    lru_map "0.4.1"
+    near-abi "0.1.1"
+
 "@near-js/crypto@0.0.4":
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/@near-js/crypto/-/crypto-0.0.4.tgz#7bb991da25f06096de51466c6331cb185314fad8"
@@ -3670,6 +3690,18 @@
     borsh "^0.7.0"
     tweetnacl "^1.0.1"
 
+"@near-js/crypto@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@near-js/crypto/-/crypto-1.2.0.tgz#a462f448c6e878d0efbbf14057365b0469a675b5"
+  integrity sha512-iYpiynirW1cB9kNttSsbNhlN4LFR1Esq08aIFyFB/qGNy8DjLYYoe2g923YBxDbVMI6Ljk6AX3G+KDnG3S9lqg==
+  dependencies:
+    "@near-js/types" "0.0.4"
+    "@near-js/utils" "0.0.5"
+    "@noble/curves" "1.2.0"
+    bn.js "5.2.1"
+    borsh "1.0.0"
+    randombytes "2.1.0"
+
 "@near-js/keystores-browser@0.0.4":
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/@near-js/keystores-browser/-/keystores-browser-0.0.4.tgz#9c1130e2c0becf6bb9cfaaa7594ad38ed25585bd"
@@ -3685,6 +3717,14 @@
   dependencies:
     "@near-js/crypto" "0.0.5"
     "@near-js/keystores" "0.0.5"
+
+"@near-js/keystores-browser@0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@near-js/keystores-browser/-/keystores-browser-0.0.8.tgz#0596370221cd6e52dfd057b8f8889c205a0291e8"
+  integrity sha512-ZWBbioO2TUdMkHbmHpwo+DC4CC9XAvS9umIBNgS1XBsY2y3NsG+dWU4bEiFC37fGBzJL9EFw+QJ6RxB+jeOfdQ==
+  dependencies:
+    "@near-js/crypto" "1.2.0"
+    "@near-js/keystores" "0.0.8"
 
 "@near-js/keystores-node@0.0.4":
   version "0.0.4"
@@ -3702,6 +3742,14 @@
     "@near-js/crypto" "0.0.5"
     "@near-js/keystores" "0.0.5"
 
+"@near-js/keystores-node@0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@near-js/keystores-node/-/keystores-node-0.0.8.tgz#fd86077ba9b48f1b73f67da29b5e59d313ea9ce2"
+  integrity sha512-wiVcKljXi7YkHyQrg1Aw7HubmSGRpC+jNgjCdNBd645Qr9YuSLr/OGTCdliO4QWalU+lUgBV63eSxzAMeUa3Aw==
+  dependencies:
+    "@near-js/crypto" "1.2.0"
+    "@near-js/keystores" "0.0.8"
+
 "@near-js/keystores@0.0.4":
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/@near-js/keystores/-/keystores-0.0.4.tgz#da03069497bb14741a4d97f7ad4746baf9a09ea7"
@@ -3717,6 +3765,28 @@
   dependencies:
     "@near-js/crypto" "0.0.5"
     "@near-js/types" "0.0.4"
+
+"@near-js/keystores@0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@near-js/keystores/-/keystores-0.0.8.tgz#9d2c6365718839fa17946cce895511aece640b80"
+  integrity sha512-H3JQroNbx0AvNpXsGiDdjVZCFPqd6Qx29XK618GhwSqvvmFQxq96sh51dmPhJ+jVxFUTt7Q9es8fujYbZceAzw==
+  dependencies:
+    "@near-js/crypto" "1.2.0"
+    "@near-js/types" "0.0.4"
+
+"@near-js/providers@0.0.10":
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/@near-js/providers/-/providers-0.0.10.tgz#68066c81454e3769993f83b27b2be209dfee900a"
+  integrity sha512-c3t2+34mL5YHn93pwPwJr6LPUZbpmBPtBoyhX105R8l8QxShy4L8IHPj5ZhBowN1+Yrq6c5Cnw57SqHHqwz9tg==
+  dependencies:
+    "@near-js/transactions" "1.1.0"
+    "@near-js/types" "0.0.4"
+    "@near-js/utils" "0.0.5"
+    bn.js "5.2.1"
+    borsh "1.0.0"
+    http-errors "1.7.2"
+  optionalDependencies:
+    node-fetch "2.6.7"
 
 "@near-js/providers@0.0.6":
   version "0.0.6"
@@ -3764,6 +3834,15 @@
     "@near-js/keystores" "0.0.5"
     js-sha256 "^0.9.0"
 
+"@near-js/signers@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@near-js/signers/-/signers-0.1.0.tgz#a2724318e0781dd5348d1978a45247759e30e688"
+  integrity sha512-EWnkzqLPcVzSXE4Y4HbtrJSqUEqVehn516PxCayRVRJ7bo6ytkas/U6e+J5Dn/vpH/Ny5Y/tcmt+A0s4vbCLZA==
+  dependencies:
+    "@near-js/crypto" "1.2.0"
+    "@near-js/keystores" "0.0.8"
+    "@noble/hashes" "1.3.3"
+
 "@near-js/transactions@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@near-js/transactions/-/transactions-0.2.0.tgz#c23b73d94ebcf8b4cd1b5d2176f620e499a143ca"
@@ -3790,6 +3869,19 @@
     borsh "^0.7.0"
     js-sha256 "^0.9.0"
 
+"@near-js/transactions@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@near-js/transactions/-/transactions-1.1.0.tgz#7092f09237d7778a9ba05148a2cddbf50f18bfbd"
+  integrity sha512-0kP8unj0RND20lP67nCtDN3fz0CvO/C9AX0EqlT5dAyi4ZQBabgVQq272RtT9xnaoA7OP6OPB3GUWGJS+MwsTw==
+  dependencies:
+    "@near-js/crypto" "1.2.0"
+    "@near-js/signers" "0.1.0"
+    "@near-js/types" "0.0.4"
+    "@near-js/utils" "0.0.5"
+    "@noble/hashes" "1.3.3"
+    bn.js "5.2.1"
+    borsh "1.0.0"
+
 "@near-js/types@0.0.4":
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/@near-js/types/-/types-0.0.4.tgz#d941689df41c850aeeeaeb9d498418acec515404"
@@ -3806,6 +3898,17 @@
     bn.js "5.2.1"
     depd "^2.0.0"
     mustache "^4.0.0"
+
+"@near-js/utils@0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@near-js/utils/-/utils-0.0.5.tgz#7c7f80140c039535b04ec48ed84b9681407ea57a"
+  integrity sha512-0YnPruP6xZc/scIAX7E3GrTrFMNAyB9bFZOoOdA60GPzHwTTfpXsdozZvsQN4LvfFuiCDN1OEhwx7EtJh43DRw==
+  dependencies:
+    "@near-js/types" "0.0.4"
+    bn.js "5.2.1"
+    bs58 "4.0.0"
+    depd "2.0.0"
+    mustache "4.0.0"
 
 "@near-js/wallet-account@0.0.6":
   version "0.0.6"
@@ -3836,6 +3939,21 @@
     "@near-js/utils" "0.0.4"
     bn.js "5.2.1"
     borsh "^0.7.0"
+
+"@near-js/wallet-account@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@near-js/wallet-account/-/wallet-account-1.0.2.tgz#25014069e4102e8b61c73bf64b85f1803ac032f2"
+  integrity sha512-bbouucpBgFtZ3bI7KvcYT8/r1q4w5UVIbbZqTUnuXpkceSQ7IxjeKCR00Iastj9EOXWAAAJBYkn0942QJjBC5w==
+  dependencies:
+    "@near-js/accounts" "1.0.2"
+    "@near-js/crypto" "1.2.0"
+    "@near-js/keystores" "0.0.8"
+    "@near-js/signers" "0.1.0"
+    "@near-js/transactions" "1.1.0"
+    "@near-js/types" "0.0.4"
+    "@near-js/utils" "0.0.5"
+    bn.js "5.2.1"
+    borsh "1.0.0"
 
 "@near-snap/sdk@^0.6.0":
   version "0.6.0"
@@ -3923,6 +4041,23 @@
   version "15.2.8"
   resolved "https://registry.yarnpkg.com/@ngtools/webpack/-/webpack-15.2.8.tgz#df8fb9300ccf94cab8f8ad69fb16fd31181e6c82"
   integrity sha512-BJexeT4FxMtToVBGa3wdl6rrkYXgilP0kkSH4Qzu4MPlLPbeBSr4XQalQriewlpC2uzG0r2SJfrAe2eDhtSykA==
+
+"@noble/curves@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.2.0.tgz#92d7e12e4e49b23105a2555c6984d41733d65c35"
+  integrity sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==
+  dependencies:
+    "@noble/hashes" "1.3.2"
+
+"@noble/hashes@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.2.tgz#6f26dbc8fbc7205873ce3cee2f690eba0d421b39"
+  integrity sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==
+
+"@noble/hashes@1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.3.tgz#39908da56a4adc270147bb07968bf3b16cfe1699"
+  integrity sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -7617,6 +7752,16 @@ ajv-keywords@^5.0.0:
   dependencies:
     fast-deep-equal "^3.1.3"
 
+ajv@8.11.2:
+  version "8.11.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.2.tgz#aecb20b50607acf2569b6382167b65a96008bb78"
+  integrity sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
 ajv@8.12.0, ajv@^8.0.0, ajv@^8.11.2:
   version "8.12.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
@@ -8223,6 +8368,13 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base-x@^2.0.1:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-2.0.6.tgz#4582a91ebcec99ee06f4e4032030b0cf1c2941d8"
+  integrity sha512-UAmjxz9KbK+YIi66xej+pZVo/vxUOh49ubEvZW5egCbxhur05pBb+hwuireQwKO4nDpsNm64/jEei17LEpsr5g==
+  dependencies:
+    safe-buffer "^5.0.1"
+
 base-x@^3.0.2, base-x@^3.0.8:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.9.tgz#6349aaabb58526332de9f60995e548a53fe21320"
@@ -8446,6 +8598,11 @@ borsh@0.7.0, borsh@^0.7.0:
     bs58 "^4.0.0"
     text-encoding-utf-8 "^1.0.2"
 
+borsh@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/borsh/-/borsh-1.0.0.tgz#b564c8cc8f7a91e3772b9aef9e07f62b84213c1f"
+  integrity sha512-fSVWzzemnyfF89EPwlUNsrS5swF5CrtiN4e+h0/lLf4dz2he4L3ndM20PS9wj7ICSkXJe/TQUHdaPTq15b1mNQ==
+
 bottleneck@^2.18.1:
   version "2.19.5"
   resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.19.5.tgz#5df0b90f59fd47656ebe63c78a98419205cadd91"
@@ -8614,6 +8771,13 @@ bs-logger@0.x, bs-logger@^0.2.6:
   integrity sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==
   dependencies:
     fast-json-stable-stringify "2.x"
+
+bs58@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/bs58/-/bs58-4.0.0.tgz#65f5deaf6d74e6135a99f763ca6209ab424b9172"
+  integrity sha512-/jcGuUuSebyxwLLfKrbKnCJttxRf9PM51EnHTwmFKBxl4z1SGkoAhrfd6uZKE0dcjQTfm6XzTP8DPr1tzE4KIw==
+  dependencies:
+    base-x "^2.0.1"
 
 bs58@^4.0.0, bs58@^4.0.1:
   version "4.0.1"
@@ -12763,6 +12927,17 @@ http-deceiver@^1.2.7:
   resolved "https://registry.yarnpkg.com/http-deceiver/-/http-deceiver-1.2.7.tgz#fa7168944ab9a519d337cb0bec7284dc3e723d87"
   integrity sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw==
 
+http-errors@1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.2.tgz#4f5029cf13239f31036e5b2e55292bcfbcc85c8f"
+  integrity sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.3"
+    setprototypeof "1.1.1"
+    statuses ">= 1.5.0 < 2"
+    toidentifier "1.0.0"
+
 http-errors@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.0.tgz#b7774a1486ef73cf7667ac9ae0858c012c57b9d3"
@@ -15407,6 +15582,11 @@ lru-cache@^9.1.1:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.0.3.tgz#b40014d7d2d16d94130b87297a04a1f24874ae7c"
   integrity sha512-B7gr+F6MkqB3uzINHXNctGieGsRTMwIBgxkp0yq/5BwcuDzD4A8wQpHQW6vDAm1uKSLQghmRdD9sKqf2vJ1cEg==
 
+lru_map@0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/lru_map/-/lru_map-0.4.1.tgz#f7b4046283c79fb7370c36f8fca6aee4324b0a98"
+  integrity sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==
+
 ltgt@^2.1.2:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ltgt/-/ltgt-2.2.1.tgz#f35ca91c493f7b73da0e07495304f17b31f87ee5"
@@ -16057,6 +16237,11 @@ multiformats@^9.4.2:
   resolved "https://registry.yarnpkg.com/multiformats/-/multiformats-9.7.0.tgz#845799e8df70fbb6b15922500e45cb87cf12f7e5"
   integrity sha512-uv/tcgwk0yN4DStopnBN4GTgvaAlYdy6KnZpuzEPFOYQd71DYFJjs0MN1ERElAflrZaYyGBWXyGxL5GgrxIx0Q==
 
+mustache@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/mustache/-/mustache-4.0.0.tgz#7f02465dbb5b435859d154831c032acdfbbefb31"
+  integrity sha512-FJgjyX/IVkbXBXYUwH+OYwQKqWpFPLaLVESd70yHjSDunwzV2hZOoTBvPf4KLoxesUzzyfTH6F784Uqd7Wm5yA==
+
 mustache@^4.0.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/mustache/-/mustache-4.2.0.tgz#e5892324d60a12ec9c2a73359edca52972bf6f64"
@@ -16177,6 +16362,32 @@ near-api-js@^2.1.3:
     near-abi "0.1.1"
     node-fetch "^2.6.1"
     tweetnacl "^1.0.1"
+
+near-api-js@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/near-api-js/-/near-api-js-3.0.2.tgz#e5d9a97e248f5885bdd166df30452aef0f252b14"
+  integrity sha512-o8rgHH5ZV+V9grZTu4GSILupq41JyU3Mt/G6rZ2pBybHA2ozkfp9oIXKRqC4mCkbUtYLy//YoXuLRGLsRDlB2w==
+  dependencies:
+    "@near-js/accounts" "1.0.2"
+    "@near-js/crypto" "1.2.0"
+    "@near-js/keystores" "0.0.8"
+    "@near-js/keystores-browser" "0.0.8"
+    "@near-js/keystores-node" "0.0.8"
+    "@near-js/providers" "0.0.10"
+    "@near-js/signers" "0.1.0"
+    "@near-js/transactions" "1.1.0"
+    "@near-js/types" "0.0.4"
+    "@near-js/utils" "0.0.5"
+    "@near-js/wallet-account" "1.0.2"
+    "@noble/curves" "1.2.0"
+    ajv "8.11.2"
+    ajv-formats "2.1.1"
+    bn.js "5.2.1"
+    borsh "1.0.0"
+    depd "2.0.0"
+    http-errors "1.7.2"
+    near-abi "0.1.1"
+    node-fetch "2.6.7"
 
 near-hd-key@^1.2.1:
   version "1.2.1"
@@ -16303,17 +16514,17 @@ node-fetch-native@^1.4.0, node-fetch-native@^1.4.1:
   resolved "https://registry.yarnpkg.com/node-fetch-native/-/node-fetch-native-1.4.1.tgz#5a336e55b4e1b1e72b9927da09fecd2b374c9be5"
   integrity sha512-NsXBU0UgBxo2rQLOeWNZqS3fvflWePMECr8CoSWoSTqCqGbVVsvl9vZu1HfQicYN0g5piV9Gh8RTEvo/uP752w==
 
+node-fetch@2.6.7, node-fetch@^2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-fetch@^2.6.1, node-fetch@^2.6.8:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
-  dependencies:
-    whatwg-url "^5.0.0"
-
-node-fetch@^2.6.7:
-  version "2.6.7"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
-  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
   dependencies:
     whatwg-url "^5.0.0"
 
@@ -18364,7 +18575,7 @@ radix3@^1.1.0:
   resolved "https://registry.yarnpkg.com/radix3/-/radix3-1.1.0.tgz#9745df67a49c522e94a33d0a93cf743f104b6e0d"
   integrity sha512-pNsHDxbGORSvuSScqNJ+3Km6QAVqk8CfsCBIEoDgpqLrkD2f3QM4I7d1ozJJ172OmIcoUcerZaNWqtLkRXTV3A==
 
-randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
+randombytes@2.1.0, randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
   integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
@@ -19399,6 +19610,11 @@ setprototypeof@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
   integrity sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==
+
+setprototypeof@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.1.tgz#7e95acb24aa92f5885e0abef5ba131330d4ae683"
+  integrity sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==
 
 setprototypeof@1.2.0:
   version "1.2.0"
@@ -20442,6 +20658,11 @@ toggle-selection@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/toggle-selection/-/toggle-selection-1.0.6.tgz#6e45b1263f2017fa0acc7d89d78b15b8bf77da32"
   integrity sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==
+
+toidentifier@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
+  integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
 toidentifier@1.0.1:
   version "1.0.1"


### PR DESCRIPTION
It was necessary to add the ability to associate an application inside an iframe with a parent window and allow seamless initialization and method calls. This will help integrate applications inside wallets. For example Telegram HERE Wallet:

https://github.com/near/wallet-selector/assets/14349805/0e9bbc9f-5222-40bf-9592-3689e151d317


`topLevelInjected` method is needed because wallet-selector is designed in such a way that only modal-ui knows about the contract that the application uses. 