### PR TITLE
fix: Handle transactions after NAJ update to v4.0.x for WalletConnect

### DIFF
--- a/packages/wallet-connect/src/lib/wallet-connect.ts
+++ b/packages/wallet-connect/src/lib/wallet-connect.ts
@@ -354,7 +354,10 @@ const WalletConnect: WalletBehaviourFactory<
       },
     });
 
-    return nearAPI.transactions.SignedTransaction.decode(Buffer.from(result));
+    // @ts-ignore
+    const isBuffer = result?.type === "Buffer";
+    const txResult = isBuffer ? result : Object.values(result);
+    return nearAPI.transactions.SignedTransaction.decode(Buffer.from(txResult));
   };
 
   const requestSignTransactions = async (transactions: Array<Transaction>) => {
@@ -408,7 +411,12 @@ const WalletConnect: WalletBehaviourFactory<
     });
 
     return results.map((result) => {
-      return nearAPI.transactions.SignedTransaction.decode(Buffer.from(result));
+      // @ts-ignore
+      const isBuffer = result?.type === "Buffer";
+      const txResult = isBuffer ? result : Object.values(result);
+      return nearAPI.transactions.SignedTransaction.decode(
+        Buffer.from(txResult)
+      );
     });
   };
 


### PR DESCRIPTION
# Description

After the update of wallet selector to use NAJ `v4.0.x` the wallet-connect `signAndSendTransaction(s)` has stopped working because the type of the value of  `tx.encode()` has changed from `Buffer` to `Uint8Array` since NAJ v3  the `borsh@1.0.0` update.

WalletConnect uses [formats and encodes](https://github.com/WalletConnect/walletconnect-monorepo/blob/v2.0/packages/sign-client/src/controllers/engine.ts#L1454) the payload and this handles the `Buffer` and `Uint8Array` differently.

This PR adds support to handle the result returned from a wallet that uses latest version of NAJ (Uint8Array) and still keeps support for the old versions (Buffer).

I have also updated the web-examples of WalletConnect to add support for the latest version(s) of NAJ:
https://github.com/WalletConnect/web-examples/pull/702

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [x] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
