### PR TITLE
refactor: migrate near-api-js to use  individual packages

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,14 +20,15 @@
   },
   "homepage": "https://github.com/near/wallet-selector/tree/main/packages/core",
   "dependencies": {
+    "@near-js/crypto": "^2.3.0",
+    "@near-js/providers": "^2.3.0",
+    "@near-js/types": "^2.3.0",
+    "@near-js/transactions": "^2.3.0",
     "@near-js/signers": "2.1.0",
     "borsh": "2.0.0",
     "events": "3.3.0",
     "js-sha256": "0.9.0",
     "rxjs": "7.8.1"
-  },
-  "peerDependencies": {
-    "near-api-js": "^4.0.0 || ^5.0.0"
   },
   "publishConfig": {
     "directory": "../../dist/packages/core"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -72,7 +72,7 @@ export type {
   SignMessageParams,
 } from "./lib/wallet";
 
-export type { FinalExecutionOutcome } from "near-api-js/lib/providers/index.js";
+export type { FinalExecutionOutcome } from "@near-js/types";
 
 export {
   waitFor,

--- a/packages/core/src/lib/helpers/verify-signature/verify-signature.ts
+++ b/packages/core/src/lib/helpers/verify-signature/verify-signature.ts
@@ -1,4 +1,6 @@
-import { utils, providers } from "near-api-js";
+import { PublicKey } from "@near-js/crypto";
+import { JsonRpcProvider } from "@near-js/providers";
+import type { AccessKeyView } from "@near-js/types";
 import { serialize } from "borsh";
 import { sha256 } from "js-sha256";
 import type {
@@ -7,7 +9,6 @@ import type {
   ViewAccessKeyParams,
 } from "./verify-signature.types";
 import { Payload, payloadSchema } from "./payload";
-import type { AccessKeyView } from "near-api-js/lib/providers/provider.js";
 
 export const verifySignature = ({
   publicKey,
@@ -28,9 +29,9 @@ export const verifySignature = ({
   // https://github.com/gagdiez/near-login/blob/main/authenticate/wallet-authenticate.js#L21
   const hashedPayload = Uint8Array.from(sha256.array(borshPayload));
 
-  // Convert real signature to buffer base64
-  const realSignature = Buffer.from(signature, "base64");
-  const pk = utils.PublicKey.from(publicKey);
+  // Convert real signature to Uint8Array from base64
+  const realSignature = new Uint8Array(Buffer.from(signature, "base64"));
+  const pk = PublicKey.from(publicKey);
 
   // Verify the signature
   return pk.verify(hashedPayload, realSignature);
@@ -41,7 +42,7 @@ const fetchAllUserKeys = async ({
   network,
   publicKey,
 }: ViewAccessKeyParams): Promise<AccessKeyView> => {
-  const provider = new providers.JsonRpcProvider({ url: network.nodeUrl });
+  const provider = new JsonRpcProvider({ url: network.nodeUrl });
   const key = await provider.query({
     request_type: "view_access_key",
     account_id: accountId,

--- a/packages/core/src/lib/services/provider/provider.service.mocks.ts
+++ b/packages/core/src/lib/services/provider/provider.service.mocks.ts
@@ -1,4 +1,4 @@
-import type { QueryResponseKind } from "near-api-js/lib/providers/provider.js";
+import type { QueryResponseKind } from "@near-js/types";
 
 export const createQueryResponseMock = (): QueryResponseKind => ({
   block_height: 0,

--- a/packages/core/src/lib/services/provider/provider.service.spec.ts
+++ b/packages/core/src/lib/services/provider/provider.service.spec.ts
@@ -4,20 +4,18 @@ import type {
   ViewAccessKeyParams,
 } from "./provider.service.types";
 import { mock } from "jest-mock-extended";
-import type {
-  FinalExecutionOutcome,
-  JsonRpcProvider,
-} from "near-api-js/lib/providers/index.js";
-import * as nearAPI from "near-api-js";
+import type { FinalExecutionOutcome } from "@near-js/types";
+import { JsonRpcProvider } from "@near-js/providers";
+import * as providers from "@near-js/providers";
 import {
   createQueryResponseMock,
   createViewAccessKeyResponseMock,
 } from "./provider.service.mocks";
-import type { SignedTransaction } from "near-api-js/lib/transaction.js";
+import type { SignedTransaction } from "@near-js/transactions";
 import type {
   BlockReference,
   BlockResult,
-} from "near-api-js/lib/providers/provider.js";
+} from "@near-js/types";
 
 const defaults = {
   url: "https://test.rpc.fastnear.com",
@@ -25,10 +23,9 @@ const defaults = {
 
 const setup = (url: string) => {
   const provider = mock<JsonRpcProvider>();
-
   jest
-    .spyOn(nearAPI.providers, "JsonRpcProvider")
-    .mockImplementation(() => provider);
+    .spyOn(providers, "JsonRpcProvider")
+    .mockImplementation(() => provider as unknown as JsonRpcProvider);
 
   return {
     provider,

--- a/packages/core/src/lib/services/provider/provider.service.ts
+++ b/packages/core/src/lib/services/provider/provider.service.ts
@@ -1,25 +1,22 @@
-import * as nearAPI from "near-api-js";
+import { FailoverRpcProvider, JsonRpcProvider } from "@near-js/providers";
 import type {
   AccessKeyView,
   BlockReference,
   QueryResponseKind,
   RpcQueryRequest,
-} from "near-api-js/lib/providers/provider.js";
+} from "@near-js/types";
 import type {
   ProviderService,
   QueryParams,
   ViewAccessKeyParams,
 } from "./provider.service.types";
-import { JsonRpcProvider } from "near-api-js/lib/providers/index.js";
-import type { SignedTransaction } from "near-api-js/lib/transaction.js";
+import type { SignedTransaction } from "@near-js/transactions";
 
 export class Provider implements ProviderService {
-  private provider: nearAPI.providers.FailoverRpcProvider;
+  private provider: FailoverRpcProvider;
 
   constructor(urls: Array<string>) {
-    this.provider = new nearAPI.providers.FailoverRpcProvider(
-      this.urlsToProviders(urls)
-    );
+    this.provider = new FailoverRpcProvider(this.urlsToProviders(urls));
   }
 
   query<Response extends QueryResponseKind>(

--- a/packages/core/src/lib/services/provider/provider.service.types.ts
+++ b/packages/core/src/lib/services/provider/provider.service.types.ts
@@ -4,8 +4,8 @@ import type {
   BlockResult,
   QueryResponseKind,
   FinalExecutionOutcome,
-} from "near-api-js/lib/providers/provider.js";
-import type { SignedTransaction } from "near-api-js/lib/transaction.js";
+} from "@near-js/types";
+import type { SignedTransaction } from "@near-js/transactions";
 
 export type QueryParams = { [key in string]: unknown };
 

--- a/packages/core/src/lib/wallet-selector.spec.ts
+++ b/packages/core/src/lib/wallet-selector.spec.ts
@@ -3,7 +3,7 @@ import { getNetworkPreset } from "./options";
 import {
   JsonRpcProvider,
   FailoverRpcProvider,
-} from "near-api-js/lib/providers/index.js";
+} from "@near-js/providers";
 import type { Network } from "./options.types";
 import type { Store } from "./store.types";
 import type { WalletModuleFactory } from "./wallet";
@@ -54,9 +54,9 @@ jest.mock("./store", () => {
   };
 });
 
-jest.mock("near-api-js/lib/providers/index.js", () => {
+jest.mock("@near-js/providers", () => {
   const originalModule = jest.requireActual(
-    "near-api-js/lib/providers/index.js"
+    "@near-js/providers"
   );
   return {
     ...originalModule,

--- a/packages/core/src/lib/wallet/wallet.types.ts
+++ b/packages/core/src/lib/wallet/wallet.types.ts
@@ -1,4 +1,4 @@
-import type { providers, utils } from "near-api-js";
+import type { KeyType } from "@near-js/crypto";
 import type {
   EventEmitterService,
   LoggerService,
@@ -9,8 +9,8 @@ import type { Options } from "../options.types";
 import type { ReadOnlyStore } from "../store.types";
 import type { Transaction, Action } from "./transactions.types";
 import type { Modify, Optional } from "../utils.types";
-import type { FinalExecutionOutcome } from "near-api-js/lib/providers/index.js";
-import type { SignedTransaction } from "near-api-js/lib/transaction.js";
+import type { FinalExecutionOutcome } from "@near-js/types";
+import type { SignedTransaction } from "@near-js/transactions";
 import type { Signer } from "@near-js/signers";
 
 interface BaseWalletMetadata {
@@ -79,7 +79,7 @@ export interface VerifiedOwner {
   blockId: string;
   publicKey: string;
   signature: string;
-  keyType: utils.key_pair.KeyType;
+  keyType: KeyType;
 }
 
 export interface SignMessageParams {
@@ -148,14 +148,14 @@ interface BaseWalletBehaviour extends Signer {
    */
   signAndSendTransaction(
     params: SignAndSendTransactionParams
-  ): Promise<providers.FinalExecutionOutcome>;
+  ): Promise<FinalExecutionOutcome>;
   /**
    * Signs one or more transactions before sending to the network.
    * The user must be signed in to call this method as there's at least charges for gas spent.
    */
   signAndSendTransactions(
     params: SignAndSendTransactionsParams
-  ): Promise<Array<providers.FinalExecutionOutcome>>;
+  ): Promise<Array<FinalExecutionOutcome>>;
   signMessage?(params: SignMessageParams): Promise<SignedMessage | void>;
   /**
    * Create a signed transaction that is ready to be broadcast to the network

--- a/packages/wallet-utils/package.json
+++ b/packages/wallet-utils/package.json
@@ -20,12 +20,16 @@
   },
   "homepage": "https://github.com/near/wallet-selector/tree/main/packages/wallet-utils",
   "dependencies": {
-    "@near-wallet-selector/core": "workspace:*"
+    "@near-wallet-selector/core": "workspace:*",
+    "@near-js/transactions": "^2.3.0",
+    "@near-js/crypto": "^2.3.0",
+    "@near-js/providers": "^2.3.0",
+    "@near-js/signers": "2.1.0",
+    "@near-js/utils": "^2.3.0",
+    "@near-js/types": "^2.3.0"
   },
   "publishConfig": {
     "directory": "../../dist/packages/wallet-utils"
   },
-  "peerDependencies": {
-    "near-api-js": "^4.0.0 || ^5.0.0"
-  }
+  "peerDependencies": {}
 }

--- a/packages/wallet-utils/src/lib/sign-transactions.ts
+++ b/packages/wallet-utils/src/lib/sign-transactions.ts
@@ -1,7 +1,10 @@
-import type { Signer } from "near-api-js";
-import * as nearAPI from "near-api-js";
+import type { Signer } from "@near-js/signers";
+import { JsonRpcProvider } from "@near-js/providers";
+import { createTransaction, signTransaction, SignedTransaction } from "@near-js/transactions";
+import { PublicKey } from "@near-js/crypto";
+import { baseDecode } from "@near-js/utils";
+import type { AccessKeyViewRaw } from "@near-js/types";
 import type { Network, Transaction } from "@near-wallet-selector/core";
-import type { AccessKeyViewRaw } from "near-api-js/lib/providers/provider.js";
 import { createAction } from "./create-action";
 
 export const signTransactions = async (
@@ -9,11 +12,11 @@ export const signTransactions = async (
   signer: Signer,
   network: Network
 ) => {
-  const provider = new nearAPI.providers.JsonRpcProvider({
+  const provider = new JsonRpcProvider({
     url: network.nodeUrl,
   });
 
-  const signedTransactions: Array<nearAPI.transactions.SignedTransaction> = [];
+  const signedTransactions: Array<SignedTransaction> = [];
 
   for (let i = 0; i < transactions.length; i++) {
     const publicKey = await signer.getPublicKey(
@@ -35,16 +38,16 @@ export const signTransactions = async (
       createAction(action)
     );
 
-    const transaction = nearAPI.transactions.createTransaction(
+    const transaction = createTransaction(
       transactions[i].signerId,
-      nearAPI.utils.PublicKey.from(publicKey.toString()),
+      PublicKey.from(publicKey.toString()),
       transactions[i].receiverId,
       accessKey.nonce + i + 1,
       actions,
-      nearAPI.utils.serialize.base_decode(block.header.hash)
+      baseDecode(block.header.hash)
     );
 
-    const response = await nearAPI.transactions.signTransaction(
+    const response = await signTransaction(
       transaction,
       signer,
       transactions[i].signerId,

--- a/packages/wallet-utils/src/lib/wallet-utils.spec.ts
+++ b/packages/wallet-utils/src/lib/wallet-utils.spec.ts
@@ -1,5 +1,8 @@
 import { createAction } from "./wallet-utils";
-import { transactions, utils } from "near-api-js";
+import { actionCreators } from "@near-js/transactions";
+import { PublicKey } from "@near-js/crypto";
+
+const { transfer: transferAction, stake: stakeAction, addKey, functionCall, deleteKey, createAccount, deployContract, deleteAccount } = actionCreators;
 
 const TEST_PUBLIC_KEY = "ed25519:Anu5D32fr5YsQGVULF4fz3R2E3pNaeUhj4hsKcE4vDyk";
 
@@ -7,11 +10,11 @@ describe("transformActions", () => {
   it("correctly transforms 'CreateAccount' action", () => {
     const actions = createAction({ type: "CreateAccount" });
 
-    expect(actions).toEqual(transactions.createAccount());
+    expect(actions).toEqual(createAccount());
   });
 
   it("correctly transforms 'DeployContract' action", () => {
-    const code = Buffer.from("{}");
+    const code = new Uint8Array(Buffer.from("{}"));
 
     const actions = createAction({
       type: "DeployContract",
@@ -20,11 +23,11 @@ describe("transformActions", () => {
       },
     });
 
-    expect(actions).toEqual(transactions.deployContract(code));
+    expect(actions).toEqual(deployContract(code));
   });
 
   it("correctly transforms 'FunctionCall' action", () => {
-    const args = Buffer.from("{}");
+    const args = new Uint8Array(Buffer.from("{}"));
     const gas = "1";
     const deposit = "2";
     const methodName = "methodName";
@@ -40,7 +43,7 @@ describe("transformActions", () => {
     });
 
     expect(actions).toEqual(
-      transactions.functionCall(methodName, args, BigInt(gas), BigInt(deposit))
+      functionCall(methodName, args, BigInt(gas), BigInt(deposit))
     );
   });
 
@@ -53,7 +56,7 @@ describe("transformActions", () => {
       },
     });
 
-    expect(actions).toEqual(transactions.transfer(BigInt(deposit)));
+    expect(actions).toEqual(transferAction(BigInt(deposit)));
   });
 
   it("correctly transforms 'Stake' action", () => {
@@ -69,7 +72,7 @@ describe("transformActions", () => {
     });
 
     expect(actions).toEqual(
-      transactions.stake(BigInt(stake), utils.PublicKey.from(publicKey))
+      stakeAction(BigInt(stake), PublicKey.from(publicKey))
     );
   });
 
@@ -86,9 +89,9 @@ describe("transformActions", () => {
     });
 
     expect(actions).toEqual(
-      transactions.addKey(
-        utils.PublicKey.from(publicKey),
-        transactions.fullAccessKey()
+      addKey(
+        PublicKey.from(publicKey),
+        actionCreators.fullAccessKey()
       )
     );
   });
@@ -114,9 +117,9 @@ describe("transformActions", () => {
     });
 
     expect(actions).toEqual(
-      transactions.addKey(
-        utils.PublicKey.from(publicKey),
-        transactions.functionCallAccessKey(
+      addKey(
+        PublicKey.from(publicKey),
+        actionCreators.functionCallAccessKey(
           receiverId,
           methodNames,
           BigInt(allowance)
@@ -136,7 +139,7 @@ describe("transformActions", () => {
     });
 
     expect(actions).toEqual(
-      transactions.deleteKey(utils.PublicKey.from(publicKey))
+      deleteKey(PublicKey.from(publicKey))
     );
   });
 
@@ -150,6 +153,6 @@ describe("transformActions", () => {
       },
     });
 
-    expect(actions).toEqual(transactions.deleteAccount(beneficiaryId));
+    expect(actions).toEqual(deleteAccount(beneficiaryId));
   });
 });


### PR DESCRIPTION

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/near/wallet-selector/blob/main/CONTRIBUTING.md).
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [x] **If this is a code change**: I have written unit tests.
- [ ] **If this changes code in a published package**: I have run `pnpm changeset` to create a `changeset` JSON document appropriate for this change.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

Refactored all the packages to used the @near-js packages 

## Related issues

Fixes #1412 
