### PR TITLE
feat: Implement createSignedTransaction and returns SignedTransaction

### DIFF
--- a/examples/react/components/Content.tsx
+++ b/examples/react/components/Content.tsx
@@ -129,7 +129,8 @@ const Content: React.FC = () => {
       : "Failed to verify";
 
     alert(
-      `${alertMessage} signed message: '${message.message
+      `${alertMessage} signed message: '${
+        message.message
       }': \n ${JSON.stringify(signedMessage)}`
     );
   };
@@ -138,31 +139,39 @@ const Content: React.FC = () => {
     async (e: Submitted) => {
       e.preventDefault();
 
-      const { fieldset, message, donation, multiple, signonly } = e.target.elements;
+      const { fieldset, message, donation, multiple, signonly } =
+        e.target.elements;
 
       fieldset.disabled = true;
 
       if (signonly.checked) {
         return signTransaction({
           receiverId: CONTRACT_ID,
-          actions: [{
-            type: "FunctionCall",
-            params: {
-              methodName: "addMessage",
-              args: { text: message.value },
-              gas: BOATLOAD_OF_GAS,
-              deposit: utils.format.parseNearAmount(donation.value) || "0",
+          actions: [
+            {
+              type: "FunctionCall",
+              params: {
+                methodName: "addMessage",
+                args: { text: message.value },
+                gas: BOATLOAD_OF_GAS,
+                deposit: utils.format.parseNearAmount(donation.value) || "0",
+              },
             },
-          }]
-        }).then((signedTransaction) => {
-          alert("Successfully signed transaction. Signature is:\n" + signedTransaction);
-          console.log("signedTx", signedTransaction)
-          return signedTransaction;
-        }).catch((err) => {
-          alert("Failed to sign transaction " + err);
-          console.log("Failed to sign transaction");
-          throw err;
+          ],
         })
+          .then((signedTransaction) => {
+            alert(
+              "Successfully signed transaction. Signature is:\n" +
+                signedTransaction
+            );
+            console.log("signedTx", signedTransaction);
+            return signedTransaction;
+          })
+          .catch((err) => {
+            alert("Failed to sign transaction " + err);
+            console.log("Failed to sign transaction");
+            throw err;
+          });
       }
 
       return addMessages(message.value, donation.value || "0", multiple.checked)

--- a/examples/react/components/Content.tsx
+++ b/examples/react/components/Content.tsx
@@ -30,7 +30,7 @@ const Content: React.FC = () => {
     viewFunction,
     callFunction,
     signAndSendTransactions,
-    signTransaction,
+    createSignedTransaction,
     wallet,
     signMessage,
     walletSelector,
@@ -145,21 +145,19 @@ const Content: React.FC = () => {
       fieldset.disabled = true;
 
       if (signonly.checked) {
-        return signTransaction({
-          receiverId: CONTRACT_ID,
-          actions: [
-            {
-              type: "FunctionCall",
-              params: {
-                methodName: "addMessage",
-                args: { text: message.value },
-                gas: BOATLOAD_OF_GAS,
-                deposit: utils.format.parseNearAmount(donation.value) || "0",
-              },
+        return createSignedTransaction(CONTRACT_ID, [
+          {
+            type: "FunctionCall",
+            params: {
+              methodName: "addMessage",
+              args: { text: message.value },
+              gas: BOATLOAD_OF_GAS,
+              deposit: utils.format.parseNearAmount(donation.value) || "0",
             },
-          ],
-        })
+          },
+        ])
           .then((signedTransaction) => {
+            fieldset.disabled = false;
             alert(
               "Successfully signed transaction. Signature is:\n" +
                 signedTransaction

--- a/examples/react/components/Form.tsx
+++ b/examples/react/components/Form.tsx
@@ -31,6 +31,10 @@ const Form: React.FC<FormProps> = ({ signedAccountId, onSubmit }) => {
           <label htmlFor="multiple">Multiple Transactions:</label>
           <input id="multiple" type="checkbox" />
         </p>
+        <p>
+          <label htmlFor="signonly">Sign only and Return Signature:</label>
+          <input id="signonly" type="checkbox" />
+        </p>
         <button type="submit">Sign</button>
       </fieldset>
     </form>

--- a/packages/arepa-wallet/src/lib/arepa-wallet.ts
+++ b/packages/arepa-wallet/src/lib/arepa-wallet.ts
@@ -240,6 +240,12 @@ const ArepaWallet: WalletBehaviourFactory<
 
       throw new Error(`Method not supported by ${metadata.name}`);
     },
+
+    async signTransaction(transaction) {
+      logger.log("signTransaction", { transaction });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
+    },
   };
 };
 

--- a/packages/arepa-wallet/src/lib/arepa-wallet.ts
+++ b/packages/arepa-wallet/src/lib/arepa-wallet.ts
@@ -234,6 +234,12 @@ const ArepaWallet: WalletBehaviourFactory<
         callbackUrl,
       });
     },
+
+    async createSignedTransaction(receiverId, actions) {
+      logger.log("createSignedTransaction", { receiverId, actions });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
+    },
   };
 };
 

--- a/packages/bitget-wallet/src/lib/bitget-wallet.ts
+++ b/packages/bitget-wallet/src/lib/bitget-wallet.ts
@@ -250,6 +250,12 @@ const BitgetWallet: WalletBehaviourFactory<InjectedWallet> = async ({
 
       throw new Error(`Method not supported by ${metadata.name}`);
     },
+
+    async signTransaction(transaction) {
+      logger.log("signTransaction", { transaction });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
+    },
   };
 };
 

--- a/packages/bitget-wallet/src/lib/bitget-wallet.ts
+++ b/packages/bitget-wallet/src/lib/bitget-wallet.ts
@@ -45,6 +45,7 @@ const BitgetWallet: WalletBehaviourFactory<InjectedWallet> = async ({
   provider,
   emitter,
   logger,
+  metadata,
 }) => {
   const _state = setupBitgetWalletState();
 
@@ -242,6 +243,12 @@ const BitgetWallet: WalletBehaviourFactory<InjectedWallet> = async ({
 
           return res.response;
         });
+    },
+
+    async createSignedTransaction(receiverId, actions) {
+      logger.log("createSignedTransaction", { receiverId, actions });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
     },
   };
 };

--- a/packages/coin98-wallet/src/lib/coin98-wallet.ts
+++ b/packages/coin98-wallet/src/lib/coin98-wallet.ts
@@ -201,7 +201,7 @@ const Coin98Wallet: WalletBehaviourFactory<InjectedWallet> = async ({
       logger.log("signTransaction", { transaction });
 
       return await nearAPI.transactions.signTransaction(
-        transaction as unknown as nearAPI.transactions.Transaction,
+        transaction,
         _state.wallet.near.signer,
         transaction.signerId,
         options.network.networkId

--- a/packages/coin98-wallet/src/lib/coin98-wallet.ts
+++ b/packages/coin98-wallet/src/lib/coin98-wallet.ts
@@ -180,6 +180,18 @@ const Coin98Wallet: WalletBehaviourFactory<InjectedWallet> = async ({
 
       return results;
     },
+
+    async createSignedTransaction(receiverId, actions) {
+      logger.log("createSignedTransaction", { receiverId, actions });
+
+      const [signedTx] = await signTransactions(
+        transformTransactions([{ receiverId, actions }]),
+        _state.wallet.near.signer,
+        options.network
+      );
+
+      return signedTx;
+    },
   };
 };
 

--- a/packages/coin98-wallet/src/lib/coin98-wallet.ts
+++ b/packages/coin98-wallet/src/lib/coin98-wallet.ts
@@ -13,6 +13,7 @@ import { getActiveAccount } from "@near-wallet-selector/core";
 import type { InjectedCoin98 } from "./injected-coin98-wallet";
 import { signTransactions } from "@near-wallet-selector/wallet-utils";
 import type { FinalExecutionOutcome } from "near-api-js/lib/providers";
+import * as nearAPI from "near-api-js";
 import icon from "./icon";
 
 declare global {
@@ -191,6 +192,17 @@ const Coin98Wallet: WalletBehaviourFactory<InjectedWallet> = async ({
       );
 
       return signedTx;
+    },
+
+    async signTransaction(transaction) {
+      logger.log("signTransaction", { transaction });
+
+      return await nearAPI.transactions.signTransaction(
+        transaction as unknown as nearAPI.transactions.Transaction,
+        _state.wallet.near.signer,
+        transaction.signerId,
+        options.network.networkId
+      );
     },
   };
 };

--- a/packages/core/docs/api/wallet.md
+++ b/packages/core/docs/api/wallet.md
@@ -335,3 +335,42 @@ Allows users to sign a message for a specific recipient using their NEAR account
   await wallet.signMessage({ message, recipient, nonce });
 })();
 ```
+
+### `.createSignedTransaction(receiverId, actions)`
+
+**Parameters**
+
+- `receiverId` (`string`): Account ID to receive the transaction.
+- `actions` (`Array<Action>`): NEAR Action(s) to sign. You can find more information on `Action` [here](./transactions.md).
+
+**Returns**
+
+- `Promise<SignedTransaction | void>`: Returns a signed transaction that is ready to be broadcast to the network. Browser wallets may not return the signed transaction as they may need to redirect for signing.
+
+**Description**
+
+Signs one or more NEAR Actions and returns a signed transaction that is ready to be broadcast to the network. The user must be signed in to call this method. This is useful when you want to sign a transaction but broadcast it later or through a different mechanism.
+
+**Example**
+
+```ts
+(async () => {
+  const signedTx = await wallet.createSignedTransaction(
+    "guest-book.testnet",
+    [{
+      type: "FunctionCall",
+      params: {
+        methodName: "addMessage",
+        args: { text: "Hello World!" },
+        gas: "30000000000000",
+        deposit: "10000000000000000000000",
+      }
+    }]
+  );
+  
+  if (signedTx) {
+    // Broadcast the signed transaction using your preferred method
+    // e.g. using near-api-js provider
+  }
+})();
+```

--- a/packages/core/docs/guides/custom-wallets.md
+++ b/packages/core/docs/guides/custom-wallets.md
@@ -74,6 +74,12 @@ const MyWallet: WalletBehaviourFactory<BrowserWallet> = ({
       // that allows users to sign a message for a specific receiver using their NEAR account
       return await wallet.signMessage({ message, nonce, recipient, callbackUrl, state });
     },
+
+    async createSignedTransaction(receiverId, actions) {
+      // Creates a signed transaction without sending it to the network. 
+      // The signing process uses the each wallet's signing to create a valid transaction that can later be broadcast.
+      return await wallet.signTransaction({receiverId, actions})
+    }
   };
 };
 
@@ -154,3 +160,10 @@ This method is similar to `signAndSendTransaction` but instead sends a batch of 
 
 This method allows users to sign a message for a specific recipient using their NEAR account.
 Returns the `SignedMessage` based on the [NEP413](https://github.com/near/NEPs/blob/master/neps/nep-0413.md).
+
+### `createSignedTransaction`
+This method creates a signed transaction without sending it to the network. It's useful when you need to create a signed transaction that will be sent later.
+
+The method takes the same parameters as `signAndSendTransaction` but returns a signed transaction object instead of sending it. This gives more flexibility in how the transaction is ultimately processed.
+
+> Note: Not all wallets support this functionality. Check the wallet's capabilities before using this method.

--- a/packages/core/src/lib/services/wallet-modules/wallet-modules.service.ts
+++ b/packages/core/src/lib/services/wallet-modules/wallet-modules.service.ts
@@ -8,6 +8,7 @@ import type {
   Account,
   InstantLinkWallet,
   SignMessageParams,
+  Action,
 } from "../../wallet";
 import type { StorageService } from "../storage/storage.service.types";
 import type { Options } from "../../options.types";
@@ -301,6 +302,7 @@ export class WalletModules {
     const _signIn = wallet.signIn;
     const _signOut = wallet.signOut;
     const _signMessage = wallet.signMessage;
+    const _createSignedTransaction = wallet.createSignedTransaction;
 
     wallet.signIn = async (params: never) => {
       const accounts = await _signIn(params);
@@ -330,6 +332,19 @@ export class WalletModules {
       this.validateSignMessageParams(params);
 
       return await _signMessage(params);
+    };
+
+    wallet.createSignedTransaction = async (
+      receiverId: string,
+      actions: Array<Action>
+    ) => {
+      if (_createSignedTransaction === undefined) {
+        throw Error(
+          `The createSignedTransaction method is not supported by ${wallet.metadata.name}`
+        );
+      }
+
+      return await _createSignedTransaction(receiverId, actions);
     };
 
     return wallet;

--- a/packages/core/src/lib/wallet/wallet.types.ts
+++ b/packages/core/src/lib/wallet/wallet.types.ts
@@ -10,7 +10,7 @@ import type { ReadOnlyStore } from "../store.types";
 import type { Transaction, Action } from "./transactions.types";
 import type { Modify, Optional } from "../utils.types";
 import type { FinalExecutionOutcome } from "near-api-js/lib/providers";
-import { SignedTransaction } from "near-api-js/lib/transaction";
+import type { SignedTransaction } from "near-api-js/lib/transaction";
 
 interface BaseWalletMetadata {
   /**

--- a/packages/core/src/lib/wallet/wallet.types.ts
+++ b/packages/core/src/lib/wallet/wallet.types.ts
@@ -157,9 +157,9 @@ interface BaseWalletBehaviour {
   ): Promise<Array<providers.FinalExecutionOutcome>>;
   signMessage?(params: SignMessageParams): Promise<SignedMessage | void>;
   /**
-   * Signs one or more transactions and returns a signed transaction that is ready to be broadcast to the network
+   * Create a signed transaction that is ready to be broadcast to the network
    */
-  createSignedTransaction(
+  createSignedTransaction?(
     receiverId: string,
     actions: Array<Action>
   ): Promise<SignedTransaction | void>;

--- a/packages/core/src/lib/wallet/wallet.types.ts
+++ b/packages/core/src/lib/wallet/wallet.types.ts
@@ -122,6 +122,15 @@ interface SignAndSendTransactionsParams {
   transactions: Array<Optional<Transaction, "signerId">>;
 }
 
+interface SignTransactionParams {
+  signerId: string;
+  publicKey: string;
+  nonce: bigint;
+  receiverId: string;
+  actions: Array<Action>;
+  blockHash: Uint8Array;
+}
+
 interface BaseWalletBehaviour {
   /**
    * Programmatically sign in. Hardware wallets (e.g. Ledger) require `derivationPaths` to validate access key permissions.
@@ -163,6 +172,12 @@ interface BaseWalletBehaviour {
     receiverId: string,
     actions: Array<Action>
   ): Promise<SignedTransaction | void>;
+  /**
+   * Signs one or more transactions and returns a signed transaction that is ready to be broadcast to the network
+   */
+  signTransaction(
+    transaction: SignTransactionParams
+  ): Promise<[Uint8Array, SignedTransaction]>;
 }
 
 type BaseWallet<

--- a/packages/core/src/lib/wallet/wallet.types.ts
+++ b/packages/core/src/lib/wallet/wallet.types.ts
@@ -10,7 +10,10 @@ import type { ReadOnlyStore } from "../store.types";
 import type { Transaction, Action } from "./transactions.types";
 import type { Modify, Optional } from "../utils.types";
 import type { FinalExecutionOutcome } from "near-api-js/lib/providers";
-import type { SignedTransaction } from "near-api-js/lib/transaction";
+import type {
+  SignedTransaction,
+  Transaction as nearAPITransaction,
+} from "near-api-js/lib/transaction";
 
 interface BaseWalletMetadata {
   /**
@@ -122,15 +125,6 @@ interface SignAndSendTransactionsParams {
   transactions: Array<Optional<Transaction, "signerId">>;
 }
 
-interface SignTransactionParams {
-  signerId: string;
-  publicKey: string;
-  nonce: bigint;
-  receiverId: string;
-  actions: Array<Action>;
-  blockHash: Uint8Array;
-}
-
 interface BaseWalletBehaviour {
   /**
    * Programmatically sign in. Hardware wallets (e.g. Ledger) require `derivationPaths` to validate access key permissions.
@@ -176,7 +170,7 @@ interface BaseWalletBehaviour {
    * Signs one or more transactions and returns a signed transaction that is ready to be broadcast to the network
    */
   signTransaction(
-    transaction: SignTransactionParams
+    transaction: nearAPITransaction
   ): Promise<[Uint8Array, SignedTransaction]>;
 }
 

--- a/packages/core/src/lib/wallet/wallet.types.ts
+++ b/packages/core/src/lib/wallet/wallet.types.ts
@@ -10,6 +10,7 @@ import type { ReadOnlyStore } from "../store.types";
 import type { Transaction, Action } from "./transactions.types";
 import type { Modify, Optional } from "../utils.types";
 import type { FinalExecutionOutcome } from "near-api-js/lib/providers";
+import { SignedTransaction } from "near-api-js/lib/transaction";
 
 interface BaseWalletMetadata {
   /**
@@ -155,6 +156,12 @@ interface BaseWalletBehaviour {
     params: SignAndSendTransactionsParams
   ): Promise<Array<providers.FinalExecutionOutcome>>;
   signMessage?(params: SignMessageParams): Promise<SignedMessage | void>;
+  /**
+   * Signs one or more transactions and returns a signed transaction that is ready to be broadcast to the network
+   */
+  signTransaction?(
+    params: SignAndSendTransactionParams
+  ): Promise<SignedTransaction | void>;
 }
 
 type BaseWallet<

--- a/packages/core/src/lib/wallet/wallet.types.ts
+++ b/packages/core/src/lib/wallet/wallet.types.ts
@@ -159,8 +159,9 @@ interface BaseWalletBehaviour {
   /**
    * Signs one or more transactions and returns a signed transaction that is ready to be broadcast to the network
    */
-  signTransaction?(
-    params: SignAndSendTransactionParams
+  createSignedTransaction(
+    receiverId: string,
+    actions: Array<Action>
   ): Promise<SignedTransaction | void>;
 }
 

--- a/packages/ethereum-wallets/src/lib/index.ts
+++ b/packages/ethereum-wallets/src/lib/index.ts
@@ -986,6 +986,15 @@ const EthereumWallets: WalletBehaviourFactory<
       logger.log("EthereumWallets:signAndSendTransactions", { transactions });
       return await signAndSendTransactions(transactions);
     },
+
+    async createSignedTransaction(receiverId, actions) {
+      logger.log("EthereumWallets:createSignedTransaction", {
+        receiverId,
+        actions,
+      });
+
+      throw new Error(`Method not supported by Ethereum Wallets`);
+    },
   };
 };
 

--- a/packages/ethereum-wallets/src/lib/index.ts
+++ b/packages/ethereum-wallets/src/lib/index.ts
@@ -995,6 +995,12 @@ const EthereumWallets: WalletBehaviourFactory<
 
       throw new Error(`Method not supported by Ethereum Wallets`);
     },
+
+    async signTransaction(transaction) {
+      logger.log("EthereumWallets:signTransaction", { transaction });
+
+      throw new Error(`Method not supported by Ethereum Wallets`);
+    },
   };
 };
 

--- a/packages/here-wallet/src/lib/selector.ts
+++ b/packages/here-wallet/src/lib/selector.ts
@@ -110,5 +110,11 @@ export const initHereWallet: SelectorInit = async (config) => {
       });
       throw new Error(`Method not supported by Here Wallet`);
     },
+
+    async signTransaction(transaction) {
+      logger.log("signTransaction", { transaction });
+
+      throw new Error(`Method not supported by Here Wallet`);
+    },
   };
 };

--- a/packages/here-wallet/src/lib/selector.ts
+++ b/packages/here-wallet/src/lib/selector.ts
@@ -102,5 +102,13 @@ export const initHereWallet: SelectorInit = async (config) => {
       logger.log("HereWallet:signAndSendTransactions", data);
       return await here.signAndSendTransactions(data);
     },
+
+    async createSignedTransaction(receiverId, actions) {
+      logger.log("HereWallet:createSignedTransaction", {
+        actions,
+        receiverId,
+      });
+      throw new Error(`Method not supported by Here Wallet`);
+    },
   };
 };

--- a/packages/hot-wallet/src/lib/index.ts
+++ b/packages/hot-wallet/src/lib/index.ts
@@ -127,6 +127,14 @@ export function setupHotWallet(): WalletModuleFactory<InjectedWallet> {
               "HOT:verifyOwner is deprecated, use signMessage method with implementation NEP0413 Standard"
             );
           },
+
+          async createSignedTransaction(receiverId, actions) {
+            config.logger.log("HOTWallet:createSignedTransaction", {
+              actions,
+              receiverId,
+            });
+            throw new Error(`Method not supported by HOT Wallet`);
+          },
         };
       },
     };

--- a/packages/hot-wallet/src/lib/index.ts
+++ b/packages/hot-wallet/src/lib/index.ts
@@ -135,6 +135,12 @@ export function setupHotWallet(): WalletModuleFactory<InjectedWallet> {
             });
             throw new Error(`Method not supported by HOT Wallet`);
           },
+
+          async signTransaction(transaction) {
+            config.logger.log("signTransaction", { transaction });
+
+            throw new Error(`Method not supported by HOT Wallet`);
+          },
         };
       },
     };

--- a/packages/intear-wallet/src/lib/intear-wallet.ts
+++ b/packages/intear-wallet/src/lib/intear-wallet.ts
@@ -888,6 +888,12 @@ const IntearWallet: WalletBehaviourFactory<
         logger
       );
     },
+
+    async createSignedTransaction(receiverId, actions) {
+      logger.log("createSignedTransaction", { receiverId, actions });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
+    },
   });
 };
 

--- a/packages/intear-wallet/src/lib/intear-wallet.ts
+++ b/packages/intear-wallet/src/lib/intear-wallet.ts
@@ -894,6 +894,12 @@ const IntearWallet: WalletBehaviourFactory<
 
       throw new Error(`Method not supported by ${metadata.name}`);
     },
+
+    async signTransaction(transaction) {
+      logger.log("signTransaction", { transaction });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
+    },
   });
 };
 

--- a/packages/ledger/src/lib/ledger.ts
+++ b/packages/ledger/src/lib/ledger.ts
@@ -375,6 +375,17 @@ const Ledger: WalletBehaviourFactory<HardwareWallet> = async ({
 
       return signedTransactions;
     },
+
+    async signTransaction(transaction) {
+      logger.log("signTransaction", { transaction });
+
+      return await nearAPI.transactions.signTransaction(
+        transaction as unknown as nearAPI.transactions.Transaction,
+        signer,
+        transaction.signerId,
+        options.network.networkId
+      );
+    },
   };
 };
 

--- a/packages/ledger/src/lib/ledger.ts
+++ b/packages/ledger/src/lib/ledger.ts
@@ -356,6 +356,25 @@ const Ledger: WalletBehaviourFactory<HardwareWallet> = async ({
         signature: encodedSignature,
       };
     },
+
+    async createSignedTransaction(receiverId, actions) {
+      logger.log("createSignedTransaction", { receiverId, actions });
+
+      if (!_state.accounts.length) {
+        throw new Error("Wallet not signed in");
+      }
+
+      // Note: Connection must be triggered by user interaction.
+      await connectLedgerDevice();
+
+      const [signedTransactions] = await signTransactions(
+        transformTransactions([{ receiverId, actions }]),
+        signer,
+        options.network
+      );
+
+      return signedTransactions;
+    },
   };
 };
 

--- a/packages/ledger/src/lib/ledger.ts
+++ b/packages/ledger/src/lib/ledger.ts
@@ -380,7 +380,7 @@ const Ledger: WalletBehaviourFactory<HardwareWallet> = async ({
       logger.log("signTransaction", { transaction });
 
       return await nearAPI.transactions.signTransaction(
-        transaction as unknown as nearAPI.transactions.Transaction,
+        transaction,
         signer,
         transaction.signerId,
         options.network.networkId

--- a/packages/math-wallet/src/lib/math-wallet.ts
+++ b/packages/math-wallet/src/lib/math-wallet.ts
@@ -181,6 +181,18 @@ const MathWallet: WalletBehaviourFactory<InjectedWallet> = async ({
 
       return results;
     },
+
+    async createSignedTransaction(receiverId, actions) {
+      logger.log("createSignedTransaction", { receiverId, actions });
+
+      const [signedTx] = await signTransactions(
+        transformTransactions([{ receiverId, actions }]),
+        _state.wallet.signer,
+        options.network
+      );
+
+      return signedTx;
+    },
   };
 };
 

--- a/packages/math-wallet/src/lib/math-wallet.ts
+++ b/packages/math-wallet/src/lib/math-wallet.ts
@@ -11,6 +11,7 @@ import { getActiveAccount } from "@near-wallet-selector/core";
 import type { InjectedMathWallet } from "./injected-math-wallet";
 import { signTransactions } from "@near-wallet-selector/wallet-utils";
 import type { FinalExecutionOutcome } from "near-api-js/lib/providers";
+import nearAPITransactions from "near-api-js/lib/transaction";
 import icon from "./icon";
 
 declare global {
@@ -192,6 +193,17 @@ const MathWallet: WalletBehaviourFactory<InjectedWallet> = async ({
       );
 
       return signedTx;
+    },
+
+    async signTransaction(transaction) {
+      logger.log("signTransaction", { transaction });
+
+      return await nearAPITransactions.signTransaction(
+        transaction as unknown as nearAPITransactions.Transaction,
+        _state.wallet.signer,
+        transaction.signerId,
+        options.network.networkId
+      );
     },
   };
 };

--- a/packages/math-wallet/src/lib/math-wallet.ts
+++ b/packages/math-wallet/src/lib/math-wallet.ts
@@ -199,7 +199,7 @@ const MathWallet: WalletBehaviourFactory<InjectedWallet> = async ({
       logger.log("signTransaction", { transaction });
 
       return await nearAPITransactions.signTransaction(
-        transaction as unknown as nearAPITransactions.Transaction,
+        transaction,
         _state.wallet.signer,
         transaction.signerId,
         options.network.networkId

--- a/packages/meteor-wallet-app/src/lib/meteor-wallet-app.ts
+++ b/packages/meteor-wallet-app/src/lib/meteor-wallet-app.ts
@@ -193,6 +193,11 @@ const createMeteorWalletAppInjected: WalletBehaviourFactory<
 
       throw new Error(`Method not supported by ${metadata.name}`);
     },
+    async signTransaction(transaction) {
+      logger.log("signTransaction", { transaction });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
+    },
   };
 };
 

--- a/packages/meteor-wallet-app/src/lib/meteor-wallet-app.ts
+++ b/packages/meteor-wallet-app/src/lib/meteor-wallet-app.ts
@@ -112,7 +112,7 @@ const createMeteorWalletAppInjected: WalletBehaviourFactory<
   {
     contractId?: string;
   }
-> = async ({ metadata }) => {
+> = async ({ metadata, logger }) => {
   let signedInAccounts: Array<Account> = [];
 
   return {
@@ -187,6 +187,11 @@ const createMeteorWalletAppInjected: WalletBehaviourFactory<
         },
       });
       return data;
+    },
+    async createSignedTransaction(receiverId, actions) {
+      logger.log("createSignedTransaction", { receiverId, actions });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
     },
   };
 };

--- a/packages/meteor-wallet/src/lib/meteor-wallet.ts
+++ b/packages/meteor-wallet/src/lib/meteor-wallet.ts
@@ -195,6 +195,12 @@ const createMeteorWalletInjected: WalletBehaviourFactory<
       throw new Error(`Method not supported by ${metadata.name}`);
     },
 
+    async signTransaction(transaction) {
+      logger.log("signTransaction", { transaction });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
+    },
+
     buildImportAccountsUrl() {
       return `https://wallet.meteorwallet.app/batch-import?network=${_state.wallet._networkId}`;
     },

--- a/packages/meteor-wallet/src/lib/meteor-wallet.ts
+++ b/packages/meteor-wallet/src/lib/meteor-wallet.ts
@@ -42,7 +42,7 @@ const setupWalletState = async (
 const createMeteorWalletInjected: WalletBehaviourFactory<
   InjectedWallet,
   { params: MeteorWalletParams_Injected }
-> = async ({ options, logger, store, params }) => {
+> = async ({ options, logger, store, params, metadata }) => {
   const _state = await setupWalletState(params, options.network);
 
   const getAccounts = async (): Promise<Array<Account>> => {
@@ -187,6 +187,12 @@ const createMeteorWalletInjected: WalletBehaviourFactory<
       return _state.wallet.requestSignTransactions({
         transactions,
       });
+    },
+
+    async createSignedTransaction(receiverId, actions) {
+      logger.log("createSignedTransaction", { receiverId, actions });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
     },
 
     buildImportAccountsUrl() {

--- a/packages/my-near-wallet/src/lib/my-near-wallet.ts
+++ b/packages/my-near-wallet/src/lib/my-near-wallet.ts
@@ -150,6 +150,12 @@ const MyNearWallet: WalletBehaviourFactory<
       );
     },
 
+    async createSignedTransaction(receiverId, actions) {
+      logger.log("createSignedTransaction", { receiverId, actions });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
+    },
+
     buildImportAccountsUrl() {
       return `${params.walletUrl}/batch-import`;
     },

--- a/packages/my-near-wallet/src/lib/my-near-wallet.ts
+++ b/packages/my-near-wallet/src/lib/my-near-wallet.ts
@@ -156,6 +156,12 @@ const MyNearWallet: WalletBehaviourFactory<
       throw new Error(`Method not supported by ${metadata.name}`);
     },
 
+    async signTransaction(transaction) {
+      logger.log("signTransaction", { transaction });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
+    },
+
     buildImportAccountsUrl() {
       return `${params.walletUrl}/batch-import`;
     },

--- a/packages/narwallets/src/lib/narwallets.ts
+++ b/packages/narwallets/src/lib/narwallets.ts
@@ -263,6 +263,12 @@ const Narwallets: WalletBehaviourFactory<InjectedWallet> = async ({
         Array<FinalExecutionOutcome>
       >;
     },
+
+    async createSignedTransaction(receiverId, actions) {
+      logger.log("createSignedTransaction", { receiverId, actions });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
+    },
   };
 };
 

--- a/packages/narwallets/src/lib/narwallets.ts
+++ b/packages/narwallets/src/lib/narwallets.ts
@@ -269,6 +269,12 @@ const Narwallets: WalletBehaviourFactory<InjectedWallet> = async ({
 
       throw new Error(`Method not supported by ${metadata.name}`);
     },
+
+    async signTransaction(transaction) {
+      logger.log("signTransaction", { transaction });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
+    },
   };
 };
 

--- a/packages/near-mobile-wallet/src/lib/init.wallet.ts
+++ b/packages/near-mobile-wallet/src/lib/init.wallet.ts
@@ -91,5 +91,10 @@ export const initNearMobileWallet: NearMobileWalletInit = async (config) => {
       logger.log("[NearMobileWallet]: signAndSendTransactions", data);
       return await nearMobileWallet.signAndSendTransactions(data);
     },
+
+    async createSignedTransaction(receiverId, actions) {
+      logger.log("createSignedTransaction", { receiverId, actions });
+      throw new Error(`Method not supported by ${config.metadata.name}`);
+    },
   };
 };

--- a/packages/near-mobile-wallet/src/lib/init.wallet.ts
+++ b/packages/near-mobile-wallet/src/lib/init.wallet.ts
@@ -96,5 +96,10 @@ export const initNearMobileWallet: NearMobileWalletInit = async (config) => {
       logger.log("createSignedTransaction", { receiverId, actions });
       throw new Error(`Method not supported by ${config.metadata.name}`);
     },
+
+    async signTransaction(transaction) {
+      logger.log("signTransaction", { transaction });
+      throw new Error(`Method not supported by ${config.metadata.name}`);
+    },
   };
 };

--- a/packages/near-snap/src/lib/selector.ts
+++ b/packages/near-snap/src/lib/selector.ts
@@ -86,5 +86,11 @@ export const initNearSnap: WalletBehaviourFactory<InjectedWallet> = async (
 
       throw new Error(`Method not supported by ${config.metadata.name}`);
     },
+
+    async signTransaction(transaction) {
+      logger.log("signTransaction", { transaction });
+
+      throw new Error(`Method not supported by ${config.metadata.name}`);
+    },
   };
 };

--- a/packages/near-snap/src/lib/selector.ts
+++ b/packages/near-snap/src/lib/selector.ts
@@ -80,5 +80,11 @@ export const initNearSnap: WalletBehaviourFactory<InjectedWallet> = async (
 
       return await account.executeTransactions(transactions);
     },
+
+    async createSignedTransaction(receiverId, actions) {
+      logger.log("createSignedTransaction", { receiverId, actions });
+
+      throw new Error(`Method not supported by ${config.metadata.name}`);
+    },
   };
 };

--- a/packages/nightly/src/lib/nightly.ts
+++ b/packages/nightly/src/lib/nightly.ts
@@ -258,7 +258,7 @@ const Nightly: WalletBehaviourFactory<InjectedWallet> = async ({
       logger.log("signTransaction", { transaction });
 
       return await nearAPI.transactions.signTransaction(
-        transaction as unknown as nearAPI.transactions.Transaction,
+        transaction,
         signer,
         transaction.signerId,
         options.network.networkId

--- a/packages/nightly/src/lib/nightly.ts
+++ b/packages/nightly/src/lib/nightly.ts
@@ -242,11 +242,11 @@ const Nightly: WalletBehaviourFactory<InjectedWallet> = async ({
       return results;
     },
 
-    async signTransaction({ actions, receiverId, signerId }) {
-      logger.log("signTransaction", { signerId, receiverId, actions });
+    async createSignedTransaction(receiverId, actions) {
+      logger.log("createSignedTransaction", { receiverId, actions });
 
       const [signedTx] = await signTransactions(
-        transformTransactions([{ signerId, receiverId, actions }]),
+        transformTransactions([{ receiverId, actions }]),
         signer,
         options.network
       );

--- a/packages/nightly/src/lib/nightly.ts
+++ b/packages/nightly/src/lib/nightly.ts
@@ -254,6 +254,17 @@ const Nightly: WalletBehaviourFactory<InjectedWallet> = async ({
       return signedTx;
     },
 
+    async signTransaction(transaction) {
+      logger.log("signTransaction", { transaction });
+
+      return await nearAPI.transactions.signTransaction(
+        transaction as unknown as nearAPI.transactions.Transaction,
+        signer,
+        transaction.signerId,
+        options.network.networkId
+      );
+    },
+
     async importAccountsInSecureContext(params) {
       _state.wallet.importWalletsNear(params.accounts);
     },

--- a/packages/nightly/src/lib/nightly.ts
+++ b/packages/nightly/src/lib/nightly.ts
@@ -242,6 +242,18 @@ const Nightly: WalletBehaviourFactory<InjectedWallet> = async ({
       return results;
     },
 
+    async signTransaction({ actions, receiverId, signerId }) {
+      logger.log("signTransaction", { signerId, receiverId, actions });
+
+      const [signedTx] = await signTransactions(
+        transformTransactions([{ signerId, receiverId, actions }]),
+        signer,
+        options.network
+      );
+
+      return signedTx;
+    },
+
     async importAccountsInSecureContext(params) {
       _state.wallet.importWalletsNear(params.accounts);
     },

--- a/packages/okx-wallet/src/lib/okx-wallet.ts
+++ b/packages/okx-wallet/src/lib/okx-wallet.ts
@@ -240,6 +240,12 @@ const OKXWallet: WalletBehaviourFactory<InjectedWallet> = async ({
         throw new Error("Failed to create signed transaction");
       }
     },
+
+    async signTransaction(transaction) {
+      logger.log("signTransaction", { transaction });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
+    },
   };
 };
 

--- a/packages/okx-wallet/src/lib/okx-wallet.ts
+++ b/packages/okx-wallet/src/lib/okx-wallet.ts
@@ -220,6 +220,26 @@ const OKXWallet: WalletBehaviourFactory<InjectedWallet> = async ({
         throw new Error("sign Error");
       }
     },
+
+    async createSignedTransaction(receiverId, actions) {
+      logger.log("createSignedTransaction", { receiverId, actions });
+      const { contract } = store.getState();
+
+      if (!_state.wallet.isSignedIn() || !contract) {
+        throw new Error("Wallet not signed in");
+      }
+
+      try {
+        const signedTx = await _state.wallet.signTransaction({
+          receiverId: receiverId || contract.contractId,
+          actions: transformActions(actions),
+        });
+        const signedTransaction = getSignedTransaction(signedTx);
+        return signedTransaction;
+      } catch (error) {
+        throw new Error("Failed to create signed transaction");
+      }
+    },
   };
 };
 

--- a/packages/ramper-wallet/src/lib/ramper-wallet.ts
+++ b/packages/ramper-wallet/src/lib/ramper-wallet.ts
@@ -180,6 +180,12 @@ const RamperWallet: WalletBehaviourFactory<InjectedWallet> = async ({
         throw new Error("Failed to send transactions");
       }
     },
+
+    async createSignedTransaction(receiverId, actions) {
+      logger.log("createSignedTransaction", { receiverId, actions });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
+    },
   };
 };
 

--- a/packages/ramper-wallet/src/lib/ramper-wallet.ts
+++ b/packages/ramper-wallet/src/lib/ramper-wallet.ts
@@ -186,6 +186,12 @@ const RamperWallet: WalletBehaviourFactory<InjectedWallet> = async ({
 
       throw new Error(`Method not supported by ${metadata.name}`);
     },
+
+    async signTransaction(transaction) {
+      logger.log("signTransaction", { transaction });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
+    },
   };
 };
 

--- a/packages/react-hook/README.md
+++ b/packages/react-hook/README.md
@@ -53,7 +53,8 @@ export default function OtherComponent() {
     getBalance,
     getAccessKeys,
     signAndSendTransactions,
-    signMessage
+    signMessage,
+    createSignedTransaction
   } = useWalletSelector();
   ...
   // walletSelector to interact with the wallet.

--- a/packages/react-hook/src/lib/WalletSelectorProvider.tsx
+++ b/packages/react-hook/src/lib/WalletSelectorProvider.tsx
@@ -15,7 +15,7 @@ import {
 import { setupModal } from "@near-wallet-selector/modal-ui";
 import { providers } from "near-api-js";
 import type { QueryResponseKind } from "near-api-js/lib/providers/provider";
-import { SignedTransaction } from "near-api-js/lib/transaction";
+import type { SignedTransaction } from "near-api-js/lib/transaction";
 
 class WalletError extends Error {
   constructor(message: string) {
@@ -83,7 +83,9 @@ export interface WalletSelectorProviderValue {
     message: SignMessageParams,
     signedMessage: SignedMessage
   ) => Promise<boolean>;
-  signTransaction: (params: SignTransactionParams) => Promise<SignedTransaction | void>;
+  signTransaction: (
+    params: SignTransactionParams
+  ) => Promise<SignedTransaction | void>;
 }
 
 const DEFAULT_GAS = "30000000000000";
@@ -227,17 +229,15 @@ export function WalletSelectorProvider({
   );
 
   const signTransaction = useCallback(
-    async ({
-      actions,
-      receiverId,
-      signerId
-    }: SignTransactionParams) => {
+    async ({ actions, receiverId }: SignTransactionParams) => {
       if (!wallet) {
         throw new WalletError("No wallet connected");
       }
 
       if (!wallet.signTransaction) {
-        throw new WalletError("Wallet does not support sign transaction only. Please use callFunction or signAndSendTransactions instead.");
+        throw new WalletError(
+          "Wallet does not support sign transaction only. Please use callFunction or signAndSendTransactions instead."
+        );
       }
 
       const signedTx = await wallet.signTransaction({

--- a/packages/react-hook/src/lib/WalletSelectorProvider.tsx
+++ b/packages/react-hook/src/lib/WalletSelectorProvider.tsx
@@ -54,12 +54,6 @@ export interface SignMessageParams {
   callbackUrl?: string;
 }
 
-export interface SignTransactionParams {
-  signerId?: string;
-  receiverId?: string;
-  actions: Array<Action>;
-}
-
 export type SetupParams = WalletSelectorParams & {
   createAccessKeyFor?: string;
 };
@@ -83,8 +77,9 @@ export interface WalletSelectorProviderValue {
     message: SignMessageParams,
     signedMessage: SignedMessage
   ) => Promise<boolean>;
-  signTransaction: (
-    params: SignTransactionParams
+  createSignedTransaction: (
+    receiverId: string,
+    actions: Array<Action>
   ) => Promise<SignedTransaction | void>;
 }
 
@@ -228,22 +223,22 @@ export function WalletSelectorProvider({
     [wallet]
   );
 
-  const signTransaction = useCallback(
-    async ({ actions, receiverId }: SignTransactionParams) => {
+  const createSignedTransaction = useCallback(
+    async (receiverId: string, actions: Array<Action>) => {
       if (!wallet) {
         throw new WalletError("No wallet connected");
       }
 
-      if (!wallet.signTransaction) {
+      if (!wallet.createSignedTransaction) {
         throw new WalletError(
           "Wallet does not support sign transaction only. Please use callFunction or signAndSendTransactions instead."
         );
       }
 
-      const signedTx = await wallet.signTransaction({
-        receiverId: receiverId,
-        actions: actions,
-      });
+      const signedTx = await wallet.createSignedTransaction(
+        receiverId,
+        actions
+      );
 
       return signedTx;
     },
@@ -389,7 +384,7 @@ export function WalletSelectorProvider({
     signMessage,
     getAccount,
     verifyMessage,
-    signTransaction,
+    createSignedTransaction,
   };
 
   return (

--- a/packages/sender/src/lib/sender.ts
+++ b/packages/sender/src/lib/sender.ts
@@ -332,6 +332,12 @@ const Sender: WalletBehaviourFactory<InjectedWallet> = async ({
         });
       }
     },
+
+    async createSignedTransaction(receiverId, actions) {
+      logger.log("createSignedTransaction", { receiverId, actions });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
+    },
   };
 };
 

--- a/packages/sender/src/lib/sender.ts
+++ b/packages/sender/src/lib/sender.ts
@@ -338,6 +338,12 @@ const Sender: WalletBehaviourFactory<InjectedWallet> = async ({
 
       throw new Error(`Method not supported by ${metadata.name}`);
     },
+
+    async signTransaction(transaction) {
+      logger.log("signTransaction", { transaction });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
+    },
   };
 };
 

--- a/packages/wallet-connect/src/lib/wallet-connect.ts
+++ b/packages/wallet-connect/src/lib/wallet-connect.ts
@@ -732,6 +732,12 @@ const WalletConnect: WalletBehaviourFactory<
 
       throw new Error(`Method not supported by ${metadata.name}`);
     },
+
+    async signTransaction(transaction) {
+      logger.log("signTransaction", { transaction });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
+    },
   };
 };
 

--- a/packages/wallet-connect/src/lib/wallet-connect.ts
+++ b/packages/wallet-connect/src/lib/wallet-connect.ts
@@ -164,7 +164,16 @@ const getSignatureData = (result: Uint8Array) => {
 const WalletConnect: WalletBehaviourFactory<
   BridgeWallet,
   { params: WalletConnectExtraOptions }
-> = async ({ id, options, store, params, provider, emitter, logger }) => {
+> = async ({
+  id,
+  options,
+  store,
+  params,
+  provider,
+  emitter,
+  logger,
+  metadata,
+}) => {
   const _state = await setupWalletConnectState(id, params, emitter);
 
   const getChainId = () => {
@@ -716,6 +725,12 @@ const WalletConnect: WalletBehaviourFactory<
 
         return results;
       }
+    },
+
+    async createSignedTransaction(receiverId, actions) {
+      logger.log("createSignedTransaction", { receiverId, actions });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
     },
   };
 };

--- a/packages/welldone-wallet/src/lib/welldone.ts
+++ b/packages/welldone-wallet/src/lib/welldone.ts
@@ -388,7 +388,7 @@ const WelldoneWallet: WalletBehaviourFactory<InjectedWallet> = async ({
       logger.log("signTransaction", { transaction });
 
       return await nearAPI.transactions.signTransaction(
-        transaction as unknown as nearAPI.transactions.Transaction,
+        transaction,
         signer,
         transaction.signerId,
         options.network.networkId

--- a/packages/welldone-wallet/src/lib/welldone.ts
+++ b/packages/welldone-wallet/src/lib/welldone.ts
@@ -372,6 +372,18 @@ const WelldoneWallet: WalletBehaviourFactory<InjectedWallet> = async ({
       return results;
     },
 
+    async createSignedTransaction(receiverId, actions) {
+      logger.log("createSignedTransaction", { receiverId, actions });
+
+      const [signedTx] = await signTransactions(
+        transformTransactions([{ receiverId, actions }]),
+        signer,
+        options.network
+      );
+
+      return signedTx;
+    },
+
     async importAccountsInSecureContext({ accounts }) {
       if (!_state.wallet) {
         throw new Error("Wallet is not installed");

--- a/packages/welldone-wallet/src/lib/welldone.ts
+++ b/packages/welldone-wallet/src/lib/welldone.ts
@@ -384,6 +384,17 @@ const WelldoneWallet: WalletBehaviourFactory<InjectedWallet> = async ({
       return signedTx;
     },
 
+    async signTransaction(transaction) {
+      logger.log("signTransaction", { transaction });
+
+      return await nearAPI.transactions.signTransaction(
+        transaction as unknown as nearAPI.transactions.Transaction,
+        signer,
+        transaction.signerId,
+        options.network.networkId
+      );
+    },
+
     async importAccountsInSecureContext({ accounts }) {
       if (!_state.wallet) {
         throw new Error("Wallet is not installed");

--- a/packages/xdefi/src/lib/xdefi.ts
+++ b/packages/xdefi/src/lib/xdefi.ts
@@ -152,6 +152,12 @@ const XDEFI: WalletBehaviourFactory<InjectedWallet> = async ({
 
       throw new Error(`Method not supported by ${metadata.name}`);
     },
+
+    async signTransaction(transaction) {
+      logger.log("signTransaction", { transaction });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
+    },
   };
 };
 

--- a/packages/xdefi/src/lib/xdefi.ts
+++ b/packages/xdefi/src/lib/xdefi.ts
@@ -146,6 +146,12 @@ const XDEFI: WalletBehaviourFactory<InjectedWallet> = async ({
 
       return result;
     },
+
+    async createSignedTransaction(receiverId, actions) {
+      logger.log("createSignedTransaction", { receiverId, actions });
+
+      throw new Error(`Method not supported by ${metadata.name}`);
+    },
   };
 };
 


### PR DESCRIPTION
# Description
This pull request introduces the new `createSignedTransaction` and `signTransaction` methods to the wallet-selector. This method enables wallets to create signed transactions and return a Signed Transaction object, empowering developers to handle raw signed transactions for custom workflows.

## Changes
- Added the `createSignedTransaction(receiverId, actions)` method and `signTransaction(transaction)` method to the wallet type and behavior interface.
- Added mandatory `signTransaction` as a mandatory method for each wallet
- Implemented or stubbed `createSignedTransaction` in all wallet modules. For unsupported wallets, the method includes logging parameters and throwing "not supported" errors.
- Extended wallet type definitions and documentation to include signing transaction.
- React example app adjustments:
  - Added a "Sign only and Return Signature" checkbox to the form.
  - Submission handler uses `createSignedTransaction` if the checkbox is checked, showing the signature in an alert and logging it to the console.

## Motivation

Previously, wallet-selector did not provide a unified way to create and retrieve signed transactions without immediately sending them. This new method improves flexibility for dApp developers who need to inspect, store, or relay signed transactions directly.

## Usage Example

```typescript
// Example usage in a dApp:
const signedTx = await wallet.createSignedTransaction(receiverId, actions);
console.log(signedTx); // Outputs the Signed Transaction object
```

In the React example app, select "Sign only and Return Signature" to try this flow.

## Additional Notes

- Not all wallets currently support this method; unsupported wallets will throw a clear error.
- These changes are backwards-compatible and do not affect existing transaction flows.

## Reference

- The design and implementation of `createSignedTransaction` [`near-api-js` Account.signTransaction](https://github.com/near/near-api-js/blob/master/packages/accounts/src/account.ts#L270-L273).

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [ ] FIX - a PR of this type patches a bug.
- [x] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
