### PR TITLE
fix: signandsendtxs hook returns results

### DIFF
--- a/packages/react-hook/src/lib/WalletSelectorProvider.tsx
+++ b/packages/react-hook/src/lib/WalletSelectorProvider.tsx
@@ -237,12 +237,18 @@ export function WalletSelectorProvider({
    * @returns {Promise<Transaction[]>} - the resulting transactions
    */
   const signAndSendTransactions = useCallback(
-    ({ transactions }: { transactions: Array<Transaction> }) => {
+    async ({ transactions }: { transactions: Array<Transaction> }) => {
       if (!wallet) {
         throw new WalletError("No wallet connected");
       }
 
-      return wallet.signAndSendTransactions({ transactions });
+      const sentTxs = (await wallet.signAndSendTransactions({
+        transactions,
+      })) as Array<FinalExecutionOutcome>;
+
+      return sentTxs.map((tx: FinalExecutionOutcome) =>
+        providers.getTransactionLastResult(tx)
+      );
     },
     [wallet]
   );


### PR DESCRIPTION
# Description

Our current `signAndSendTransactions` hook returns a vector of `FinalExecutionOutcome`, but people is generally waiting for the actual result

This PR modifies the hook so it returns the result of the Transaction, and not the execution object itself

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [x] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
