### PR TITLE
fix: disable wallet connect signMessage

### DIFF
--- a/packages/wallet-connect/src/lib/wallet-connect.ts
+++ b/packages/wallet-connect/src/lib/wallet-connect.ts
@@ -79,7 +79,9 @@ const WC_METHODS = [
   "near_signTransaction",
   "near_signTransactions",
   "near_verifyOwner",
-  "near_signMessage",
+  // disabling this due to WalletConnect not supporting it
+  // see https://docs.reown.com/advanced/multichain/rpc-reference/near-rpc
+  // "near_signMessage",
 ];
 
 const WC_EVENTS = ["chainChanged", "accountsChanged"];


### PR DESCRIPTION
# Description

Hey,
WalletConnect is broken in wallet selector due to them not supporting [near_signMessage](https://docs.reown.com/advanced/multichain/rpc-reference/near-rpc).
The fix is fairly simple, because we can just remove this method from the required namespace.

Testing this fix is unfortunately not that easy, because Fireblocks is currently the only wallet that support WalletConnect on Near and it's hard to get an account there.

This fix will have a high impact, because Fireblocks is the institutional standard for wallets.

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [x] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
