### PR TITLE
fix: strict esm import of near-api-js

### DIFF
--- a/.changeset/lazy-yaks-nail.md
+++ b/.changeset/lazy-yaks-nail.md
@@ -1,0 +1,33 @@
+---
+"@near-wallet-selector/ethereum-wallets": patch
+"@near-wallet-selector/my-near-wallet": patch
+"@near-wallet-selector/wallet-connect": patch
+"@near-wallet-selector/bitget-wallet": patch
+"@near-wallet-selector/coin98-wallet": patch
+"@near-wallet-selector/intear-wallet": patch
+"@near-wallet-selector/ramper-wallet": patch
+"@near-wallet-selector/arepa-wallet": patch
+"@near-wallet-selector/wallet-utils": patch
+"@near-wallet-selector/math-wallet": patch
+"@near-wallet-selector/okx-wallet": patch
+"@near-wallet-selector/react-hook": patch
+"@near-wallet-selector/nightly": patch
+"@near-wallet-selector/ledger": patch
+"@near-wallet-selector/sender": patch
+"@near-wallet-selector/xdefi": patch
+"@near-wallet-selector/core": patch
+"@near-wallet-selector/bitte-wallet": patch
+"@near-wallet-selector/here-wallet": patch
+"@near-wallet-selector/hot-wallet": patch
+"@near-wallet-selector/meteor-wallet": patch
+"@near-wallet-selector/meteor-wallet-app": patch
+"@near-wallet-selector/modal-ui": patch
+"@near-wallet-selector/modal-ui-js": patch
+"@near-wallet-selector/narwallets": patch
+"@near-wallet-selector/near-mobile-wallet": patch
+"@near-wallet-selector/near-snap": patch
+"@near-wallet-selector/unity-wallet": patch
+"@near-wallet-selector/welldone-wallet": patch
+---
+
+fix: esm imports from near-api-js

--- a/packages/arepa-wallet/src/lib/arepa-wallet.spec.ts
+++ b/packages/arepa-wallet/src/lib/arepa-wallet.spec.ts
@@ -4,7 +4,7 @@ import type {
   WalletConnection,
   ConnectedWalletAccount,
 } from "near-api-js";
-import type { AccountView } from "near-api-js/lib/providers/provider";
+import type { AccountView } from "near-api-js/lib/providers/provider.js";
 import { mock } from "jest-mock-extended";
 
 import { mockWallet } from "../../../core/src/lib/testUtils";

--- a/packages/bitget-wallet/src/lib/bitget-wallet.spec.ts
+++ b/packages/bitget-wallet/src/lib/bitget-wallet.spec.ts
@@ -8,7 +8,7 @@ import type {
   BitgetWalletEvents,
   SignOutResponse,
 } from "./injected-bitget-wallet";
-import type { FinalExecutionOutcome } from "near-api-js/lib/providers";
+import type { FinalExecutionOutcome } from "near-api-js/lib/providers/index.js";
 import { setupBitgetWallet } from "./bitget-wallet";
 
 const accountId = "test-account.testnet";

--- a/packages/coin98-wallet/src/lib/coin98-wallet.spec.ts
+++ b/packages/coin98-wallet/src/lib/coin98-wallet.spec.ts
@@ -5,7 +5,7 @@ import { mockWallet } from "../../../core/src/lib/testUtils";
 import type { MockWalletDependencies } from "../../../core/src/lib/testUtils";
 import type { InjectedWallet } from "../../../core/src/lib/wallet";
 import { setupCoin98Wallet } from "./coin98-wallet";
-import type { Signer } from "near-api-js/lib/signer";
+import type { Signer } from "near-api-js/lib/signer.js";
 
 const accountId = "amirsaran.testnet";
 const publicKey = "GF7tLvSzcxX4EtrMFtGvGTb2yUj2DhL8hWzc97BwUkyC";

--- a/packages/coin98-wallet/src/lib/coin98-wallet.ts
+++ b/packages/coin98-wallet/src/lib/coin98-wallet.ts
@@ -12,7 +12,7 @@ import type {
 import { getActiveAccount } from "@near-wallet-selector/core";
 import type { InjectedCoin98 } from "./injected-coin98-wallet";
 import { signTransactions } from "@near-wallet-selector/wallet-utils";
-import type { FinalExecutionOutcome } from "near-api-js/lib/providers";
+import type { FinalExecutionOutcome } from "near-api-js/lib/providers/index.js";
 import * as nearAPI from "near-api-js";
 import icon from "./icon";
 

--- a/packages/coin98-wallet/src/lib/injected-coin98-wallet.ts
+++ b/packages/coin98-wallet/src/lib/injected-coin98-wallet.ts
@@ -2,7 +2,7 @@ import type {
   SignedMessage,
   SignMessageParams,
 } from "@near-wallet-selector/core";
-import type { Signer } from "near-api-js/lib/signer";
+import type { Signer } from "near-api-js/lib/signer.js";
 
 interface IConnectParams {
   prefix: string;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -72,7 +72,7 @@ export type {
   SignMessageParams,
 } from "./lib/wallet";
 
-export type { FinalExecutionOutcome } from "near-api-js/lib/providers";
+export type { FinalExecutionOutcome } from "near-api-js/lib/providers/index.js";
 
 export {
   waitFor,

--- a/packages/core/src/lib/helpers/verify-signature/verify-signature.ts
+++ b/packages/core/src/lib/helpers/verify-signature/verify-signature.ts
@@ -7,7 +7,7 @@ import type {
   ViewAccessKeyParams,
 } from "./verify-signature.types";
 import { Payload, payloadSchema } from "./payload";
-import type { AccessKeyView } from "near-api-js/lib/providers/provider";
+import type { AccessKeyView } from "near-api-js/lib/providers/provider.js";
 
 export const verifySignature = ({
   publicKey,

--- a/packages/core/src/lib/services/provider/provider.service.mocks.ts
+++ b/packages/core/src/lib/services/provider/provider.service.mocks.ts
@@ -1,4 +1,4 @@
-import type { QueryResponseKind } from "near-api-js/lib/providers/provider";
+import type { QueryResponseKind } from "near-api-js/lib/providers/provider.js";
 
 export const createQueryResponseMock = (): QueryResponseKind => ({
   block_height: 0,

--- a/packages/core/src/lib/services/provider/provider.service.spec.ts
+++ b/packages/core/src/lib/services/provider/provider.service.spec.ts
@@ -4,18 +4,20 @@ import type {
   ViewAccessKeyParams,
 } from "./provider.service.types";
 import { mock } from "jest-mock-extended";
-import type { FinalExecutionOutcome } from "near-api-js/lib/providers";
-import type { JsonRpcProvider } from "near-api-js/lib/providers";
+import type {
+  FinalExecutionOutcome,
+  JsonRpcProvider,
+} from "near-api-js/lib/providers/index.js";
 import * as nearAPI from "near-api-js";
 import {
   createQueryResponseMock,
   createViewAccessKeyResponseMock,
 } from "./provider.service.mocks";
-import type { SignedTransaction } from "near-api-js/lib/transaction";
+import type { SignedTransaction } from "near-api-js/lib/transaction.js";
 import type {
   BlockReference,
   BlockResult,
-} from "near-api-js/lib/providers/provider";
+} from "near-api-js/lib/providers/provider.js";
 
 const defaults = {
   url: "https://rpc.testnet.near.org",

--- a/packages/core/src/lib/services/provider/provider.service.ts
+++ b/packages/core/src/lib/services/provider/provider.service.ts
@@ -4,14 +4,14 @@ import type {
   BlockReference,
   QueryResponseKind,
   RpcQueryRequest,
-} from "near-api-js/lib/providers/provider";
+} from "near-api-js/lib/providers/provider.js";
 import type {
   ProviderService,
   QueryParams,
   ViewAccessKeyParams,
 } from "./provider.service.types";
-import { JsonRpcProvider } from "near-api-js/lib/providers";
-import type { SignedTransaction } from "near-api-js/lib/transaction";
+import { JsonRpcProvider } from "near-api-js/lib/providers/index.js";
+import type { SignedTransaction } from "near-api-js/lib/transaction.js";
 
 export class Provider implements ProviderService {
   private provider: nearAPI.providers.FailoverRpcProvider;

--- a/packages/core/src/lib/services/provider/provider.service.types.ts
+++ b/packages/core/src/lib/services/provider/provider.service.types.ts
@@ -4,8 +4,8 @@ import type {
   BlockResult,
   QueryResponseKind,
   FinalExecutionOutcome,
-} from "near-api-js/lib/providers/provider";
-import type { SignedTransaction } from "near-api-js/lib/transaction";
+} from "near-api-js/lib/providers/provider.js";
+import type { SignedTransaction } from "near-api-js/lib/transaction.js";
 
 export type QueryParams = { [key in string]: unknown };
 

--- a/packages/core/src/lib/wallet-selector.spec.ts
+++ b/packages/core/src/lib/wallet-selector.spec.ts
@@ -3,7 +3,7 @@ import { getNetworkPreset } from "./options";
 import {
   JsonRpcProvider,
   FailoverRpcProvider,
-} from "near-api-js/lib/providers";
+} from "near-api-js/lib/providers/index.js";
 import type { Network } from "./options.types";
 import type { Store } from "./store.types";
 import type { WalletModuleFactory } from "./wallet";
@@ -54,8 +54,10 @@ jest.mock("./store", () => {
   };
 });
 
-jest.mock("near-api-js/lib/providers", () => {
-  const originalModule = jest.requireActual("near-api-js/lib/providers");
+jest.mock("near-api-js/lib/providers/index.js", () => {
+  const originalModule = jest.requireActual(
+    "near-api-js/lib/providers/index.js"
+  );
   return {
     ...originalModule,
     FailoverRpcProvider: jest.fn(),

--- a/packages/core/src/lib/wallet/wallet.types.ts
+++ b/packages/core/src/lib/wallet/wallet.types.ts
@@ -9,8 +9,8 @@ import type { Options } from "../options.types";
 import type { ReadOnlyStore } from "../store.types";
 import type { Transaction, Action } from "./transactions.types";
 import type { Modify, Optional } from "../utils.types";
-import type { FinalExecutionOutcome } from "near-api-js/lib/providers";
-import type { SignedTransaction } from "near-api-js/lib/transaction";
+import type { FinalExecutionOutcome } from "near-api-js/lib/providers/index.js";
+import type { SignedTransaction } from "near-api-js/lib/transaction.js";
 import type { Signer } from "@near-js/signers";
 
 interface BaseWalletMetadata {

--- a/packages/ethereum-wallets/src/lib/index.ts
+++ b/packages/ethereum-wallets/src/lib/index.ts
@@ -4,10 +4,10 @@ import type {
   ExecutionStatus,
   FinalExecutionOutcome,
   FunctionCallPermissionView,
-} from "near-api-js/lib/providers/provider";
-import { JsonRpcProvider } from "near-api-js/lib/providers";
-import { stringifyJsonOrBytes } from "near-api-js/lib/transaction";
-import { parseRpcError } from "near-api-js/lib/utils/rpc_errors";
+} from "near-api-js/lib/providers/provider.js";
+import { JsonRpcProvider } from "near-api-js/lib/providers/index.js";
+import { stringifyJsonOrBytes } from "near-api-js/lib/transaction.js";
+import { parseRpcError } from "near-api-js/lib/utils/rpc_errors.js";
 import {
   type WalletModuleFactory,
   type WalletBehaviourFactory,

--- a/packages/intear-wallet/src/lib/intear-wallet.ts
+++ b/packages/intear-wallet/src/lib/intear-wallet.ts
@@ -9,8 +9,8 @@ import type {
 } from "@near-wallet-selector/core";
 import icon from "./icon";
 import * as nearAPI from "near-api-js";
-import { KeyType } from "near-api-js/lib/utils/key_pair";
-import type { AccessKeyView } from "near-api-js/lib/providers/provider";
+import { KeyType } from "near-api-js/lib/utils/key_pair.js";
+import type { AccessKeyView } from "near-api-js/lib/providers/provider.js";
 import { createAction } from "@near-wallet-selector/wallet-utils";
 
 interface LoggerService {

--- a/packages/ledger/src/lib/ledger.ts
+++ b/packages/ledger/src/lib/ledger.ts
@@ -21,7 +21,7 @@ import { isLedgerSupported, LedgerClient } from "./ledger-client";
 import type { Subscription } from "./ledger-client";
 import type { Signer } from "near-api-js";
 import * as nearAPI from "near-api-js";
-import type { FinalExecutionOutcome } from "near-api-js/lib/providers";
+import type { FinalExecutionOutcome } from "near-api-js/lib/providers/index.js";
 import icon from "./icon";
 import { serializeLedgerNEP413Payload } from "./nep413/ledger-payload";
 

--- a/packages/math-wallet/src/lib/injected-math-wallet.ts
+++ b/packages/math-wallet/src/lib/injected-math-wallet.ts
@@ -1,4 +1,4 @@
-import type { Signer } from "near-api-js/lib/signer";
+import type { Signer } from "near-api-js/lib/signer.js";
 
 interface LoginParams {
   contractId?: string;

--- a/packages/math-wallet/src/lib/math-wallet.ts
+++ b/packages/math-wallet/src/lib/math-wallet.ts
@@ -10,8 +10,8 @@ import type {
 import { getActiveAccount } from "@near-wallet-selector/core";
 import type { InjectedMathWallet } from "./injected-math-wallet";
 import { signTransactions } from "@near-wallet-selector/wallet-utils";
-import type { FinalExecutionOutcome } from "near-api-js/lib/providers";
-import * as nearAPITransactions from "near-api-js/lib/transaction";
+import type { FinalExecutionOutcome } from "near-api-js/lib/providers/index.js";
+import * as nearAPITransactions from "near-api-js/lib/transaction.js";
 import icon from "./icon";
 
 declare global {

--- a/packages/my-near-wallet/src/lib/mnw-connect.ts
+++ b/packages/my-near-wallet/src/lib/mnw-connect.ts
@@ -14,11 +14,11 @@ import {
   providers,
   transactions,
 } from "near-api-js";
-import type { KeyPairString, PublicKey } from "near-api-js/lib/utils";
-import { KeyPair, serialize } from "near-api-js/lib/utils";
+import type { KeyPairString, PublicKey } from "near-api-js/lib/utils/index.js";
+import { KeyPair, serialize } from "near-api-js/lib/utils/index.js";
 import * as borsh from "borsh";
-import { SCHEMA } from "near-api-js/lib/transaction";
-import type { JsonRpcProvider } from "near-api-js/lib/providers";
+import { SCHEMA } from "near-api-js/lib/transaction.js";
+import type { JsonRpcProvider } from "near-api-js/lib/providers/index.js";
 
 const DEFAULT_POPUP_WIDTH = 480;
 const DEFAULT_POPUP_HEIGHT = 640;

--- a/packages/nightly/src/lib/injected-nightly.ts
+++ b/packages/nightly/src/lib/injected-nightly.ts
@@ -6,8 +6,8 @@ import type {
 import type {
   SignedTransaction as NearSignedTransaction,
   Transaction as NearTransaction,
-} from "near-api-js/lib/transaction";
-import type { PublicKey as NearPublicKey } from "near-api-js/lib/utils";
+} from "near-api-js/lib/transaction.js";
+import type { PublicKey as NearPublicKey } from "near-api-js/lib/utils/index.js";
 interface NightlyAccount {
   accountId: string;
   publicKey: NearPublicKey;

--- a/packages/nightly/src/lib/nightly.ts
+++ b/packages/nightly/src/lib/nightly.ts
@@ -14,7 +14,7 @@ import { signTransactions } from "@near-wallet-selector/wallet-utils";
 import type { Signer } from "near-api-js";
 import * as nearAPI from "near-api-js";
 import type { NearNightly, InjectedNightly } from "./injected-nightly";
-import type { FinalExecutionOutcome } from "near-api-js/lib/providers";
+import type { FinalExecutionOutcome } from "near-api-js/lib/providers/index.js";
 import icon from "./icon";
 
 declare global {

--- a/packages/okx-wallet/src/lib/okx-wallet.spec.ts
+++ b/packages/okx-wallet/src/lib/okx-wallet.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @nx/enforce-module-boundaries */
 import { mock } from "jest-mock-extended";
 import type { ProviderService } from "packages/core/src/lib/services";
-import type { FinalExecutionOutcome } from "near-api-js/lib/providers";
+import type { FinalExecutionOutcome } from "near-api-js/lib/providers/index.js";
 
 import { setupOKXWallet } from "./okx-wallet";
 import { mockWallet } from "../../../core/src/lib/testUtils";
@@ -17,11 +17,11 @@ const transactions = [
   },
 ];
 
-jest.mock("near-api-js/lib/transaction", () => {
+jest.mock("near-api-js/lib/transaction.js", () => {
   return {
-    ...jest.requireActual("near-api-js/lib/transaction"),
+    ...jest.requireActual("near-api-js/lib/transaction.js"),
     SignedTransaction: {
-      ...jest.requireActual("near-api-js/lib/transaction").SignedTransaction,
+      ...jest.requireActual("near-api-js/lib/transaction.js").SignedTransaction,
       decode: jest.fn().mockReturnValue({}),
     },
   };

--- a/packages/okx-wallet/src/lib/okx-wallet.ts
+++ b/packages/okx-wallet/src/lib/okx-wallet.ts
@@ -1,5 +1,5 @@
 import { isMobile } from "is-mobile";
-import { SignedTransaction } from "near-api-js/lib/transaction";
+import { SignedTransaction } from "near-api-js/lib/transaction.js";
 import { isCurrentBrowserSupported, waitFor } from "@near-wallet-selector/core";
 
 import type {

--- a/packages/ramper-wallet/src/lib/ramper-wallet.ts
+++ b/packages/ramper-wallet/src/lib/ramper-wallet.ts
@@ -19,7 +19,7 @@ import {
   signIn,
   sendTransaction,
 } from "@ramper/near";
-import type { Action } from "near-api-js/lib/transaction";
+import type { Action } from "near-api-js/lib/transaction.js";
 
 interface RamperWalletState {
   wallet: InjectedRamperWallet;

--- a/packages/ramper-wallet/src/lib/ramper-wallet.types.ts
+++ b/packages/ramper-wallet/src/lib/ramper-wallet.types.ts
@@ -7,7 +7,7 @@ import type {
   TransactionResultType,
   User,
 } from "@ramper/near";
-import type { FinalExecutionOutcome } from "near-api-js/lib/providers";
+import type { FinalExecutionOutcome } from "near-api-js/lib/providers/index.js";
 
 type TransactionResult = {
   type: TransactionResultType;

--- a/packages/react-hook/src/lib/WalletSelectorProvider.tsx
+++ b/packages/react-hook/src/lib/WalletSelectorProvider.tsx
@@ -14,8 +14,8 @@ import {
 } from "@near-wallet-selector/core";
 import { setupModal } from "@near-wallet-selector/modal-ui";
 import { providers } from "near-api-js";
-import type { QueryResponseKind } from "near-api-js/lib/providers/provider";
-import type { SignedTransaction } from "near-api-js/lib/transaction";
+import type { QueryResponseKind } from "near-api-js/lib/providers/provider.js";
+import type { SignedTransaction } from "near-api-js/lib/transaction.js";
 
 class WalletError extends Error {
   constructor(message: string) {

--- a/packages/sender/src/lib/sender.spec.ts
+++ b/packages/sender/src/lib/sender.spec.ts
@@ -9,7 +9,7 @@ import type {
   SenderEvents,
   SignOutResponse,
 } from "./injected-sender";
-import type { FinalExecutionOutcome } from "near-api-js/lib/providers";
+import type { FinalExecutionOutcome } from "near-api-js/lib/providers/index.js";
 import { setupSender } from "./sender";
 
 const accountId = "test-account.testnet";

--- a/packages/wallet-connect/src/lib/wallet-connect.ts
+++ b/packages/wallet-connect/src/lib/wallet-connect.ts
@@ -1,6 +1,6 @@
 import type { KeyPair, providers } from "near-api-js";
 import * as nearAPI from "near-api-js";
-import type { AccessKeyViewRaw } from "near-api-js/lib/providers/provider";
+import type { AccessKeyViewRaw } from "near-api-js/lib/providers/provider.js";
 import type { SignClientTypes, SessionTypes } from "@walletconnect/types";
 import type {
   WalletModuleFactory,

--- a/packages/wallet-utils/src/lib/sign-transactions.ts
+++ b/packages/wallet-utils/src/lib/sign-transactions.ts
@@ -1,7 +1,7 @@
 import type { Signer } from "near-api-js";
 import * as nearAPI from "near-api-js";
 import type { Network, Transaction } from "@near-wallet-selector/core";
-import type { AccessKeyViewRaw } from "near-api-js/lib/providers/provider";
+import type { AccessKeyViewRaw } from "near-api-js/lib/providers/provider.js";
 import { createAction } from "./create-action";
 
 export const signTransactions = async (

--- a/packages/xdefi/src/lib/injected-xdefi.ts
+++ b/packages/xdefi/src/lib/injected-xdefi.ts
@@ -1,6 +1,6 @@
 import type { Transaction } from "@near-wallet-selector/core";
-import type { FinalExecutionOutcome } from "near-api-js/lib/providers";
-import type { PublicKey as NearPublicKey } from "near-api-js/lib/utils";
+import type { FinalExecutionOutcome } from "near-api-js/lib/providers/index.js";
+import type { PublicKey as NearPublicKey } from "near-api-js/lib/utils/index.js";
 
 export interface NearAccount {
   accountId: string;


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/near/wallet-selector/blob/main/CONTRIBUTING.md).
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [x] **If this is a code change**: I have written unit tests.
- [x] **If this changes code in a published package**: I have run `yarn changeset` to create a `changeset` JSON document appropriate for this change.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

Importing `wallet-selector/core` in applications using `babel>5` gives an error, since we are importing from `near-api-js/lib` without using the `.js` extension 

## Test Plan

Tests already existed

## Related issues/PRs

Related to #1381 
