### PR TITLE
test: add unit tests in core package

### DIFF
--- a/packages/core/src/lib/helpers/detect-browser.spec.ts
+++ b/packages/core/src/lib/helpers/detect-browser.spec.ts
@@ -1,0 +1,132 @@
+import { isCurrentBrowserSupported } from "./detect-browser";
+import type { Browser } from "./detect-browser";
+
+describe("isCurrentBrowserSupported", () => {
+  const originalNavigator = global.navigator;
+
+  afterEach(() => {
+    global.navigator = originalNavigator;
+  });
+
+  it("should detect Chrome correctly", () => {
+    Object.defineProperty(global, "navigator", {
+      value: {
+        userAgent:
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    const supportedBrowsers: Array<Browser> = ["chrome", "firefox"];
+    const result = isCurrentBrowserSupported(supportedBrowsers);
+
+    expect(result).toBe(true);
+  });
+
+  it("should detect Firefox correctly", () => {
+    Object.defineProperty(global, "navigator", {
+      value: {
+        userAgent:
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:89.0) Gecko/20100101 Firefox/89.0",
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    const supportedBrowsers: Array<Browser> = ["chrome", "firefox"];
+    const result = isCurrentBrowserSupported(supportedBrowsers);
+
+    expect(result).toBe(true);
+  });
+
+  it("should detect Safari correctly", () => {
+    Object.defineProperty(global, "navigator", {
+      value: {
+        userAgent:
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.1 Safari/605.1.15",
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    const supportedBrowsers: Array<Browser> = ["safari", "chrome"];
+    const result = isCurrentBrowserSupported(supportedBrowsers);
+
+    expect(result).toBe(true);
+  });
+
+  it("should return false for unsupported browsers", () => {
+    Object.defineProperty(global, "navigator", {
+      value: {
+        userAgent:
+          "Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko",
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    const supportedBrowsers: Array<Browser> = ["chrome", "firefox"];
+    const result = isCurrentBrowserSupported(supportedBrowsers);
+
+    expect(result).toBe(false);
+  });
+
+  it("should return false when navigator is undefined (server-side)", () => {
+    // @ts-expect-error - Intentionally removing navigator for testing
+    delete global.navigator;
+
+    const supportedBrowsers: Array<Browser> = ["chrome", "firefox"];
+    const result = isCurrentBrowserSupported(supportedBrowsers);
+
+    expect(result).toBe(false);
+  });
+
+  it("should detect Edge Chromium correctly", () => {
+    Object.defineProperty(global, "navigator", {
+      value: {
+        userAgent:
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36 Edg/91.0.864.59",
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    const supportedBrowsers: Array<Browser> = ["edge-chromium", "chrome"];
+    const result = isCurrentBrowserSupported(supportedBrowsers);
+
+    expect(result).toBe(true);
+  });
+
+  it("should return false when supported browsers array is empty", () => {
+    Object.defineProperty(global, "navigator", {
+      value: {
+        userAgent:
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    const supportedBrowsers: Array<Browser> = [];
+    const result = isCurrentBrowserSupported(supportedBrowsers);
+
+    expect(result).toBe(false);
+  });
+
+  it("should return false when detected browser is not in supported list", () => {
+    Object.defineProperty(global, "navigator", {
+      value: {
+        userAgent:
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    const supportedBrowsers: Array<Browser> = ["firefox", "safari"];
+    const result = isCurrentBrowserSupported(supportedBrowsers);
+
+    expect(result).toBe(false);
+  });
+});

--- a/packages/core/src/lib/helpers/getActiveAccount.spec.ts
+++ b/packages/core/src/lib/helpers/getActiveAccount.spec.ts
@@ -1,0 +1,121 @@
+import { getActiveAccount } from "./getActiveAccount";
+import type { WalletSelectorState } from "../store.types";
+
+describe("getActiveAccount", () => {
+  it("should return the active account when one exists", () => {
+    const state: WalletSelectorState = {
+      contract: null,
+      modules: [],
+      accounts: [
+        {
+          accountId: "alice.near",
+          active: false,
+        },
+        {
+          accountId: "bob.near",
+          active: true,
+        },
+        {
+          accountId: "charlie.near",
+          active: false,
+        },
+      ],
+      selectedWalletId: "wallet-2",
+      recentlySignedInWallets: [],
+      rememberRecentWallets: "true",
+    };
+
+    const result = getActiveAccount(state);
+
+    expect(result).toEqual({
+      accountId: "bob.near",
+      active: true,
+    });
+    expect(result?.accountId).toBe("bob.near");
+  });
+
+  it("should return null when no active account exists", () => {
+    const state: WalletSelectorState = {
+      contract: null,
+      modules: [],
+      accounts: [
+        {
+          accountId: "alice.near",
+          active: false,
+        },
+        {
+          accountId: "bob.near",
+          active: false,
+        },
+      ],
+      selectedWalletId: null,
+      recentlySignedInWallets: [],
+      rememberRecentWallets: "true",
+    };
+
+    const result = getActiveAccount(state);
+
+    expect(result).toBeNull();
+  });
+
+  it("should return null when accounts array is empty", () => {
+    const state: WalletSelectorState = {
+      contract: null,
+      modules: [],
+      accounts: [],
+      selectedWalletId: null,
+      recentlySignedInWallets: [],
+      rememberRecentWallets: "true",
+    };
+
+    const result = getActiveAccount(state);
+
+    expect(result).toBeNull();
+  });
+
+  it("should return the account when only one account exists and it is active", () => {
+    const state: WalletSelectorState = {
+      contract: null,
+      modules: [],
+      accounts: [
+        {
+          accountId: "single.near",
+          active: true,
+        },
+      ],
+      selectedWalletId: "wallet-1",
+      recentlySignedInWallets: [],
+      rememberRecentWallets: "true",
+    };
+
+    const result = getActiveAccount(state);
+
+    expect(result).not.toBeNull();
+    expect(result?.accountId).toBe("single.near");
+    expect(result?.active).toBe(true);
+  });
+
+  it("should return the first active account when multiple active accounts exist", () => {
+    const state: WalletSelectorState = {
+      contract: null,
+      modules: [],
+      accounts: [
+        {
+          accountId: "first.near",
+          active: true,
+        },
+        {
+          accountId: "second.near",
+          active: true,
+        },
+      ],
+      selectedWalletId: "wallet-1",
+      recentlySignedInWallets: [],
+      rememberRecentWallets: "true",
+    };
+
+    const result = getActiveAccount(state);
+
+    expect(result?.accountId).toBe("first.near");
+  });
+});

--- a/packages/core/src/lib/helpers/waitFor.spec.ts
+++ b/packages/core/src/lib/helpers/waitFor.spec.ts
@@ -1,0 +1,104 @@
+import { waitFor } from "./waitFor";
+
+describe("waitFor", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("should resolve when condition becomes true", async () => {
+    let conditionMet = false;
+
+    const promise = waitFor(() => conditionMet, {
+      timeout: 1000,
+      interval: 100,
+    });
+
+    jest.advanceTimersByTime(100);
+    conditionMet = true;
+    jest.advanceTimersByTime(100);
+
+    await expect(promise).resolves.toBe(true);
+  });
+
+  it("should throw error when timeout is exceeded", async () => {
+    const conditionMet = false;
+
+    const promise = waitFor(() => conditionMet, {
+      timeout: 200,
+      interval: 50,
+    });
+
+    jest.advanceTimersByTime(250);
+
+    await expect(promise).rejects.toThrow("Exceeded timeout");
+  });
+
+  it("should use custom timeout and interval options", async () => {
+    let conditionMet = false;
+
+    const promise = waitFor(() => conditionMet, {
+      timeout: 500,
+      interval: 200,
+    });
+
+    jest.advanceTimersByTime(200);
+    conditionMet = true;
+    jest.advanceTimersByTime(200);
+
+    await expect(promise).resolves.toBe(true);
+  });
+
+  it("should use default timeout and interval when options not provided", async () => {
+    let conditionMet = false;
+
+    const promise = waitFor(() => conditionMet);
+
+    conditionMet = true;
+    jest.advanceTimersByTime(50);
+
+    await expect(promise).resolves.toBe(true);
+  });
+
+  it("should resolve immediately when condition is already true", async () => {
+    const conditionMet = true;
+
+    const promise = waitFor(() => conditionMet, {
+      timeout: 1000,
+      interval: 100,
+    });
+
+    jest.advanceTimersByTime(10);
+
+    await expect(promise).resolves.toBe(true);
+  });
+
+  it("should poll condition multiple times at specified interval", async () => {
+    let checkCount = 0;
+    let conditionMet = false;
+
+    const promise = waitFor(
+      () => {
+        checkCount++;
+        return conditionMet;
+      },
+      {
+        timeout: 1000,
+        interval: 100,
+      }
+    );
+
+    jest.advanceTimersByTime(100);
+    expect(checkCount).toBeGreaterThan(0);
+
+    jest.advanceTimersByTime(100);
+    conditionMet = true;
+    jest.advanceTimersByTime(100);
+
+    await expect(promise).resolves.toBe(true);
+    expect(checkCount).toBeGreaterThan(1);
+  });
+});

--- a/packages/core/src/lib/services/storage/json-storage.service.spec.ts
+++ b/packages/core/src/lib/services/storage/json-storage.service.spec.ts
@@ -1,0 +1,173 @@
+import { JsonStorage } from "./json-storage.service";
+import type { StorageService } from "./storage.service.types";
+
+describe("JsonStorage", () => {
+  let mockStorage: jest.Mocked<StorageService>;
+  let jsonStorage: JsonStorage;
+
+  beforeEach(() => {
+    mockStorage = {
+      getItem: jest.fn(),
+      setItem: jest.fn(),
+      removeItem: jest.fn(),
+    };
+  });
+
+  describe("constructor", () => {
+    it("should create instance with string namespace", () => {
+      jsonStorage = new JsonStorage(mockStorage, "my-namespace");
+      expect(jsonStorage).toBeInstanceOf(JsonStorage);
+    });
+
+    it("should create instance with array namespace", () => {
+      jsonStorage = new JsonStorage(mockStorage, ["level1", "level2"]);
+      expect(jsonStorage).toBeInstanceOf(JsonStorage);
+    });
+  });
+
+  describe("getItem", () => {
+    beforeEach(() => {
+      jsonStorage = new JsonStorage(mockStorage, "test-namespace");
+    });
+
+    it("should get and parse JSON item correctly", async () => {
+      const testData = { name: "test", value: 123 };
+      mockStorage.getItem.mockResolvedValue(JSON.stringify(testData));
+
+      const result = await jsonStorage.getItem<typeof testData>("my-key");
+
+      expect(result).toEqual(testData);
+      expect(mockStorage.getItem).toHaveBeenCalledWith("test-namespace:my-key");
+    });
+
+    it("should return null when item does not exist", async () => {
+      mockStorage.getItem.mockResolvedValue(null);
+
+      const result = await jsonStorage.getItem("non-existent");
+
+      expect(result).toBeNull();
+      expect(mockStorage.getItem).toHaveBeenCalledWith(
+        "test-namespace:non-existent"
+      );
+    });
+
+    it("should handle namespace prefixing correctly", async () => {
+      mockStorage.getItem.mockResolvedValue('{"test": true}');
+
+      await jsonStorage.getItem("my-key");
+
+      expect(mockStorage.getItem).toHaveBeenCalledWith("test-namespace:my-key");
+    });
+
+    it("should handle array namespace correctly", async () => {
+      jsonStorage = new JsonStorage(mockStorage, ["level1", "level2"]);
+      mockStorage.getItem.mockResolvedValue('{"test": true}');
+
+      await jsonStorage.getItem("my-key");
+
+      expect(mockStorage.getItem).toHaveBeenCalledWith("level1:level2:my-key");
+    });
+  });
+
+  describe("setItem", () => {
+    beforeEach(() => {
+      jsonStorage = new JsonStorage(mockStorage, "test-namespace");
+    });
+
+    it("should set item with JSON serialization", async () => {
+      const testData = { name: "test", value: 123, nested: { key: "value" } };
+
+      await jsonStorage.setItem("my-key", testData);
+
+      expect(mockStorage.setItem).toHaveBeenCalledWith(
+        "test-namespace:my-key",
+        JSON.stringify(testData)
+      );
+    });
+
+    it("should handle different data types", async () => {
+      await jsonStorage.setItem("string-key", "test-string");
+      expect(mockStorage.setItem).toHaveBeenCalledWith(
+        "test-namespace:string-key",
+        JSON.stringify("test-string")
+      );
+
+      await jsonStorage.setItem("number-key", 42);
+      expect(mockStorage.setItem).toHaveBeenCalledWith(
+        "test-namespace:number-key",
+        JSON.stringify(42)
+      );
+
+      await jsonStorage.setItem("array-key", [1, 2, 3]);
+      expect(mockStorage.setItem).toHaveBeenCalledWith(
+        "test-namespace:array-key",
+        JSON.stringify([1, 2, 3])
+      );
+    });
+
+    it("should handle namespace prefixing", async () => {
+      const testData = { value: "test" };
+
+      await jsonStorage.setItem("my-key", testData);
+
+      expect(mockStorage.setItem).toHaveBeenCalledWith(
+        "test-namespace:my-key",
+        JSON.stringify(testData)
+      );
+    });
+  });
+
+  describe("removeItem", () => {
+    beforeEach(() => {
+      jsonStorage = new JsonStorage(mockStorage, "test-namespace");
+    });
+
+    it("should remove item correctly", async () => {
+      mockStorage.removeItem.mockResolvedValue();
+
+      await jsonStorage.removeItem("my-key");
+
+      expect(mockStorage.removeItem).toHaveBeenCalledWith(
+        "test-namespace:my-key"
+      );
+    });
+
+    it("should handle namespace prefixing", async () => {
+      await jsonStorage.removeItem("my-key");
+
+      expect(mockStorage.removeItem).toHaveBeenCalledWith(
+        "test-namespace:my-key"
+      );
+    });
+
+    it("should handle array namespace correctly", async () => {
+      jsonStorage = new JsonStorage(mockStorage, ["level1", "level2"]);
+
+      await jsonStorage.removeItem("my-key");
+
+      expect(mockStorage.removeItem).toHaveBeenCalledWith(
+        "level1:level2:my-key"
+      );
+    });
+  });
+
+  describe("namespace handling", () => {
+    it("should use colon as delimiter", () => {
+      jsonStorage = new JsonStorage(mockStorage, ["a", "b", "c"]);
+      mockStorage.getItem.mockResolvedValue('{"test": true}');
+
+      jsonStorage.getItem("key");
+
+      expect(mockStorage.getItem).toHaveBeenCalledWith("a:b:c:key");
+    });
+
+    it("should handle single string namespace", () => {
+      jsonStorage = new JsonStorage(mockStorage, "single-namespace");
+      mockStorage.getItem.mockResolvedValue('{"test": true}');
+
+      jsonStorage.getItem("key");
+
+      expect(mockStorage.getItem).toHaveBeenCalledWith("single-namespace:key");
+    });
+  });
+});

--- a/packages/core/src/lib/services/storage/web-storage.service.spec.ts
+++ b/packages/core/src/lib/services/storage/web-storage.service.spec.ts
@@ -1,0 +1,135 @@
+import { WebStorageService } from "./web-storage.service";
+
+describe("WebStorageService", () => {
+  let storageService: WebStorageService;
+  let mockLocalStorage: Storage;
+
+  beforeEach(() => {
+    mockLocalStorage = {
+      getItem: jest.fn(),
+      setItem: jest.fn(),
+      removeItem: jest.fn(),
+      clear: jest.fn(),
+      length: 0,
+      key: jest.fn(),
+    };
+
+    Object.defineProperty(global, "localStorage", {
+      value: mockLocalStorage,
+      writable: true,
+      configurable: true,
+    });
+
+    storageService = new WebStorageService();
+  });
+
+  afterEach(() => {
+    // @ts-expect-error - Removing for cleanup
+    delete global.localStorage;
+  });
+
+  describe("getItem", () => {
+    it("should get item from localStorage", async () => {
+      (mockLocalStorage.getItem as jest.Mock).mockReturnValue("test-value");
+
+      const result = await storageService.getItem("test-key");
+
+      expect(result).toBe("test-value");
+      expect(mockLocalStorage.getItem).toHaveBeenCalledWith("test-key");
+    });
+
+    it("should return null when item does not exist", async () => {
+      (mockLocalStorage.getItem as jest.Mock).mockReturnValue(null);
+
+      const result = await storageService.getItem("non-existent");
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null when localStorage is undefined (server-side)", async () => {
+      // @ts-expect-error - Intentionally removing for test
+      delete global.localStorage;
+
+      storageService = new WebStorageService();
+
+      const result = await storageService.getItem("test-key");
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("setItem", () => {
+    it("should set item to localStorage", async () => {
+      await storageService.setItem("test-key", "test-value");
+
+      expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
+        "test-key",
+        "test-value"
+      );
+    });
+
+    it("should handle different value types", async () => {
+      await storageService.setItem("string-key", "value");
+      expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
+        "string-key",
+        "value"
+      );
+
+      await storageService.setItem("number-key", "123");
+      expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
+        "number-key",
+        "123"
+      );
+    });
+
+    it("should not throw error when localStorage is undefined (server-side)", async () => {
+      // @ts-expect-error - Intentionally removing for test
+      delete global.localStorage;
+
+      storageService = new WebStorageService();
+
+      await expect(
+        storageService.setItem("test-key", "test-value")
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe("removeItem", () => {
+    it("should remove item from localStorage", async () => {
+      await storageService.removeItem("test-key");
+
+      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith("test-key");
+    });
+
+    it("should not throw error when localStorage is undefined (server-side)", async () => {
+      // @ts-expect-error - Intentionally removing for test
+      delete global.localStorage;
+
+      storageService = new WebStorageService();
+
+      await expect(
+        storageService.removeItem("test-key")
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe("async behavior", () => {
+    it("should return promises that resolve correctly", async () => {
+      (mockLocalStorage.getItem as jest.Mock).mockReturnValue("async-value");
+
+      const promise = storageService.getItem("test-key");
+
+      expect(promise).toBeInstanceOf(Promise);
+      const result = await promise;
+      expect(result).toBe("async-value");
+    });
+
+    it("should handle async setItem correctly", async () => {
+      const promise = storageService.setItem("test-key", "test-value");
+
+      expect(promise).toBeInstanceOf(Promise);
+      await promise;
+      expect(mockLocalStorage.setItem).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/core/src/lib/translate/translate.spec.ts
+++ b/packages/core/src/lib/translate/translate.spec.ts
@@ -1,0 +1,206 @@
+/* eslint-disable @typescript-eslint/no-explicit-any*/
+import { translate, allowOnlyLanguage } from "./translate";
+
+describe("translate", () => {
+  const originalWindow = global.window;
+
+  beforeEach(() => {
+    allowOnlyLanguage(undefined);
+  });
+
+  afterEach(() => {
+    if (originalWindow) {
+      global.window = originalWindow;
+    } else {
+      // @ts-expect-error - Intentionally removing for cleanup
+      delete global.window;
+    }
+  });
+
+  describe("default behavior", () => {
+    it("should return English text by default", () => {
+      global.window = {
+        navigator: {
+          language: "en",
+          languages: ["en"],
+        },
+      } as any;
+
+      const result = translate("modal.wallet.connectYourWallet");
+
+      expect(result).toBe("Connect Your Wallet");
+    });
+
+    it("should return key when translation is missing", () => {
+      global.window = {
+        navigator: {
+          language: "en",
+          languages: ["en"],
+        },
+      } as any;
+
+      const result = translate("non.existent.key");
+
+      expect(result).toBe("non.existent.key");
+    });
+  });
+
+  describe("language detection", () => {
+    it("should return Spanish translation for Spanish browser", () => {
+      global.window = {
+        navigator: {
+          language: "es",
+          languages: ["es"],
+        },
+      } as any;
+
+      const result = translate("modal.wallet.connectYourWallet");
+
+      expect(result).toBe("Conecta Tu Billetera");
+    });
+
+    it("should use navigator.languages[0] when available", () => {
+      global.window = {
+        navigator: {
+          language: "en",
+          languages: ["es", "en"],
+        },
+      } as any;
+
+      const result = translate("modal.wallet.connectYourWallet");
+
+      expect(result).toBe("Conecta Tu Billetera");
+    });
+
+    it("should fallback to navigator.language when languages array is empty", () => {
+      global.window = {
+        navigator: {
+          language: "es",
+          languages: [],
+        },
+      } as any;
+
+      const result = translate("modal.wallet.connectYourWallet");
+
+      expect(result).toBe("Conecta Tu Billetera");
+    });
+  });
+
+  describe("language code shortening", () => {
+    it("should shorten language code with hyphen (en-US -> en)", () => {
+      global.window = {
+        navigator: {
+          language: "en-US",
+          languages: ["en-US"],
+        },
+      } as any;
+
+      const result = translate("modal.wallet.connectYourWallet");
+
+      expect(result).toBe("Connect Your Wallet");
+    });
+
+    it("should shorten language code with underscore (en_GB -> en)", () => {
+      global.window = {
+        navigator: {
+          language: "en_GB",
+          languages: ["en_GB"],
+        },
+      } as any;
+
+      const result = translate("modal.wallet.connectYourWallet");
+
+      expect(result).toBe("Connect Your Wallet");
+    });
+  });
+
+  describe("allowOnlyLanguage override", () => {
+    it("should use allowOnlyLanguage override instead of browser language", () => {
+      allowOnlyLanguage("es");
+
+      global.window = {
+        navigator: {
+          language: "en",
+          languages: ["en"],
+        },
+      } as any;
+
+      const result = translate("modal.wallet.connectYourWallet");
+
+      expect(result).toBe("Conecta Tu Billetera");
+    });
+
+    it("should use browser language when allowOnlyLanguage is undefined", () => {
+      allowOnlyLanguage(undefined);
+
+      global.window = {
+        navigator: {
+          language: "es",
+          languages: ["es"],
+        },
+      } as any;
+
+      const result = translate("modal.wallet.connectYourWallet");
+
+      expect(result).toBe("Conecta Tu Billetera");
+    });
+
+    it("should shorten override language code correctly", () => {
+      allowOnlyLanguage("es");
+
+      global.window = {
+        navigator: {
+          language: "en",
+          languages: ["en"],
+        },
+      } as any;
+
+      const result = translate("modal.wallet.connectYourWallet");
+
+      expect(result).toBe("Conecta Tu Billetera");
+    });
+  });
+
+  describe("nested object paths", () => {
+    it("should handle nested object paths correctly", () => {
+      global.window = {
+        navigator: {
+          language: "en",
+          languages: ["en"],
+        },
+      } as any;
+
+      const result = translate("modal.wallet.connectingMessage.injected");
+
+      expect(result).toBe("Confirm the connection in the extension window");
+    });
+
+    it("should return key when nested path is invalid", () => {
+      global.window = {
+        navigator: {
+          language: "en",
+          languages: ["en"],
+        },
+      } as any;
+
+      const result = translate("modal.wallet.invalid.path");
+
+      expect(result).toBe("modal.wallet.invalid.path");
+    });
+  });
+
+  describe("unsupported languages", () => {
+    it("should fallback to English for unsupported language", () => {
+      global.window = {
+        navigator: {
+          language: "fr-FR",
+          languages: ["fr-FR"],
+        },
+      } as any;
+
+      const result = translate("modal.wallet.connectYourWallet");
+
+      expect(result).toBe("Connect Your Wallet");
+    });
+  });
+});


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to NEAR JavaScript API here: https://github.com/near/wallet-selector/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/near/wallet-selector/blob/main/CONTRIBUTING.md).
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [x] **If this is a code change**: I have written unit tests.
- [ ] **If this changes code in a published package**: I have run `pnpm changeset` to create a `changeset` JSON document appropriate for this change.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

This PR adds comprehensive unit test coverage for 6 core modules in the `@near-wallet-selector/core` package


## Test Files Added

- `lib/translate/translate.spec.ts` - Translation functionality with language detection
- `lib/helpers/waitFor.spec.ts` - Async polling utility with timeout/interval handling
- `lib/helpers/detect-browser.spec.ts` - Browser detection (Chrome, Firefox, Safari, Edge)
- `lib/helpers/getActiveAccount.spec.ts` - Active account retrieval from state
- `lib/services/storage/web-storage.service.spec.ts` - WebStorageService operations
- `lib/services/storage/json-storage.service.spec.ts` - JsonStorage with namespace support


## Impact

- Improves code reliability and maintainability
- Provides safety net for future refactoring
- Documents expected behavior through test cases
- Increases overall test coverage for the core package
