### PR TITLE
fix: Increase timeout when checking installed Nightly extension.

### DIFF
--- a/packages/nightly/src/lib/nightly.ts
+++ b/packages/nightly/src/lib/nightly.ts
@@ -60,7 +60,9 @@ const setupNightlyState = async (
   };
 };
 const isInstalled = () => {
-  return waitFor(() => !!window.nightly?.near).catch(() => false);
+  return waitFor(() => !!window.nightly?.near, { timeout: 5000 }).catch(
+    () => false
+  );
 };
 const Nightly: WalletBehaviourFactory<InjectedWallet> = async ({
   metadata,


### PR DESCRIPTION
# Description
When the user has a dozen extensions, Nightly has stopped detecting correctly. Nightly is injected a few milliseconds later.
 
Increasing the time to check whether an extension is installed solves this problem.



Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [x] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
