### PR TITLE
fix: exclude example packages from changeset tracking

### DIFF
--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@near-wallet-selector-examples/react",
+  "private": true,
   "dependencies": {
     "@near-wallet-selector/math-wallet": "workspace:*",
     "@near-wallet-selector/meteor-wallet": "workspace:*",

--- a/examples/vanilla/package.json
+++ b/examples/vanilla/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "@near-wallet-selector-examples/react",
+  "name": "@near-wallet-selector-examples/vanilla",
+  "private": true,
   "dependencies": {
     "@near-wallet-selector/math-wallet": "workspace:*",
     "@near-wallet-selector/meteor-wallet": "workspace:*",


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to NEAR JavaScript API here: https://github.com/near/wallet-selector/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/near/wallet-selector/blob/main/CONTRIBUTING.md).
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [ ] **If this is a code change**: I have written unit tests.
- [ ] **If this changes code in a published package**: I have run `pnpm changeset` to create a `changeset` JSON document appropriate for this change.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

Example were being included in changeset version tracking, which is not desired since they are development/demonstration packages that shouldn't be published or versioned separately

This PR excludes the example packages from changeset tracking by marking them as `private: true` in their respective `package.json` files.

According to [changeset documentation](https://github.com/changesets/changesets/blob/main/docs/config-file-options.md#ignore-array-of-packages), private packages are automatically ignored by changesets by default.

## Related issues/PRs

**Failed Action:** https://github.com/near/wallet-selector/actions/runs/17257342584/job/48971797602
```
🦋  error an error occurred while publishing @near-wallet-selector-examples/react: ERR_PNPM_PACKAGE_VERSION_NOT_FOUND undefined 
🦋  error {
🦋  error   "error": {
🦋  error     "code": "ERR_PNPM_PACKAGE_VERSION_NOT_FOUND",
🦋  error     "message": "Package version is not defined in the package.json."
🦋  error   }
🦋  error }
🦋  error 
🦋  error an error occurred while publishing @near-wallet-selector-examples/react: ERR_PNPM_PACKAGE_VERSION_NOT_FOUND undefined 
🦋  error {
🦋  error   "error": {
🦋  error     "code": "ERR_PNPM_PACKAGE_VERSION_NOT_FOUND",
🦋  error     "message": "Package version is not defined in the package.json."
🦋  error   }
🦋  error }
🦋  error 

🦋  error packages failed to publish:
🦋  @near-wallet-selector-examples/react@undefined
🦋  @near-wallet-selector-examples/react@undefined
 ELIFECYCLE  Command failed with exit code 1.
Error: Error: The process '/home/runner/setup-pnpm/node_modules/.bin/pnpm' failed with exit code 1
Error: The process '/home/runner/setup-pnpm/node_modules/.bin/pnpm' failed with exit code 1
```
