### PR TITLE
Ethereum tx show details - skipSignInAccessKey bugfix

### DIFF
--- a/packages/ethereum-wallets/src/lib/index.ts
+++ b/packages/ethereum-wallets/src/lib/index.ts
@@ -317,7 +317,7 @@ const EthereumWallets: WalletBehaviourFactory<
               options.network.networkId,
               devMode ? address + "." + devModeAccount : address
             );
-            if (!keyPair) {
+            if (!keyPair && !skipSignInAccessKey) {
               try {
                 wagmiCore!.disconnect(wagmiConfig);
               } catch (error) {

--- a/packages/ethereum-wallets/src/lib/index.ts
+++ b/packages/ethereum-wallets/src/lib/index.ts
@@ -591,6 +591,7 @@ const EthereumWallets: WalletBehaviourFactory<
             for (const [index, tx] of txs.entries()) {
               let txHash;
               let txError: string | null = null;
+              let showDetails = false;
               while (!txHash) {
                 try {
                   await (() => {
@@ -599,6 +600,10 @@ const EthereumWallets: WalletBehaviourFactory<
                         selectedIndex: index,
                         ethTxHashes,
                         error: txError,
+                        showDetails,
+                        onShowDetails: (state: boolean) => {
+                          showDetails = state;
+                        },
                         onConfirm: async () => {
                           try {
                             txError = null;
@@ -606,6 +611,7 @@ const EthereumWallets: WalletBehaviourFactory<
                               selectedIndex: index,
                               ethTxHashes,
                               error: txError,
+                              showDetails,
                             });
                             txHash = await executeTransaction({
                               tx,

--- a/packages/ethereum-wallets/src/lib/modal.ts
+++ b/packages/ethereum-wallets/src/lib/modal.ts
@@ -98,11 +98,15 @@ export function createTxModal({
     selectedIndex,
     ethTxHashes,
     error,
+    showDetails,
+    onShowDetails,
     onConfirm,
   }: {
     selectedIndex: number;
     ethTxHashes: Array<string>;
     error?: string | null;
+    onShowDetails?: (state: boolean) => void;
+    showDetails?: boolean;
     onConfirm?: () => void;
   }) => {
     const container = document.querySelector(
@@ -339,6 +343,16 @@ export function createTxModal({
       ".ethereum-wallet-txs-details"
     ) as HTMLElement | null;
 
+    if (detailsContainer && toggleButton) {
+      if (showDetails) {
+        detailsContainer.style.display = "block";
+        toggleButton.textContent = "Hide details";
+      } else {
+        detailsContainer.style.display = "none";
+        toggleButton.textContent = "Show details";
+      }
+    }
+
     toggleButton?.addEventListener("click", () => {
       if (!detailsContainer || !toggleButton) {
         return;
@@ -350,9 +364,15 @@ export function createTxModal({
       ) {
         detailsContainer.style.display = "block";
         toggleButton.textContent = "Hide details";
+        if (onShowDetails) {
+          onShowDetails(true);
+        }
       } else {
         detailsContainer.style.display = "none";
         toggleButton.textContent = "Show details";
+        if (onShowDetails) {
+          onShowDetails(false);
+        }
       }
     });
   };


### PR DESCRIPTION
Bug fixes:
- Ethereum transaction details button state (don't close the details when signing the transaction)
- During account or network switch, if skipSignInAccessKey is active then disconnecting is not necessary.