### PR TITLE
chore: remove unnecessary await from getNetworkPreset in wallet selector

### DIFF
--- a/.changeset/beige-kids-push.md
+++ b/.changeset/beige-kids-push.md
@@ -1,0 +1,5 @@
+---
+"@near-wallet-selector/core": patch
+---
+
+Remove unnecessary await from getNetworkPreset function

--- a/packages/core/src/lib/wallet-selector.spec.ts
+++ b/packages/core/src/lib/wallet-selector.spec.ts
@@ -33,7 +33,7 @@ global.localStorage = {
 jest.mock("./options", () => {
   return {
     ...jest.requireActual("./options"),
-    getNetworkPreset: jest.fn().mockResolvedValue({
+    getNetworkPreset: jest.fn().mockReturnValue({
       networkId: "testnet",
       nodeUrl: "http://node.example.com",
       helperUrl: "http://helper.example.com",
@@ -152,7 +152,7 @@ describe("setupWalletSelector", () => {
       () => mockedRpcProvider as unknown as FailoverRpcProvider
     );
 
-    const networkPreset = await getNetworkPreset("testnet", []);
+    const networkPreset = getNetworkPreset("testnet", []);
 
     await setupWalletSelector({
       ...params,

--- a/packages/core/src/lib/wallet-selector.ts
+++ b/packages/core/src/lib/wallet-selector.ts
@@ -92,7 +92,7 @@ export const setupWalletSelector = async (
 
   const emitter = new EventEmitter<WalletSelectorEvents>();
   const store = await createStore(storage);
-  const network = await getNetworkPreset(
+  const network = getNetworkPreset(
     options.network.networkId as NetworkId,
     params.fallbackRpcUrls
   );


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to NEAR JavaScript API here: https://github.com/near/wallet-selector/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/near/wallet-selector/blob/main/CONTRIBUTING.md).
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [ ] **If this is a code change**: I have written unit tests.
- [x] **If this changes code in a published package**: I have run `yarn changeset` to create a `changeset` JSON document appropriate for this change.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation
Remove unnecessary await from `getNetworkPreset` function in wallet selector