### PR TITLE
Update near-api-js Dependency

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,8 +2,7 @@
   "eslint.format.enable": true,
   "prettier.enable": false,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint":
-    true
+    "source.fixAll.eslint": "explicit"
   },
   "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "ethers": "^5.7.2",
     "https-browserify": "^1.0.0",
     "is-mobile": "^4.0.0",
-    "near-api-js": "^2.1.3",
+    "near-api-js": "^3.0.0",
     "near-seed-phrase": "^0.2.0",
     "next": "13.3.0",
     "ngx-deploy-npm": "^7.1.0",

--- a/packages/account-export/package.json
+++ b/packages/account-export/package.json
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/near/wallet-selector/tree/magin/packages/account-export",
   "peerDependencies": {
-    "near-api-js": "^1.0.0 || ^2.0.0"
+    "near-api-js": "^1.0.0 || ^2.0.0 || ^3.0.0"
   }
 }

--- a/packages/bitget-wallet/package.json
+++ b/packages/bitget-wallet/package.json
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/near/wallet-selector/tree/main/packages/bitget-wallet",
   "peerDependencies": {
-    "near-api-js": "^1.0.0 || ^2.0.0"
+    "near-api-js": "^1.0.0 || ^2.0.0 || ^3.0.0"
   }
 }

--- a/packages/coin98-wallet/package.json
+++ b/packages/coin98-wallet/package.json
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/near/wallet-selector/tree/main/packages/coin98-wallet",
   "peerDependencies": {
-    "near-api-js": "^1.0.0 || ^2.0.0"
+    "near-api-js": "^1.0.0 || ^2.0.0 || ^3.0.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,6 +20,6 @@
   },
   "homepage": "https://github.com/near/wallet-selector/tree/main/packages/core",
   "peerDependencies": {
-    "near-api-js": "^1.0.0 || ^2.0.0"
+    "near-api-js": "^1.0.0 || ^2.0.0 || ^3.0.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,6 +20,6 @@
   },
   "homepage": "https://github.com/near/wallet-selector/tree/main/packages/core",
   "peerDependencies": {
-    "near-api-js": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
+    "near-api-js": "^1.0.0 || ^2.0.0 || ^3.0.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,6 +20,6 @@
   },
   "homepage": "https://github.com/near/wallet-selector/tree/main/packages/core",
   "peerDependencies": {
-    "near-api-js": "^1.0.0 || ^2.0.0 || ^3.0.0"
+    "near-api-js": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
   }
 }

--- a/packages/here-wallet/package.json
+++ b/packages/here-wallet/package.json
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/near/wallet-selector/tree/main/packages/here-wallet",
   "peerDependencies": {
-    "near-api-js": "^1.0.0 || ^2.0.0"
+    "near-api-js": "^1.0.0 || ^2.0.0 || ^3.0.0"
   }
 }

--- a/packages/ledger/package.json
+++ b/packages/ledger/package.json
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/near/wallet-selector/tree/main/packages/ledger",
   "peerDependencies": {
-    "near-api-js": "^1.0.0 || ^2.0.0"
+    "near-api-js": "^1.0.0 || ^2.0.0 || ^3.0.0"
   }
 }

--- a/packages/ledger/src/lib/ledger-client.spec.ts
+++ b/packages/ledger/src/lib/ledger-client.spec.ts
@@ -153,7 +153,7 @@ describe("sign", () => {
 
     const transaction = createTransactionMock();
     const data = nearAPI.utils.serialize.serialize(
-      nearAPI.transactions.SCHEMA,
+      nearAPI.transactions.SCHEMA.Transaction,
       transaction
     );
 

--- a/packages/math-wallet/package.json
+++ b/packages/math-wallet/package.json
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/near/wallet-selector/tree/main/packages/math-wallet",
   "peerDependencies": {
-    "near-api-js": "^1.0.0 || ^2.0.0"
+    "near-api-js": "^1.0.0 || ^2.0.0 || ^3.0.0"
   }
 }

--- a/packages/meteor-wallet/package.json
+++ b/packages/meteor-wallet/package.json
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/near/wallet-selector/tree/main/packages/meteor-wallet",
   "peerDependencies": {
-    "near-api-js": "^1.0.0 || ^2.0.0"
+    "near-api-js": "^1.0.0 || ^2.0.0 || ^3.0.0"
   }
 }

--- a/packages/mintbase-wallet/package.json
+++ b/packages/mintbase-wallet/package.json
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/near/wallet-selector/tree/main/packages/mintbase-wallet",
   "peerDependencies": {
-    "near-api-js": "^1.0.0 || ^2.0.0"
+    "near-api-js": "^1.0.0 || ^2.0.0 || ^3.0.0"
   }
 }

--- a/packages/my-near-wallet/package.json
+++ b/packages/my-near-wallet/package.json
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/near/wallet-selector/tree/main/packages/my-near-wallet",
   "peerDependencies": {
-    "near-api-js": "^1.0.0 || ^2.0.0"
+    "near-api-js": "^1.0.0 || ^2.0.0 || ^3.0.0"
   }
 }

--- a/packages/near-mobile-wallet/package.json
+++ b/packages/near-mobile-wallet/package.json
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/near/wallet-selector/tree/main/packages/near-mobile-wallet",
   "peerDependencies": {
-    "near-api-js": "^1.0.0 || ^2.0.0"
+    "near-api-js": "^1.0.0 || ^2.0.0 || ^3.0.0"
   }
 }

--- a/packages/near-snap/package.json
+++ b/packages/near-snap/package.json
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/near/wallet-selector/tree/main/packages/near-snap",
   "peerDependencies": {
-    "near-api-js": "^1.0.0 || ^2.0.0"
+    "near-api-js": "^1.0.0 || ^2.0.0 || ^3.0.0"
   }
 }

--- a/packages/nearfi/package.json
+++ b/packages/nearfi/package.json
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/near/wallet-selector/tree/main/packages/nearfi",
   "peerDependencies": {
-    "near-api-js": "^1.0.0 || ^2.0.0"
+    "near-api-js": "^1.0.0 || ^2.0.0 || ^3.0.0"
   }
 }

--- a/packages/neth/package.json
+++ b/packages/neth/package.json
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/near/wallet-selector/tree/main/packages/neth",
   "peerDependencies": {
-    "near-api-js": "^1.0.0 || ^2.0.0"
+    "near-api-js": "^1.0.0 || ^2.0.0 || ^3.0.0"
   }
 }

--- a/packages/nightly/package.json
+++ b/packages/nightly/package.json
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/near/wallet-selector/tree/main/packages/nightly",
   "peerDependencies": {
-    "near-api-js": "^1.0.0 || ^2.0.0"
+    "near-api-js": "^1.0.0 || ^2.0.0 || ^3.0.0"
   }
 }

--- a/packages/ramper-wallet/package.json
+++ b/packages/ramper-wallet/package.json
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/near/wallet-selector/tree/main/packages/ramper-wallet",
   "peerDependencies": {
-    "near-api-js": "^1.0.0 || ^2.0.0"
+    "near-api-js": "^1.0.0 || ^2.0.0 || ^3.0.0"
   }
 }

--- a/packages/sender/package.json
+++ b/packages/sender/package.json
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/near/wallet-selector/tree/main/packages/sender",
   "peerDependencies": {
-    "near-api-js": "^1.0.0 || ^2.0.0"
+    "near-api-js": "^1.0.0 || ^2.0.0 || ^3.0.0"
   }
 }

--- a/packages/wallet-connect/package.json
+++ b/packages/wallet-connect/package.json
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/near/wallet-selector/tree/main/packages/wallet-connect",
   "peerDependencies": {
-    "near-api-js": "^1.0.0 || ^2.0.0"
+    "near-api-js": "^1.0.0 || ^2.0.0 || ^3.0.0"
   }
 }

--- a/packages/wallet-utils/package.json
+++ b/packages/wallet-utils/package.json
@@ -20,6 +20,6 @@
   },
   "homepage": "https://github.com/near/wallet-selector/tree/main/packages/wallet-utils",
   "peerDependencies": {
-    "near-api-js": "^1.0.0 || ^2.0.0"
+    "near-api-js": "^1.0.0 || ^2.0.0 || ^3.0.0"
   }
 }

--- a/packages/wallet-utils/src/lib/wallet-utils.spec.ts
+++ b/packages/wallet-utils/src/lib/wallet-utils.spec.ts
@@ -2,6 +2,8 @@ import { createAction } from "./wallet-utils";
 import { transactions, utils } from "near-api-js";
 import BN = require("bn.js");
 
+const TEST_PUBLIC_KEY = "ed25519:Anu5D32fr5YsQGVULF4fz3R2E3pNaeUhj4hsKcE4vDyk";
+
 describe("transformActions", () => {
   it("correctly transforms 'CreateAccount' action", () => {
     const actions = createAction({ type: "CreateAccount" });
@@ -57,7 +59,7 @@ describe("transformActions", () => {
 
   it("correctly transforms 'Stake' action", () => {
     const stake = "1";
-    const publicKey = "";
+    const publicKey = TEST_PUBLIC_KEY;
 
     const actions = createAction({
       type: "Stake",
@@ -73,7 +75,7 @@ describe("transformActions", () => {
   });
 
   it("correctly transforms 'AddKey' action with 'FullAccess' permission", () => {
-    const publicKey = "";
+    const publicKey = TEST_PUBLIC_KEY;
     const actions = createAction({
       type: "AddKey",
       params: {
@@ -93,7 +95,7 @@ describe("transformActions", () => {
   });
 
   it("correctly transforms 'AddKey' action with 'FunctionCall' permission", () => {
-    const publicKey = "";
+    const publicKey = TEST_PUBLIC_KEY;
     const receiverId = "test.testnet";
     const allowance = "1";
     const methodNames = ["methodName"];
@@ -125,7 +127,7 @@ describe("transformActions", () => {
   });
 
   it("correctly transforms 'DeleteKey' action", () => {
-    const publicKey = "";
+    const publicKey = TEST_PUBLIC_KEY;
 
     const actions = createAction({
       type: "DeleteKey",

--- a/packages/welldone-wallet/package.json
+++ b/packages/welldone-wallet/package.json
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/near/wallet-selector/tree/main/packages/welldone-wallet",
   "peerDependencies": {
-    "near-api-js": "^1.0.0 || ^2.0.0"
+    "near-api-js": "^1.0.0 || ^2.0.0 || ^3.0.0"
   }
 }

--- a/packages/xdefi/package.json
+++ b/packages/xdefi/package.json
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/near/wallet-selector/tree/main/packages/xdefi",
   "peerDependencies": {
-    "near-api-js": "^1.0.0 || ^2.0.0"
+    "near-api-js": "^1.0.0 || ^2.0.0 || ^3.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3466,7 +3466,7 @@
     nanoid "3.3.6"
     query-string "^7.1.3"
 
-"@mintbase-js/wallet@^0.6.0-beta.3":
+"@mintbase-js/wallet@0.6.0-beta.3":
   version "0.6.0-beta.3"
   resolved "https://registry.yarnpkg.com/@mintbase-js/wallet/-/wallet-0.6.0-beta.3.tgz#31ee107f2cf888fa120e8ca07f47e5dcd278ca26"
   integrity sha512-fzkqS3LDnSHB4YG0ync8JRuv+xQlMOzcu0btpAN8SC1hZNGUak0BTXBiNxKZQTeuH/DL+6ghh+t9VzJknOorhA==
@@ -3671,6 +3671,25 @@
     lru_map "0.4.1"
     near-abi "0.1.1"
 
+"@near-js/accounts@1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@near-js/accounts/-/accounts-1.0.4.tgz#b699dc1c63ffccc1598481b4260dfaf2507f0a69"
+  integrity sha512-6zgSwq/rQ9ggPOIkGUx9RoEurbJiojqA/axeh6o1G+46GqUBI7SUcDooyVvZjeiOvUPObnTQptDYpbV+XZji8g==
+  dependencies:
+    "@near-js/crypto" "1.2.1"
+    "@near-js/providers" "0.1.1"
+    "@near-js/signers" "0.1.1"
+    "@near-js/transactions" "1.1.2"
+    "@near-js/types" "0.0.4"
+    "@near-js/utils" "0.1.0"
+    ajv "8.11.2"
+    ajv-formats "2.1.1"
+    bn.js "5.2.1"
+    borsh "1.0.0"
+    depd "2.0.0"
+    lru_map "0.4.1"
+    near-abi "0.1.1"
+
 "@near-js/crypto@0.0.4":
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/@near-js/crypto/-/crypto-0.0.4.tgz#7bb991da25f06096de51466c6331cb185314fad8"
@@ -3703,6 +3722,18 @@
     borsh "1.0.0"
     randombytes "2.1.0"
 
+"@near-js/crypto@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@near-js/crypto/-/crypto-1.2.1.tgz#aa18bed171e68653dae9f82114636eba34ece32a"
+  integrity sha512-iJOHaGKvdudYfR8nEtRhGlgcTEHeVmxMoT0JVXmuP3peG96v/sSnA03CE6MZBeCC8txKAQOffagxE7oU6hJp9g==
+  dependencies:
+    "@near-js/types" "0.0.4"
+    "@near-js/utils" "0.1.0"
+    "@noble/curves" "1.2.0"
+    bn.js "5.2.1"
+    borsh "1.0.0"
+    randombytes "2.1.0"
+
 "@near-js/keystores-browser@0.0.4":
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/@near-js/keystores-browser/-/keystores-browser-0.0.4.tgz#9c1130e2c0becf6bb9cfaaa7594ad38ed25585bd"
@@ -3726,6 +3757,14 @@
   dependencies:
     "@near-js/crypto" "1.2.0"
     "@near-js/keystores" "0.0.8"
+
+"@near-js/keystores-browser@0.0.9":
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/@near-js/keystores-browser/-/keystores-browser-0.0.9.tgz#4d6211ad617613124aeee78ede5771b153e3bcdd"
+  integrity sha512-JzPj+RHJN2G3CEm/LyfbtZDQy/wxgOlqfh52voqPGijUHg93b27KBqtZShazAgJNkhzRbWcoluWQnd2jL8vF7A==
+  dependencies:
+    "@near-js/crypto" "1.2.1"
+    "@near-js/keystores" "0.0.9"
 
 "@near-js/keystores-node@0.0.4":
   version "0.0.4"
@@ -3751,6 +3790,14 @@
     "@near-js/crypto" "1.2.0"
     "@near-js/keystores" "0.0.8"
 
+"@near-js/keystores-node@0.0.9":
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/@near-js/keystores-node/-/keystores-node-0.0.9.tgz#c2fd2f5bfbca1c75699dd7324e300cfd12e790ed"
+  integrity sha512-2B9MYz6uIhysG1fhQSjvaPYCM7gM+UAeDchX0J8QRauXIeN8TGzpcdgkdkMUnWNTIdt3Iblh0ZuCs+FY02dTXg==
+  dependencies:
+    "@near-js/crypto" "1.2.1"
+    "@near-js/keystores" "0.0.9"
+
 "@near-js/keystores@0.0.4":
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/@near-js/keystores/-/keystores-0.0.4.tgz#da03069497bb14741a4d97f7ad4746baf9a09ea7"
@@ -3773,6 +3820,14 @@
   integrity sha512-H3JQroNbx0AvNpXsGiDdjVZCFPqd6Qx29XK618GhwSqvvmFQxq96sh51dmPhJ+jVxFUTt7Q9es8fujYbZceAzw==
   dependencies:
     "@near-js/crypto" "1.2.0"
+    "@near-js/types" "0.0.4"
+
+"@near-js/keystores@0.0.9":
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/@near-js/keystores/-/keystores-0.0.9.tgz#768aaaab1beb7f797432513cb1bbf9430e305a85"
+  integrity sha512-j8ySgVEcm2Gg6zxkSdadNtPlIqhJZdPGfWWM3tPtEoowNS9snhwZn5NRFPrgmX0+MzpF7E091CRcY90MvRVhsg==
+  dependencies:
+    "@near-js/crypto" "1.2.1"
     "@near-js/types" "0.0.4"
 
 "@near-js/providers@0.0.10":
@@ -3817,6 +3872,20 @@
   optionalDependencies:
     node-fetch "^2.6.1"
 
+"@near-js/providers@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@near-js/providers/-/providers-0.1.1.tgz#7489eb5a4248562fe98fdbc4cb55ea3f6d787e0a"
+  integrity sha512-0M/Vz2Ac34ShKVoe2ftVJ5Qg4eSbEqNXDbCDOdVj/2qbLWZa7Wpe+me5ei4TMY2ZhGdawhgJUPrYwdJzOCyf8w==
+  dependencies:
+    "@near-js/transactions" "1.1.2"
+    "@near-js/types" "0.0.4"
+    "@near-js/utils" "0.1.0"
+    bn.js "5.2.1"
+    borsh "1.0.0"
+    http-errors "1.7.2"
+  optionalDependencies:
+    node-fetch "2.6.7"
+
 "@near-js/signers@0.0.4":
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/@near-js/signers/-/signers-0.0.4.tgz#a1904ccc718d6f87b05cd2e168f33bde0cfb269a"
@@ -3842,6 +3911,15 @@
   dependencies:
     "@near-js/crypto" "1.2.0"
     "@near-js/keystores" "0.0.8"
+    "@noble/hashes" "1.3.3"
+
+"@near-js/signers@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@near-js/signers/-/signers-0.1.1.tgz#6d32b262eac9b03fab5fc1ee93d2c4055c86980f"
+  integrity sha512-focJgs04dBUfawMnyGg3yIjaMawuVz2OeLRKC4t5IQDmO4PLfdIraEuwgS7tckMq3GdrJ7nqkwkpSNYpdt7I5Q==
+  dependencies:
+    "@near-js/crypto" "1.2.1"
+    "@near-js/keystores" "0.0.9"
     "@noble/hashes" "1.3.3"
 
 "@near-js/transactions@0.2.0":
@@ -3883,6 +3961,19 @@
     bn.js "5.2.1"
     borsh "1.0.0"
 
+"@near-js/transactions@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@near-js/transactions/-/transactions-1.1.2.tgz#7dec18b463cd336e325ee61b1e1c39a6192d9e81"
+  integrity sha512-AqYA56ncwgrWjIu+bNaWjTPRZb0O+SfpWIP7U+1FKNKxNYMCtkt6zp7SlQeZn743shKVq9qMzA9+ous/KCb0QQ==
+  dependencies:
+    "@near-js/crypto" "1.2.1"
+    "@near-js/signers" "0.1.1"
+    "@near-js/types" "0.0.4"
+    "@near-js/utils" "0.1.0"
+    "@noble/hashes" "1.3.3"
+    bn.js "5.2.1"
+    borsh "1.0.0"
+
 "@near-js/types@0.0.4":
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/@near-js/types/-/types-0.0.4.tgz#d941689df41c850aeeeaeb9d498418acec515404"
@@ -3904,6 +3995,17 @@
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/@near-js/utils/-/utils-0.0.5.tgz#7c7f80140c039535b04ec48ed84b9681407ea57a"
   integrity sha512-0YnPruP6xZc/scIAX7E3GrTrFMNAyB9bFZOoOdA60GPzHwTTfpXsdozZvsQN4LvfFuiCDN1OEhwx7EtJh43DRw==
+  dependencies:
+    "@near-js/types" "0.0.4"
+    bn.js "5.2.1"
+    bs58 "4.0.0"
+    depd "2.0.0"
+    mustache "4.0.0"
+
+"@near-js/utils@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@near-js/utils/-/utils-0.1.0.tgz#1368f59008c39df1e903bd3e0f308eedcdf25c1d"
+  integrity sha512-kOVAXmJzaC8ElJD3RLEoBuqOK+d5s7jc0JkvhyEtbuEmXYHHAy9Q17/YkDcX9tyr01L85iOt66z0cODqzgtQwA==
   dependencies:
     "@near-js/types" "0.0.4"
     bn.js "5.2.1"
@@ -3953,6 +4055,21 @@
     "@near-js/transactions" "1.1.0"
     "@near-js/types" "0.0.4"
     "@near-js/utils" "0.0.5"
+    bn.js "5.2.1"
+    borsh "1.0.0"
+
+"@near-js/wallet-account@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@near-js/wallet-account/-/wallet-account-1.1.1.tgz#e66e8d10fb51f71f7cb722bdff63fb98e2b0d486"
+  integrity sha512-NnoJKtogBQ7Qz+AP+LdF70BP8Az6UXQori7OjPqJLMo73bn6lh5Ywvegwd1EB7ZEVe4BRt9+f9QkbU5M8ANfAw==
+  dependencies:
+    "@near-js/accounts" "1.0.4"
+    "@near-js/crypto" "1.2.1"
+    "@near-js/keystores" "0.0.9"
+    "@near-js/signers" "0.1.1"
+    "@near-js/transactions" "1.1.2"
+    "@near-js/types" "0.0.4"
+    "@near-js/utils" "0.1.0"
     bn.js "5.2.1"
     borsh "1.0.0"
 
@@ -16372,6 +16489,32 @@ near-api-js@^2.1.3:
     node-fetch "^2.6.1"
     tweetnacl "^1.0.1"
 
+near-api-js@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/near-api-js/-/near-api-js-3.0.4.tgz#5ee094ce53e30239cc817ca942ec3e9739296dbb"
+  integrity sha512-qKWjnugoB7kSFhzZ5GXyH/eABspCQYWBmWnM4hpV5ctnQBt89LqgEu9yD1z4sa89MvUu8BuCxwb1m00BE8iofg==
+  dependencies:
+    "@near-js/accounts" "1.0.4"
+    "@near-js/crypto" "1.2.1"
+    "@near-js/keystores" "0.0.9"
+    "@near-js/keystores-browser" "0.0.9"
+    "@near-js/keystores-node" "0.0.9"
+    "@near-js/providers" "0.1.1"
+    "@near-js/signers" "0.1.1"
+    "@near-js/transactions" "1.1.2"
+    "@near-js/types" "0.0.4"
+    "@near-js/utils" "0.1.0"
+    "@near-js/wallet-account" "1.1.1"
+    "@noble/curves" "1.2.0"
+    ajv "8.11.2"
+    ajv-formats "2.1.1"
+    bn.js "5.2.1"
+    borsh "1.0.0"
+    depd "2.0.0"
+    http-errors "1.7.2"
+    near-abi "0.1.1"
+    node-fetch "2.6.7"
+
 near-api-js@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/near-api-js/-/near-api-js-3.0.2.tgz#e5d9a97e248f5885bdd166df30452aef0f252b14"
@@ -20141,7 +20284,16 @@ string-range@~1.2, string-range@~1.2.1:
   resolved "https://registry.yarnpkg.com/string-range/-/string-range-1.2.2.tgz#a893ed347e72299bc83befbbf2a692a8d239d5dd"
   integrity sha512-tYft6IFi8SjplJpxCUxyqisD3b+R2CSkomrtJYCkvuf1KuCAWgz7YXt4O0jip7efpfCemwHEzTEAO8EuOYgh3w==
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -20237,7 +20389,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -21794,7 +21953,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -21807,6 +21966,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
# Description

This change updates the near-api-js dependency on the global level of this package to v3 (I thought incremental steps would make the changes easier to introduce). Note that only a few tests had to be adjusted (but the changes were trivial). One in `wallet-utils` and one in `leger-client`. Furthermore, we update the "peerDependencies" in all the packages (really not sure why these are even here).

If approved, this closes #1104.

To make review easier, the most relevant diff is in this commit: [962839e](https://github.com/near/wallet-selector/pull/1105/commits/962839e2cc98db6a1a595f352fdd82dae66e0393)

If accepted, I would proceed in continuing on to upgrade to v4.

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

# Type of change.

CHORE - Update long outdated package (cf #1104)

Note that I have not yet managed to build the entire project locally. These are the build status results:

    ✔    21/24 succeeded [1 read from cache]
 
    ✖    3/24 targets failed, including the following:
         - nx run near-mobile-wallet:build
         - nx run account-export:build
         - nx run modal-ui:build
         
 I am trying to track down the culprits:
 
1.  Near Mobile Wallet has this [open PR](https://github.com/Peersyst/near-mobile-wallet/pull/408) that is passing
2. The other common problem appears to be with a few react Elements not having "children": 

```
Argument of type 'Element' is not assignable to parameter of type 'ReactNode'.
  Property 'children' is missing in type 'Element' but required in type 'ReactPortal'.
```