### PR TITLE
fix: define range of `near-api-js` versions as peerDependency instead of an exact one

### DIFF
--- a/packages/account-export/package.json
+++ b/packages/account-export/package.json
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/near/wallet-selector/tree/magin/packages/account-export",
   "peerDependencies": {
-    "near-api-js": "4.0.3"
+    "near-api-js": "^4.0.0 || ^5.0.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,6 +20,6 @@
   },
   "homepage": "https://github.com/near/wallet-selector/tree/main/packages/core",
   "peerDependencies": {
-    "near-api-js": "4.0.3"
+    "near-api-js": "^4.0.0 || ^5.0.0"
   }
 }

--- a/packages/wallet-connect/package.json
+++ b/packages/wallet-connect/package.json
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/near/wallet-selector/tree/main/packages/wallet-connect",
   "peerDependencies": {
-    "near-api-js": "4.0.3"
+    "near-api-js": "^4.0.0 || ^5.0.0"
   }
 }

--- a/packages/wallet-utils/package.json
+++ b/packages/wallet-utils/package.json
@@ -20,6 +20,6 @@
   },
   "homepage": "https://github.com/near/wallet-selector/tree/main/packages/wallet-utils",
   "peerDependencies": {
-    "near-api-js": "4.0.3"
+    "near-api-js": "^4.0.0 || ^5.0.0"
   }
 }


### PR DESCRIPTION
Thanks for taking the time to submit a pull request!

If you haven't already, be sure to take a look at the [CONTRIBUTING](https://github.com/near/wallet-selector/blob/main/CONTRIBUTING.md) documentation to get up to speed with the practices in this repository.

When you're ready, switch to the "Preview" tab to select an applicable template:

- [General template (most common)](?expand=1&template=general.md)
- [Wallet integration template](?expand=1&template=wallet_integration.md)
