### PR TITLE
fix: Hide Ethereum wallets modal after tx error within a batch.

### DIFF
--- a/packages/ethereum-wallets/src/lib/index.ts
+++ b/packages/ethereum-wallets/src/lib/index.ts
@@ -688,6 +688,8 @@ const EthereumWallets: WalletBehaviourFactory<
                     "Transaction execution error, failed to parse failure reason."
                   );
                 }
+                // NOTE: after return, `finally { hideModal() }` will run.
+                return;
               }
               results.push(nearTx);
             }


### PR DESCRIPTION
# Description

Hide the Ethereum wallets modal after a transaction error within a batch. Currently it lets the user sign the next transaction in the batch even though the App handles the rejected signAndSendTransactions() promise.

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [x] FIX - a PR of this type patches a bug.
<!-- /CHECKLIST_TYPE -->
