### PR TITLE
fix: always initialize wallet selector

### DIFF
--- a/packages/core/src/lib/services/storage/web-storage.service.ts
+++ b/packages/core/src/lib/services/storage/web-storage.service.ts
@@ -2,6 +2,10 @@ import type { StorageService } from "./storage.service.types";
 
 export class WebStorageService implements StorageService {
   getItem(key: string): Promise<string | null> {
+    if (typeof localStorage === "undefined") {
+      return Promise.resolve(null);
+    }
+
     return new Promise((resolve) => {
       const value = localStorage.getItem(key);
 
@@ -10,6 +14,10 @@ export class WebStorageService implements StorageService {
   }
 
   setItem(key: string, value: string): Promise<void> {
+    if (typeof localStorage === "undefined") {
+      return Promise.resolve();
+    }
+
     return new Promise((resolve) => {
       localStorage.setItem(key, value);
 
@@ -18,6 +26,10 @@ export class WebStorageService implements StorageService {
   }
 
   removeItem(key: string): Promise<void> {
+    if (typeof localStorage === "undefined") {
+      return Promise.resolve();
+    }
+
     return new Promise((resolve) => {
       localStorage.removeItem(key);
 

--- a/packages/core/src/lib/wallet-selector.ts
+++ b/packages/core/src/lib/wallet-selector.ts
@@ -111,7 +111,7 @@ export const setupWalletSelector = async (
     provider: new Provider(rpcProviderUrls),
   });
 
-  walletModules.setup();
+  await walletModules.setup();
 
   if (params.allowMultipleSelectors) {
     return createSelector(options, store, walletModules, emitter);

--- a/packages/react-hook/src/lib/WalletSelectorProvider.tsx
+++ b/packages/react-hook/src/lib/WalletSelectorProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useState, useEffect, useCallback, useRef } from "react";
+import { createContext, useState, useEffect, useCallback } from "react";
 import type {
   Action,
   FinalExecutionOutcome,

--- a/packages/react-hook/src/lib/WalletSelectorProvider.tsx
+++ b/packages/react-hook/src/lib/WalletSelectorProvider.tsx
@@ -97,7 +97,7 @@ export function WalletSelectorProvider({
   children: React.ReactNode;
   config: SetupParams;
 }) {
-  const walletSelectorRef = useRef<Promise<WalletSelector> | null>(null);
+  const walletSelector = setupWalletSelector(config);
   const [signedAccountId, setSignedAccountId] = useState<string | null>(null);
   const [wallet, setWallet] = useState<Wallet | null>(null);
 
@@ -116,9 +116,6 @@ export function WalletSelectorProvider({
   );
 
   useEffect(() => {
-    const walletSelector = setupWalletSelector(config);
-    walletSelectorRef.current = walletSelector;
-
     walletSelector.then(async (selector) => {
       selector.subscribeOnAccountChange(async (signedAccount) => {
         setSignedAccountId(signedAccount || null);
@@ -137,7 +134,7 @@ export function WalletSelectorProvider({
    * @returns {Promise<void>} - a promise that resolves when the modal is opened
    */
   const signIn = async () => {
-    const ws = await walletSelectorRef.current;
+    const ws = await walletSelector;
     const modalInstance = setupModal(ws!, {
       contractId: config.createAccessKeyFor,
     });
@@ -371,7 +368,7 @@ export function WalletSelectorProvider({
   };
 
   const contextValue: WalletSelectorProviderValue = {
-    walletSelector: walletSelectorRef.current,
+    walletSelector,
     signedAccountId,
     wallet,
     signIn,


### PR DESCRIPTION
# Description

Some users have complained that wallet selector is not initialized when loaded, and that there is no way to know when it actually finished being initialized

I have make the `setupWalletSelector` wait for initialization, but it is important to know that this is not an amazing solution, as "logged in" instances still need to wait for all "not logged in" wallets to initialize

A new PR - which I do not have time to make right now - should deal with "early return" or "cached init", meaning that `wallet-selector` should do something smart to check all wallets if it knows that a single wallet is already logged in

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [x] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
