### PR TITLE
Force use of near-api-js@5.0.0 to fix signerId is undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "prepack": "yarn build:core && yarn build:all",
     "prepublishOnly": "yarn build:core && yarn build:all",
     "serve:angular": "nx serve angular",
-    "serve:react": "nx serve react --host=0.0.0.0 --skip-nx-cache  --configuration=development",
+    "serve:react": "nx serve react --host=0.0.0.0",
     "serve:vanilla": "nx serve vanilla",
     "test": "nx run-many --target=test --all",
     "nxs": "nx run react:lint --fix"
@@ -114,7 +114,7 @@
     "ethers": "5.7.2",
     "https-browserify": "1.0.0",
     "is-mobile": "4.0.0",
-    "near-api-js": "5.1.1",
+    "near-api-js": "5.0.0",
     "near-seed-phrase": "0.2.0",
     "next": "13.3.0",
     "ngx-deploy-npm": "7.1.0",
@@ -228,11 +228,6 @@
     "webpack-merge": "5.8.0"
   },
   "resolutions": {
-    "near-api-js": "5.1.1"
-  },
-  "overrides": {
-    "@hot-wallet/sdk": {
-      "near-api-js": "5.0.0"
-    }
+    "near-api-js": "5.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "prepack": "yarn build:core && yarn build:all",
     "prepublishOnly": "yarn build:core && yarn build:all",
     "serve:angular": "nx serve angular",
-    "serve:react": "nx serve react --host=0.0.0.0",
+    "serve:react": "nx serve react --host=0.0.0.0 --skip-nx-cache  --configuration=development",
     "serve:vanilla": "nx serve vanilla",
     "test": "nx run-many --target=test --all",
     "nxs": "nx run react:lint --fix"
@@ -114,7 +114,7 @@
     "ethers": "5.7.2",
     "https-browserify": "1.0.0",
     "is-mobile": "4.0.0",
-    "near-api-js": "5.0.0",
+    "near-api-js": "5.1.1",
     "near-seed-phrase": "0.2.0",
     "next": "13.3.0",
     "ngx-deploy-npm": "7.1.0",
@@ -226,5 +226,13 @@
     "vitest": "^0.25.8",
     "webpack": "5.75.0",
     "webpack-merge": "5.8.0"
+  },
+  "resolutions": {
+    "near-api-js": "5.1.1"
+  },
+  "overrides": {
+    "@hot-wallet/sdk": {
+      "near-api-js": "5.0.0"
+    }
   }
 }


### PR DESCRIPTION
Based on the issue reported in https://github.com/near/wallet-selector/issues/1346,  where `signerId is undefined` when using Meteor Wallet to create a function call key, I've pinned `near-api-js` to version 5.0.0 to resolve the incompatibility.

This version has been tested and works correctly .

This image shows a test performed on a HOT wallet
![Captura desde 2025-06-02 14-18-55](https://github.com/user-attachments/assets/bddb74ca-65ff-4607-a3fe-578670414b74)
