### PR TITLE
Naj Compatibility

### DIFF
--- a/.changeset/purple-webs-lie.md
+++ b/.changeset/purple-webs-lie.md
@@ -1,0 +1,6 @@
+---
+"@near-wallet-selector/core": minor
+"@near-wallet-selector/react-hook": minor
+---
+
+compatibility with naj interface

--- a/examples/react/wallets/web3modal.ts
+++ b/examples/react/wallets/web3modal.ts
@@ -69,5 +69,3 @@ export const web3Modal = createAppKit({
   coinbasePreference: "eoaOnly", // Smart accounts (Safe contract) not available on NEAR Protocol, only EOA.
   allWallets: "SHOW",
 });
-
-reconnect(wagmiAdapter.wagmiConfig);

--- a/packages/core/src/lib/helpers/index.ts
+++ b/packages/core/src/lib/helpers/index.ts
@@ -1,5 +1,6 @@
 export * from "./waitFor";
 export * from "./getActiveAccount";
 export * from "./detect-browser";
+export * from "./transform-action";
 export * from "./verify-signature/verify-signature";
 export * from "./verify-signature/payload";

--- a/packages/core/src/lib/helpers/transform-action.ts
+++ b/packages/core/src/lib/helpers/transform-action.ts
@@ -1,0 +1,83 @@
+import type { Action } from "../wallet/transactions.types";
+import type { Action as NAJAction } from "@near-js/transactions";
+
+// temp fix until we migrate Wallet Selector to use NAJ types
+export const najActionToInternal = (action: NAJAction): Action => {
+  if (action.createAccount) {
+    return { type: "CreateAccount" };
+  }
+
+  if (action.deployContract) {
+    return {
+      type: "DeployContract",
+      params: { code: action.deployContract.code },
+    };
+  }
+
+  if (action.functionCall) {
+    const { methodName, args, gas, deposit } = action.functionCall;
+    return {
+      type: "FunctionCall",
+      params: {
+        methodName,
+        args, // Uint8Array is accepted by wallet-selector
+        gas: gas.toString(),
+        deposit: deposit.toString(),
+      },
+    };
+  }
+
+  if (action.transfer) {
+    return {
+      type: "Transfer",
+      params: { deposit: action.transfer.deposit.toString() },
+    };
+  }
+
+  if (action.addKey) {
+    const { publicKey, accessKey } = action.addKey;
+
+    let permission:
+      | "FullAccess"
+      | { receiverId: string; methodNames: Array<string>; allowance?: string };
+    if ("fullAccess" in accessKey.permission) {
+      permission = "FullAccess";
+    } else if ("functionCall" in accessKey.permission) {
+      const fc = accessKey.permission.functionCall;
+      permission = {
+        receiverId: fc!.receiverId,
+        methodNames: fc!.methodNames || [],
+        allowance: fc!.allowance ? fc!.allowance.toString() : undefined,
+      };
+    } else {
+      throw new Error("Unsupported access key permission");
+    }
+
+    return {
+      type: "AddKey",
+      params: {
+        publicKey: publicKey.toString(),
+        accessKey: {
+          nonce: Number(accessKey.nonce),
+          permission,
+        },
+      },
+    };
+  }
+
+  if (action.deleteKey) {
+    return {
+      type: "DeleteKey",
+      params: { publicKey: action.deleteKey.publicKey.toString() },
+    };
+  }
+
+  if (action.deleteAccount) {
+    return {
+      type: "DeleteAccount",
+      params: { beneficiaryId: action.deleteAccount.beneficiaryId },
+    };
+  }
+
+  throw new Error("Unsupported NAJ action");
+};

--- a/packages/core/src/lib/services/wallet-modules/wallet-modules.service.ts
+++ b/packages/core/src/lib/services/wallet-modules/wallet-modules.service.ts
@@ -11,7 +11,6 @@ import type {
   Action,
   SignAndSendTransactionsParams,
   SignAndSendTransactionParams,
-  Transaction,
 } from "../../wallet";
 import type { StorageService } from "../storage/storage.service.types";
 import type { Options } from "../../options.types";
@@ -29,6 +28,7 @@ import {
 } from "../../constants";
 import { JsonStorage } from "../storage/json-storage.service";
 import type { ProviderService } from "../provider/provider.service.types";
+import type { Action as NAJAction } from "@near-js/transactions";
 import { najActionToInternal } from "../../helpers/";
 
 export class WalletModules {
@@ -409,11 +409,21 @@ export class WalletModules {
       return _signDelegateAction(...args);
     };
 
-    wallet.signAndSendTransaction = async ({ actions, receiverId, signerId }: SignAndSendTransactionParams) => {
+    wallet.signAndSendTransaction = async ({
+      actions,
+      receiverId,
+      signerId,
+    }: SignAndSendTransactionParams) => {
       // Transform `naj` actions into internal representation
-      const normalized = actions.map((a:any) => (a.enum? najActionToInternal(a) : a));
-      return await _signAndSendTransaction({ actions: normalized, receiverId, signerId });
-    }
+      const normalized = actions.map((a) =>
+        "enum" in a ? najActionToInternal(a as NAJAction) : a
+      );
+      return await _signAndSendTransaction({
+        actions: normalized,
+        receiverId,
+        signerId,
+      });
+    };
 
     wallet.signAndSendTransactions = (async ({
       transactions,
@@ -422,11 +432,10 @@ export class WalletModules {
       // Transform `naj` actions into internal representation
       const normalized = transactions.map((tx) => ({
         ...tx,
-        actions: tx.actions.map(
-          (a: any) => a.enum ? najActionToInternal(a) : a
+        actions: tx.actions.map((a) =>
+          "enum" in a ? najActionToInternal(a as NAJAction) : a
         ),
       }));
-      console.log("normalized txs:", normalized)
       return _signAndSendTransactions({ ...rest, transactions: normalized });
     }) as Wallet["signAndSendTransactions"];
 

--- a/packages/core/src/lib/services/wallet-modules/wallet-modules.service.ts
+++ b/packages/core/src/lib/services/wallet-modules/wallet-modules.service.ts
@@ -9,6 +9,9 @@ import type {
   InstantLinkWallet,
   SignMessageParams,
   Action,
+  SignAndSendTransactionsParams,
+  SignAndSendTransactionParams,
+  Transaction,
 } from "../../wallet";
 import type { StorageService } from "../storage/storage.service.types";
 import type { Options } from "../../options.types";
@@ -26,6 +29,7 @@ import {
 } from "../../constants";
 import { JsonStorage } from "../storage/json-storage.service";
 import type { ProviderService } from "../provider/provider.service.types";
+import { najActionToInternal } from "../../helpers/";
 
 export class WalletModules {
   private factories: Array<WalletModuleFactory>;
@@ -309,6 +313,8 @@ export class WalletModules {
     const _signNep413Message = wallet.signNep413Message;
     const _signTransaction = wallet.signTransaction;
     const _signDelegateAction = wallet.signDelegateAction;
+    const _signAndSendTransaction = wallet.signAndSendTransaction;
+    const _signAndSendTransactions = wallet.signAndSendTransactions;
 
     wallet.signIn = async (params: SignInParams) => {
       const accounts = await _signIn({
@@ -400,8 +406,29 @@ export class WalletModules {
         );
       }
 
-      return await _signDelegateAction(...args);
+      return _signDelegateAction(...args);
     };
+
+    wallet.signAndSendTransaction = async ({ actions, receiverId, signerId }: SignAndSendTransactionParams) => {
+      // Transform `naj` actions into internal representation
+      const normalized = actions.map((a:any) => (a.enum? najActionToInternal(a) : a));
+      return await _signAndSendTransaction({ actions: normalized, receiverId, signerId });
+    }
+
+    wallet.signAndSendTransactions = (async ({
+      transactions,
+      ...rest
+    }: SignAndSendTransactionsParams) => {
+      // Transform `naj` actions into internal representation
+      const normalized = transactions.map((tx) => ({
+        ...tx,
+        actions: tx.actions.map(
+          (a: any) => a.enum ? najActionToInternal(a) : a
+        ),
+      }));
+      console.log("normalized txs:", normalized)
+      return _signAndSendTransactions({ ...rest, transactions: normalized });
+    }) as Wallet["signAndSendTransactions"];
 
     return wallet;
   }

--- a/packages/core/src/lib/wallet/wallet.types.ts
+++ b/packages/core/src/lib/wallet/wallet.types.ts
@@ -101,7 +101,7 @@ export type SignMessageMethod = {
   signMessage(params: SignMessageParams): Promise<SignedMessage | void>;
 };
 
-interface SignAndSendTransactionParams {
+export interface SignAndSendTransactionParams {
   /**
    * Account ID used to sign the transaction. Defaults to the first account.
    */
@@ -116,7 +116,7 @@ interface SignAndSendTransactionParams {
   actions: Array<Action>;
 }
 
-interface SignAndSendTransactionsParams {
+export interface SignAndSendTransactionsParams {
   /**
    * NEAR Transactions(s) to sign and send to the network. You can find more information on `Transaction` {@link https://github.com/near/wallet-selector/blob/main/packages/core/docs/api/transactions.md | here}.
    */

--- a/packages/react-hook/src/lib/WalletSelectorProvider.tsx
+++ b/packages/react-hook/src/lib/WalletSelectorProvider.tsx
@@ -68,7 +68,7 @@ export interface WalletSelectorProviderValue {
   getAccessKeys: (accountId: string) => Promise<Array<unknown>>;
   signAndSendTransactions: (params: {
     transactions: Array<Transaction>;
-  }) => Promise<Array<object | string | number | null>>;
+  }) => Promise<Array<FinalExecutionOutcome>>;
   signMessage: (params: SignMessageParams) => Promise<void | SignedMessage>;
   getAccount: (accountId: string) => Promise<QueryResponseKindWithAmount>;
   verifyMessage: (
@@ -277,7 +277,7 @@ export function WalletSelectorProvider({
   /**
    * Signs transactions and broadcasts them to the network
    * @param {Object[]} transactions - the transactions to sign and send
-   * @returns {Promise<Transaction[]>} - the resulting transactions
+   * @returns {Promise<Array<FinalExecutionOutcome>>} - the resulting transactions
    */
   const signAndSendTransactions = useCallback(
     async ({ transactions }: { transactions: Array<Transaction> }) => {
@@ -285,13 +285,9 @@ export function WalletSelectorProvider({
         throw new WalletError("No wallet connected");
       }
 
-      const sentTxs = (await wallet.signAndSendTransactions({
+      return wallet.signAndSendTransactions({
         transactions,
-      })) as Array<FinalExecutionOutcome>;
-
-      return sentTxs.map((tx: FinalExecutionOutcome) =>
-        providers.getTransactionLastResult(tx)
-      );
+      }) as Promise<Array<FinalExecutionOutcome>>;
     },
     [wallet]
   );

--- a/packages/wallet-utils/src/lib/create-action.ts
+++ b/packages/wallet-utils/src/lib/create-action.ts
@@ -1,4 +1,4 @@
-import type { Action as NAJAction } from "near-api-js/lib/transaction";
+import type { Action as NAJAction } from "@near-js/transactions";
 import type { AddKeyPermission, Action } from "@near-wallet-selector/core";
 import { transactions, utils } from "near-api-js";
 
@@ -16,11 +16,7 @@ const getAccessKey = (permission: AddKeyPermission) => {
 };
 
 // TODO: Remove this function after all wallets use the NAJ Action by default
-export const createAction = (action: Action | NAJAction): NAJAction => {
-  if ("enum" in action) {
-    return action as NAJAction;
-  }
-
+export const createAction = (action: Action): NAJAction => {
   switch (action.type) {
     case "CreateAccount":
       return transactions.createAccount();

--- a/packages/wallet-utils/src/lib/sign-transactions.ts
+++ b/packages/wallet-utils/src/lib/sign-transactions.ts
@@ -1,4 +1,5 @@
 import type { Signer } from "near-api-js";
+
 import * as nearAPI from "near-api-js";
 import type { Network, Transaction } from "@near-wallet-selector/core";
 import type { AccessKeyViewRaw } from "near-api-js/lib/providers/provider.js";


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to NEAR JavaScript API here: https://github.com/near/wallet-selector/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/near/wallet-selector/blob/main/CONTRIBUTING.md).
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [x] **If this is a code change**: I have written unit tests.
- [x] **If this changes code in a published package**: I have run `pnpm changeset` to create a `changeset` JSON document appropriate for this change.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

This PR makes it possible to use the wallet selector as a `near-api-js` `Signer` by introducing a helper function that transforms `naj` `Actions` into the internal `Action`, and decorate the `signAndSendTransaction(s)` functions to use them  