### PR TITLE
feat: add support for string and object format in createAccessKeyFor parameter

### DIFF
--- a/.changeset/dirty-cars-shop.md
+++ b/.changeset/dirty-cars-shop.md
@@ -1,0 +1,6 @@
+---
+"@near-wallet-selector/react-hook": patch
+"@near-wallet-selector/core": patch
+---
+
+Accept string and object for createAccessKeyFor interface

--- a/examples/react/pages/index.tsx
+++ b/examples/react/pages/index.tsx
@@ -31,7 +31,10 @@ import type { SetupParams } from "@near-wallet-selector/react-hook";
 
 const walletSelectorConfig: SetupParams = {
   network: NETWORK_ID,
-  // createAccessKeyFor: CONTRACT_ID,
+  // createAccessKeyFor: {
+  //   contractId: CONTRACT_ID,
+  //   methodNames: [],
+  // },
   debug: false,
   modules: [
     setupEthereumWallets({

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -33,6 +33,23 @@ const selector = await setupWalletSelector({
   network: "testnet",
   modules: [setupMyNearWallet()],
 });
+
+// Example with createAccessKeyFor for limited access keys (object format)
+const selectorWithLimitedAccess = await setupWalletSelector({
+  network: "testnet",
+  modules: [setupMyNearWallet()],
+  createAccessKeyFor: {
+    contractId: "guest-book.testnet",
+    methodNames: ["addMessage", "getMessages"]
+  },
+});
+
+// Example with createAccessKeyFor using string format (creates key with no method restrictions)
+const selectorWithSimpleAccess = await setupWalletSelector({
+  network: "testnet",
+  modules: [setupMyNearWallet()],
+  createAccessKeyFor: "guest-book.testnet",
+});
 ```
 
 ## Options
@@ -49,6 +66,11 @@ const selector = await setupWalletSelector({
 - `allowMultipleSelectors` (`boolean?`): Optionally allow creating new instances of wallet selector.
 - `languageCode` (`string?`): Optionally set specific ISO 639-1 two-letter language code, disables language detection based on the browser's settings.
 - `relayerUrl` (`string?`): Optionally set the URL that meta-transaction enabled wallet modules can use to submit DelegateActions to a relayer
+- `createAccessKeyFor` (`string | object?`): The contract ID and method names to create a function call access key for. This allows wallets to create limited access keys for specific contract methods. Can be either:
+  - A string containing just the contract ID (creates access key with no method restrictions)
+  - An object with the following properties:
+    - `contractId` (`string`): The contract ID to create the access key for.
+    - `methodNames` (`Array<string>`): Array of method names that the access key will be limited to.
 - `storage` (`StorageService?`): Async storage implementation. Useful when [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) is unavailable. Defaults to `localStorage`.
 - `modules` (`Array<WalletModuleFactory>`): List of wallets to support in your dApp.
 

--- a/packages/core/docs/api/selector.md
+++ b/packages/core/docs/api/selector.md
@@ -16,6 +16,11 @@
 - `allowMultipleSelectors` (`boolean?`): Wether to allow multiple wallet selector instances to be created.
 - `languageCode` (`string?`): ISO 639-1 two-letter language code.
 - `relayerUrl` (`string?`): The URL where DelegateActions are sent by meta transaction enabled wallet modules.
+- `createAccessKeyFor` (`string | object?`): The contract ID and method names to create a function call access key for. This allows wallets to create limited access keys for specific contract methods. Can be either:
+  - A string containing just the contract ID (creates access key with no method restrictions)
+  - An object with the following properties:
+    - `contractId` (`string`): The contract ID to create the access key for.
+    - `methodNames` (`Array<string>`): Array of method names that the access key will be limited to.
 
 **Description**
 

--- a/packages/core/src/lib/options.ts
+++ b/packages/core/src/lib/options.ts
@@ -40,6 +40,17 @@ export const resolveOptions = (params: WalletSelectorParams) => {
     optimizeWalletOrder: params.optimizeWalletOrder === false ? false : true,
     randomizeWalletOrder: params.randomizeWalletOrder || false,
     relayerUrl: params.relayerUrl || undefined,
+    createAccessKeyFor: params.createAccessKeyFor
+      ? typeof params.createAccessKeyFor === "string"
+        ? {
+            contractId: params.createAccessKeyFor,
+            methodNames: [],
+          }
+        : {
+            contractId: params.createAccessKeyFor.contractId,
+            methodNames: params.createAccessKeyFor.methodNames,
+          }
+      : undefined,
   };
 
   return {

--- a/packages/core/src/lib/options.types.ts
+++ b/packages/core/src/lib/options.types.ts
@@ -50,4 +50,11 @@ export interface Options {
    * The URL where DelegateActions are sent by meta transaction enabled wallet modules.
    */
   relayerUrl: string | undefined;
+  /**
+   * The contract ID and method names to create a function call access key for
+   */
+  createAccessKeyFor?: {
+    contractId: string;
+    methodNames: Array<string>;
+  };
 }

--- a/packages/core/src/lib/services/wallet-modules/wallet-modules.service.ts
+++ b/packages/core/src/lib/services/wallet-modules/wallet-modules.service.ts
@@ -303,7 +303,9 @@ export class WalletModules {
   }
 
   private decorateWallet(wallet: Wallet): Wallet {
-    const _signIn = wallet.signIn;
+    const _signIn = wallet.signIn as (
+      params: SignInParams
+    ) => Promise<Array<Account>>;
     const _signOut = wallet.signOut;
     const _signMessage = wallet.signMessage;
     const _createSignedTransaction = wallet.createSignedTransaction;
@@ -314,10 +316,13 @@ export class WalletModules {
     const _signAndSendTransaction = wallet.signAndSendTransaction;
     const _signAndSendTransactions = wallet.signAndSendTransactions;
 
-    wallet.signIn = async (params: never) => {
-      const accounts = await _signIn(params);
+    wallet.signIn = async (params: SignInParams) => {
+      const accounts = await _signIn({
+        ...this.options.createAccessKeyFor,
+        ...params,
+      });
 
-      const { contractId, methodNames = [] } = params as SignInParams;
+      const { contractId, methodNames = [] } = params;
       await this.onWalletSignedIn(wallet.id, {
         accounts,
         contractId: contractId || "",

--- a/packages/core/src/lib/wallet-selector.types.ts
+++ b/packages/core/src/lib/wallet-selector.types.ts
@@ -50,6 +50,15 @@ export interface WalletSelectorParams {
    * Whether multiple RPC URLs are included, used for the FailoverRpcProvider.
    */
   fallbackRpcUrls?: Array<string>;
+  /**
+   * The contract ID and method names to create a function call access key for.
+   */
+  createAccessKeyFor?:
+    | string
+    | {
+        contractId: string;
+        methodNames: Array<string>;
+      };
 }
 
 export type WalletSelectorStore = ReadOnlyStore;

--- a/packages/react-hook/README.md
+++ b/packages/react-hook/README.md
@@ -22,7 +22,13 @@ import { WalletSelectorProvider } from '@near-wallet-selector/react-hook';
  
 const walletSelectorConfig = {
   network: "testnet",
+  // Can be a string for simple contract access
   createAccessKeyFor: "hello.near-examples.testnet",
+  // Or an object for fine-grained control:
+  // createAccessKeyFor: {
+  //   contractId: "hello.near-examples.testnet",
+  //   methodNames: ["view_greeting", "set_greeting"]
+  // },
   modules: [
     setupMyNearWallet(),
     setupMeteorWallet(),

--- a/packages/react-hook/src/lib/WalletSelectorProvider.tsx
+++ b/packages/react-hook/src/lib/WalletSelectorProvider.tsx
@@ -58,9 +58,7 @@ export interface SignMessageParams {
   callbackUrl?: string;
 }
 
-export type SetupParams = WalletSelectorParams & {
-  createAccessKeyFor?: string;
-};
+export type SetupParams = WalletSelectorParams;
 
 export interface WalletSelectorProviderValue {
   walletSelector: Promise<WalletSelector> | null;
@@ -158,7 +156,14 @@ export function WalletSelectorProvider({
   const signIn = async () => {
     const ws = await walletSelector;
     const modalInstance = setupModal(ws!, {
-      contractId: config.createAccessKeyFor,
+      contractId:
+        typeof config.createAccessKeyFor === "string"
+          ? config.createAccessKeyFor
+          : config.createAccessKeyFor?.contractId,
+      methodNames:
+        typeof config.createAccessKeyFor === "object"
+          ? config.createAccessKeyFor.methodNames
+          : [],
     });
     modalInstance.show();
   };


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/near/wallet-selector/blob/main/CONTRIBUTING.md).
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [ ] **If this is a code change**: I have written unit tests.
- [x] **If this changes code in a published package**: I have run `pnpm changeset` to create a `changeset` JSON document appropriate for this change.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation
- Update type definitions to accept both string and object formats for createAccessKeyFor
- Support string format for simple contract access
- Maintain backward compatibility with existing format

This is a fully backward-compatible enhancement so no breaking changes