### PR TITLE
test: add unit tests for wallet packages

### DIFF
--- a/packages/hot-wallet/src/lib/hot-wallet.spec.ts
+++ b/packages/hot-wallet/src/lib/hot-wallet.spec.ts
@@ -1,0 +1,260 @@
+/* eslint-disable @nx/enforce-module-boundaries */
+import { mockWallet } from "../../../core/src/lib/testUtils";
+import type { MockWalletDependencies } from "../../../core/src/lib/testUtils";
+import type { InjectedWallet } from "@near-wallet-selector/core";
+import { setupHotWallet } from "./index";
+
+// Mock the HOT SDK
+jest.mock("@hot-wallet/sdk", () => {
+  const mockHOT = {
+    isInjected: true,
+    request: jest.fn(),
+    subscribe: jest.fn(),
+  };
+  return {
+    HOT: mockHOT,
+    verifySignature: jest.fn().mockReturnValue(true),
+  };
+});
+
+import { HOT, verifySignature } from "@hot-wallet/sdk";
+
+const accountId = "test-account.testnet";
+const publicKey = "ed25519:GF7tLvSzcxX4EtrMFtGvGTb2yUj2DhL8hWzc97BwUkyC";
+
+const createHotWallet = async (deps: MockWalletDependencies = {}) => {
+  const { wallet, storage } = await mockWallet<InjectedWallet>(
+    setupHotWallet(),
+    deps
+  );
+
+  return {
+    wallet,
+    storage,
+  };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (HOT as any).isInjected = true;
+  (HOT.request as jest.Mock).mockClear();
+  (HOT.subscribe as jest.Mock).mockClear();
+  (verifySignature as jest.Mock).mockReturnValue(true);
+});
+
+afterEach(() => {
+  jest.resetModules();
+});
+
+describe("Hot Wallet - Core Functionality", () => {
+  describe("signIn", () => {
+    it("should successfully sign in", async () => {
+      (HOT.request as jest.Mock).mockResolvedValue({
+        accountId,
+        publicKey,
+      });
+
+      const { wallet, storage } = await createHotWallet();
+
+      const accounts = await wallet.signIn({ contractId: "test.testnet" });
+
+      expect(HOT.request).toHaveBeenCalledWith("near:signIn", {});
+      expect(accounts).toEqual([{ accountId, publicKey }]);
+      
+      // Verify storage was updated (key is prefixed and value is stringified by storage service)
+      expect(storage.setItem).toHaveBeenCalledWith(
+        expect.stringContaining("hot:near-account"),
+        expect.any(String)
+      );
+    });
+  });
+
+  describe("signOut", () => {
+    it("should successfully sign out when HOT is injected", async () => {
+      (HOT as any).isInjected = true;
+      (HOT.request as jest.Mock).mockResolvedValue(undefined);
+
+      const { wallet, storage } = await createHotWallet();
+
+      await wallet.signOut();
+
+      expect(HOT.request).toHaveBeenCalledWith("near:signOut", {});
+      // Verify storage was cleared (value is JSON stringified by storage service)
+      expect(storage.setItem).toHaveBeenCalledWith(
+        expect.stringContaining("hot:near-account"),
+        expect.any(String)
+      );
+    });
+
+    it("should sign out without calling HOT.request when not injected", async () => {
+      (HOT as any).isInjected = false;
+
+      const { wallet, storage } = await createHotWallet();
+
+      await wallet.signOut();
+
+      expect(HOT.request).not.toHaveBeenCalled();
+      // Verify storage.setItem was called (the exact key may be prefixed)
+      expect(storage.setItem).toHaveBeenCalled();
+    });
+  });
+
+  describe("getAccounts", () => {
+    it("should return account from HOT.request when injected", async () => {
+      (HOT as any).isInjected = true;
+      (HOT.request as jest.Mock).mockResolvedValue({
+        accountId,
+        publicKey,
+      });
+
+      const { wallet } = await createHotWallet();
+
+      const accounts = await wallet.getAccounts();
+
+      expect(HOT.request).toHaveBeenCalledWith("near:signIn", {});
+      expect(accounts).toEqual([{ accountId, publicKey }]);
+    });
+
+    it("should return account from HOT.request when injected", async () => {
+      (HOT as any).isInjected = true;
+      (HOT.request as jest.Mock).mockResolvedValue({
+        accountId,
+        publicKey,
+      });
+
+      const { wallet } = await createHotWallet();
+
+      const accounts = await wallet.getAccounts();
+
+      expect(HOT.request).toHaveBeenCalledWith("near:signIn", {});
+      expect(accounts).toEqual([{ accountId, publicKey }]);
+    });
+  });
+
+  describe("signMessage", () => {
+    it("should successfully sign message", async () => {
+      const mockSignature = {
+        signature: "ed25519:testSignature",
+        publicKey,
+        accountId,
+      };
+
+      (HOT.request as jest.Mock).mockResolvedValue(mockSignature);
+
+      const { wallet } = await createHotWallet();
+
+      const nonce = Buffer.alloc(32);
+      const result = await wallet.signMessage!({
+        message: "test message",
+        nonce: nonce,
+        recipient: "test.app",
+      });
+
+      expect(HOT.request).toHaveBeenCalledWith("near:signMessage", {
+        message: "test message",
+        nonce: Array.from(new Uint8Array(nonce)),
+        recipient: "test.app",
+      });
+      expect(verifySignature).toHaveBeenCalled();
+      expect(result).toEqual(mockSignature);
+    });
+
+    it("should throw error when signature is invalid", async () => {
+      const mockSignature = {
+        signature: "ed25519:invalidSignature",
+        publicKey,
+        accountId,
+      };
+
+      (HOT.request as jest.Mock).mockResolvedValue(mockSignature);
+      (verifySignature as jest.Mock).mockReturnValue(false);
+
+      const { wallet } = await createHotWallet();
+
+      const nonce = Buffer.alloc(32);
+      await expect(
+        wallet.signMessage!({
+          message: "test message",
+          nonce: nonce,
+          recipient: "test.app",
+        })
+      ).rejects.toEqual("Signature invalid");
+    });
+  });
+
+  describe("signAndSendTransaction", () => {
+    it("should successfully sign and send transaction", async () => {
+      const mockTransaction = {
+        transaction: { hash: "testHash" },
+      };
+
+      (HOT.request as jest.Mock).mockResolvedValue({
+        transactions: [mockTransaction],
+      });
+
+      const { wallet } = await createHotWallet();
+
+      const result = await wallet.signAndSendTransaction({
+        signerId: accountId,
+        receiverId: "test.testnet",
+        actions: [],
+      });
+
+      expect(HOT.request).toHaveBeenCalledWith(
+        "near:signAndSendTransactions",
+        expect.objectContaining({
+          transactions: expect.arrayContaining([
+            expect.objectContaining({
+              signerId: accountId,
+              receiverId: "test.testnet",
+            }),
+          ]),
+        })
+      );
+      expect(result).toEqual(mockTransaction);
+    });
+  });
+
+  describe("signAndSendTransactions", () => {
+    it("should successfully sign and send multiple transactions", async () => {
+      const mockTransactions = [
+        { transaction: { hash: "hash1" } },
+        { transaction: { hash: "hash2" } },
+      ];
+
+      (HOT.request as jest.Mock).mockResolvedValue({
+        transactions: mockTransactions,
+      });
+
+      const { wallet } = await createHotWallet();
+
+      const transactions = [
+        {
+          signerId: accountId,
+          receiverId: "test.testnet",
+          actions: [],
+        },
+        {
+          signerId: accountId,
+          receiverId: "test2.testnet",
+          actions: [],
+        },
+      ];
+
+      const result = await wallet.signAndSendTransactions({ transactions });
+
+      expect(HOT.request).toHaveBeenCalledWith(
+        "near:signAndSendTransactions",
+        expect.arrayContaining([
+          expect.objectContaining({
+            signerId: accountId,
+            receiverId: "test.testnet",
+            actions: expect.any(Array),
+          }),
+        ])
+      );
+      expect(result).toEqual(mockTransactions);
+    });
+  });
+});
+

--- a/packages/hot-wallet/src/lib/hot-wallet.spec.ts
+++ b/packages/hot-wallet/src/lib/hot-wallet.spec.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @nx/enforce-module-boundaries */
+/* eslint-disable @nx/enforce-module-boundaries, @typescript-eslint/no-explicit-any */
 import { mockWallet } from "../../../core/src/lib/testUtils";
 import type { MockWalletDependencies } from "../../../core/src/lib/testUtils";
 import type { InjectedWallet } from "@near-wallet-selector/core";
@@ -60,7 +60,7 @@ describe("Hot Wallet - Core Functionality", () => {
 
       expect(HOT.request).toHaveBeenCalledWith("near:signIn", {});
       expect(accounts).toEqual([{ accountId, publicKey }]);
-      
+
       // Verify storage was updated (key is prefixed and value is stringified by storage service)
       expect(storage.setItem).toHaveBeenCalledWith(
         expect.stringContaining("hot:near-account"),
@@ -257,4 +257,3 @@ describe("Hot Wallet - Core Functionality", () => {
     });
   });
 });
-

--- a/packages/webauthn-wallet/.babelrc
+++ b/packages/webauthn-wallet/.babelrc
@@ -1,0 +1,12 @@
+{
+  "presets": [
+    [
+      "@nrwl/js/babel",
+      {
+        "useBuiltIns": "usage"
+      }
+    ]
+  ],
+  "plugins": []
+}
+

--- a/packages/webauthn-wallet/jest.config.ts
+++ b/packages/webauthn-wallet/jest.config.ts
@@ -13,6 +13,7 @@ export default {
   },
   moduleFileExtensions: ["ts", "tsx", "js", "jsx"],
   coverageDirectory: "../../coverage/packages/webauthn-wallet",
+  setupFiles: ["<rootDir>/jest.setup.ts"],
 };
 
 

--- a/packages/webauthn-wallet/jest.setup.ts
+++ b/packages/webauthn-wallet/jest.setup.ts
@@ -1,0 +1,9 @@
+// Setup file for webauthn-wallet tests
+// This runs before the test environment is initialized
+import { TextEncoder, TextDecoder } from "util";
+
+// Polyfill TextEncoder/TextDecoder for Node.js environment
+// @ts-ignore
+global.TextEncoder = TextEncoder;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(global as any).TextDecoder = TextDecoder;

--- a/packages/webauthn-wallet/src/lib/utils.spec.ts
+++ b/packages/webauthn-wallet/src/lib/utils.spec.ts
@@ -1,0 +1,47 @@
+import {
+  generateAccountId,
+  isValidAccountId,
+  formatNearAmount,
+  WebAuthnWalletError,
+  ERROR_CODES,
+} from "./utils";
+
+describe("utils", () => {
+  describe("generateAccountId", () => {
+    it("should generate account ID with testnet suffix", () => {
+      const accountId = generateAccountId("testnet");
+
+      expect(accountId).toMatch(/^[a-z]+-[a-z]+-\d+\.testnet$/);
+    });
+
+    it("should generate account ID with mainnet suffix", () => {
+      const accountId = generateAccountId("mainnet");
+
+      expect(accountId).toMatch(/^[a-z]+-[a-z]+-\d+\.near$/);
+    });
+  });
+
+  describe("isValidAccountId", () => {
+    it("should validate correct testnet account IDs", () => {
+      expect(isValidAccountId("test-account.testnet")).toBe(true);
+      expect(isValidAccountId("happy-wallet-123.testnet")).toBe(true);
+      expect(isValidAccountId("user_name.testnet")).toBe(true);
+      expect(isValidAccountId("abc-123.testnet")).toBe(true);
+    });
+
+    it("should validate correct mainnet account IDs", () => {
+      expect(isValidAccountId("test-account.near")).toBe(true);
+      expect(isValidAccountId("happy-wallet-123.near")).toBe(true);
+      expect(isValidAccountId("user_name.near")).toBe(true);
+    });
+
+    it("should reject invalid account IDs", () => {
+      expect(isValidAccountId("invalid")).toBe(false);
+      expect(isValidAccountId("UPPERCASE.testnet")).toBe(false);
+      expect(isValidAccountId("no-suffix")).toBe(false);
+      expect(isValidAccountId("space name.testnet")).toBe(false);
+      expect(isValidAccountId(".testnet")).toBe(false);
+      expect(isValidAccountId("")).toBe(false);
+    });
+  });
+});

--- a/packages/webauthn-wallet/src/lib/utils.spec.ts
+++ b/packages/webauthn-wallet/src/lib/utils.spec.ts
@@ -1,10 +1,4 @@
-import {
-  generateAccountId,
-  isValidAccountId,
-  formatNearAmount,
-  WebAuthnWalletError,
-  ERROR_CODES,
-} from "./utils";
+import { generateAccountId, isValidAccountId } from "./utils";
 
 describe("utils", () => {
   describe("generateAccountId", () => {

--- a/packages/webauthn-wallet/src/lib/webauthn-utils.spec.ts
+++ b/packages/webauthn-wallet/src/lib/webauthn-utils.spec.ts
@@ -1,0 +1,317 @@
+/* eslint-disable @typescript-eslint/no-explicit-any*/
+import {
+  createKey,
+  getKeys,
+  isPassKeyAvailable,
+  isDeviceSupported,
+  PasskeyProcessCanceled,
+} from "./webauthn-utils";
+
+// Mock the crypto API
+const mockCredential = {
+  rawId: new Uint8Array(32).buffer,
+  id: "test-credential-id",
+  type: "public-key",
+  response: {
+    userHandle: new TextEncoder().encode("test-user.testnet"),
+    authenticatorData: new ArrayBuffer(0),
+    signature: new ArrayBuffer(0),
+    clientDataJSON: new ArrayBuffer(0),
+  } as unknown as AuthenticatorAssertionResponse,
+};
+
+describe("webauthn-utils", () => {
+  beforeAll(() => {
+    // Mock crypto.subtle.digest
+    if (!global.crypto) {
+      (global as any).crypto = {};
+    }
+    if (!global.crypto.subtle) {
+      (global.crypto as any).subtle = {};
+    }
+    (global.crypto.subtle as any).digest = jest
+      .fn()
+      .mockResolvedValue(new Uint8Array(32).buffer);
+
+    // Mock crypto.getRandomValues
+    global.crypto.getRandomValues = jest.fn((arr: any) => {
+      if (arr && "length" in arr) {
+        for (let i = 0; i < arr.length; i++) {
+          arr[i] = Math.floor(Math.random() * 256);
+        }
+      }
+      return arr;
+    }) as any;
+  });
+
+  describe("PasskeyProcessCanceled", () => {
+    it("should create custom error", () => {
+      const error = new PasskeyProcessCanceled("User cancelled");
+
+      expect(error.name).toBe("PasskeyProcessCanceled");
+      expect(error.message).toBe("User cancelled");
+      expect(error instanceof Error).toBe(true);
+    });
+  });
+
+  describe("isPassKeyAvailable", () => {
+    it("should return false when PublicKeyCredential is not available", async () => {
+      // Save original
+      const original = (global as any).PublicKeyCredential;
+      delete (global as any).PublicKeyCredential;
+
+      const result = await isPassKeyAvailable();
+
+      expect(result).toBe(false);
+
+      // Restore
+      (global as any).PublicKeyCredential = original;
+    });
+
+    it("should return true when PublicKeyCredential is available", async () => {
+      // Mock PublicKeyCredential
+      (global as any).PublicKeyCredential = {
+        isUserVerifyingPlatformAuthenticatorAvailable: jest
+          .fn()
+          .mockResolvedValue(true),
+      };
+
+      const result = await isPassKeyAvailable();
+
+      expect(result).toBe(true);
+    });
+
+    it("should return false when isUserVerifyingPlatformAuthenticatorAvailable is not available", async () => {
+      (global as any).PublicKeyCredential = {};
+
+      const result = await isPassKeyAvailable();
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("isDeviceSupported", () => {
+    it("should return true when passkey is available", async () => {
+      (global as any).PublicKeyCredential = {
+        isUserVerifyingPlatformAuthenticatorAvailable: jest
+          .fn()
+          .mockResolvedValue(true),
+      };
+
+      const result = await isDeviceSupported();
+
+      expect(result).toBe(true);
+    });
+
+    it("should return false when passkey is not available", async () => {
+      const original = (global as any).PublicKeyCredential;
+      delete (global as any).PublicKeyCredential;
+
+      const result = await isDeviceSupported();
+
+      expect(result).toBe(false);
+
+      // Restore
+      (global as any).PublicKeyCredential = original;
+    });
+
+    it("should return false when error occurs", async () => {
+      (global as any).PublicKeyCredential = {
+        isUserVerifyingPlatformAuthenticatorAvailable: jest
+          .fn()
+          .mockRejectedValue(new Error("Test error")),
+      };
+
+      const result = await isDeviceSupported();
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("createKey", () => {
+    beforeEach(() => {
+      // Mock window.location
+      Object.defineProperty(window, "location", {
+        value: { hostname: "localhost" },
+        writable: true,
+      });
+    });
+
+    it("should throw error when WebAuthn is not supported", async () => {
+      // Mock navigator without credentials
+      const originalNavigator = global.navigator;
+      Object.defineProperty(global, "navigator", {
+        value: {},
+        writable: true,
+        configurable: true,
+      });
+
+      await expect(createKey("test-user.testnet")).rejects.toThrow(
+        "WebAuthn is not supported in this browser"
+      );
+
+      // Restore
+      Object.defineProperty(global, "navigator", {
+        value: originalNavigator,
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    it("should create keypair when credential is created successfully", async () => {
+      // Mock navigator.credentials
+      Object.defineProperty(global.navigator, "credentials", {
+        value: {
+          create: jest.fn().mockResolvedValue(mockCredential),
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      // Mock crypto.getRandomValues
+      global.crypto.getRandomValues = jest.fn((arr) => arr);
+
+      const keyPair = await createKey("test-user.testnet");
+
+      expect(keyPair).toBeDefined();
+      expect(keyPair.getPublicKey()).toBeDefined();
+      expect(typeof keyPair.getPublicKey().toString()).toBe("string");
+    });
+
+    it("should throw PasskeyProcessCanceled when user cancels", async () => {
+      const notAllowedError = new Error("User cancelled");
+      notAllowedError.name = "NotAllowedError";
+
+      Object.defineProperty(global.navigator, "credentials", {
+        value: {
+          create: jest.fn().mockRejectedValue(notAllowedError),
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      await expect(createKey("test-user.testnet")).rejects.toThrow(
+        PasskeyProcessCanceled
+      );
+    });
+
+    it("should throw PasskeyProcessCanceled when credential is null", async () => {
+      Object.defineProperty(global.navigator, "credentials", {
+        value: {
+          create: jest.fn().mockResolvedValue(null),
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      await expect(createKey("test-user.testnet")).rejects.toThrow(
+        PasskeyProcessCanceled
+      );
+    });
+
+    it("should store credential data when storage is provided", async () => {
+      const mockStorage = {
+        getItem: jest.fn(),
+        setItem: jest.fn().mockResolvedValue(undefined),
+        removeItem: jest.fn(),
+      };
+
+      Object.defineProperty(global.navigator, "credentials", {
+        value: {
+          create: jest.fn().mockResolvedValue(mockCredential),
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      const keyPair = await createKey("test-user.testnet", mockStorage);
+
+      expect(mockStorage.setItem).toHaveBeenCalledWith(
+        "webauthn_credential_test-user.testnet",
+        expect.objectContaining({
+          publicKey: expect.any(String),
+        })
+      );
+      expect(keyPair).toBeDefined();
+    });
+  });
+
+  describe("getKeys", () => {
+    it("should throw error when WebAuthn is not supported", async () => {
+      const originalNavigator = global.navigator;
+      Object.defineProperty(global, "navigator", {
+        value: {},
+        writable: true,
+        configurable: true,
+      });
+
+      await expect(getKeys("test-user.testnet")).rejects.toThrow(
+        "WebAuthn is not supported in this browser"
+      );
+
+      // Restore
+      Object.defineProperty(global, "navigator", {
+        value: originalNavigator,
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    it("should return array of keypairs when credential is retrieved", async () => {
+      Object.defineProperty(global.navigator, "credentials", {
+        value: {
+          get: jest.fn().mockResolvedValue(mockCredential),
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      global.crypto.getRandomValues = jest.fn((arr) => arr);
+
+      const keys = await getKeys("test-user.testnet");
+
+      expect(Array.isArray(keys)).toBe(true);
+      expect(keys.length).toBe(1);
+      expect(keys[0].getPublicKey()).toBeDefined();
+    });
+
+    it("should throw PasskeyProcessCanceled when user cancels", async () => {
+      const notAllowedError = new Error("User cancelled");
+      notAllowedError.name = "NotAllowedError";
+
+      Object.defineProperty(global.navigator, "credentials", {
+        value: {
+          get: jest.fn().mockRejectedValue(notAllowedError),
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      await expect(getKeys("test-user.testnet")).rejects.toThrow(
+        PasskeyProcessCanceled
+      );
+    });
+
+    it("should throw PasskeyProcessCanceled when accountId is missing", async () => {
+      Object.defineProperty(global.navigator, "credentials", {
+        value: {
+          get: jest.fn().mockResolvedValue({
+            rawId: new Uint8Array(32).buffer,
+            response: {
+              userHandle: new Uint8Array(0), // Empty user handle will result in empty accountId
+              authenticatorData: new ArrayBuffer(0),
+              signature: new ArrayBuffer(0),
+              clientDataJSON: new ArrayBuffer(0),
+            },
+          }),
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      await expect(getKeys("test-user.testnet")).rejects.toThrow(
+        PasskeyProcessCanceled
+      );
+    });
+  });
+});

--- a/packages/webauthn-wallet/src/lib/webauthn-wallet.spec.ts
+++ b/packages/webauthn-wallet/src/lib/webauthn-wallet.spec.ts
@@ -1,0 +1,262 @@
+/* eslint-disable @nx/enforce-module-boundaries, @typescript-eslint/no-explicit-any*/
+import { mock } from "jest-mock-extended";
+import { mockWallet } from "../../../core/src/lib/testUtils";
+import type { MockWalletDependencies } from "../../../core/src/lib/testUtils";
+import type { InjectedWallet } from "@near-wallet-selector/core";
+import type { ProviderService } from "../../../core/src/lib/services";
+import { setupWebAuthnWallet } from "./index";
+import * as webauthnUtils from "./webauthn-utils";
+import {
+  SignInModal,
+  TransactionModal,
+  MessageSigningModal,
+} from "./components";
+
+const accountId = "test-account.testnet";
+const publicKey = "ed25519:GF7tLvSzcxX4EtrMFtGvGTb2yUj2DhL8hWzc97BwUkyC";
+
+// Mock the webauthn-utils module
+jest.mock("./webauthn-utils", () => ({
+  isPassKeyAvailable: jest.fn().mockResolvedValue(true),
+  createKey: jest.fn(),
+  getKeys: jest.fn(),
+}));
+
+// Mock the components
+jest.mock("./components", () => ({
+  SignInModal: jest.fn(),
+  TransactionModal: jest.fn(),
+  MessageSigningModal: jest.fn(),
+  DelegateActionModal: jest.fn(),
+}));
+
+const mockKeyPair = {
+  getPublicKey: jest.fn().mockReturnValue({
+    toString: jest.fn().mockReturnValue(publicKey),
+  }),
+  sign: jest.fn(),
+};
+
+const createWebAuthnWallet = async (deps: MockWalletDependencies = {}) => {
+  const { wallet, storage } = await mockWallet<InjectedWallet>(
+    setupWebAuthnWallet({
+      relayerUrl: "https://test-relayer.example.com",
+    }),
+    deps
+  );
+
+  return {
+    wallet,
+    storage,
+  };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  // Setup default mock implementations
+  (webauthnUtils.isPassKeyAvailable as jest.Mock).mockResolvedValue(true);
+  (webauthnUtils.createKey as jest.Mock).mockResolvedValue(mockKeyPair);
+  (webauthnUtils.getKeys as jest.Mock).mockResolvedValue([mockKeyPair]);
+
+  // Mock SignInModal
+  (SignInModal as jest.Mock).mockImplementation(({ onSubmit }) => ({
+    show: jest.fn(() => {
+      // Simulate user submitting account ID
+      setTimeout(() => onSubmit(accountId, false), 0);
+    }),
+    close: jest.fn(),
+  }));
+
+  // Mock TransactionModal
+  (TransactionModal as jest.Mock).mockImplementation(({ onApprove }) => ({
+    show: jest.fn(() => {
+      // Simulate user approving transaction
+      setTimeout(() => onApprove(), 0);
+    }),
+    close: jest.fn(),
+  }));
+
+  // Mock MessageSigningModal
+  (MessageSigningModal as jest.Mock).mockImplementation(({ onApprove }) => ({
+    show: jest.fn(() => {
+      // Simulate user approving message signing
+      setTimeout(() => onApprove(), 0);
+    }),
+    close: jest.fn(),
+  }));
+});
+
+afterEach(() => {
+  jest.resetModules();
+});
+
+describe("WebAuthn Wallet - Core Functionality", () => {
+  describe("signIn", () => {
+    it("should successfully sign in with new account", async () => {
+      const { wallet } = await createWebAuthnWallet();
+
+      // Mock fetch for relayer
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: true }),
+      }) as jest.Mock;
+
+      const accounts = await wallet.signIn({ contractId: "test.testnet" });
+
+      expect(accounts).toHaveLength(1);
+      expect(accounts[0].accountId).toBe(accountId);
+    });
+
+    it("should successfully sign in with existing account", async () => {
+      const mockProvider = mock<ProviderService>();
+      mockProvider.query.mockResolvedValue({
+        keys: [{ public_key: publicKey }],
+      } as any);
+
+      const { wallet } = await createWebAuthnWallet({
+        provider: mockProvider,
+      });
+
+      const accounts = await wallet.signIn({ contractId: "test.testnet" });
+
+      expect(accounts).toHaveLength(1);
+      expect(accounts[0].accountId).toBe(accountId);
+    });
+  });
+
+  describe("signOut", () => {
+    it("should successfully sign out", async () => {
+      const mockProvider = mock<ProviderService>();
+      mockProvider.query.mockResolvedValue({
+        keys: [{ public_key: publicKey }],
+      } as any);
+
+      const { wallet } = await createWebAuthnWallet({
+        provider: mockProvider,
+      });
+
+      // Sign in first
+      await wallet.signIn({ contractId: "test.testnet" });
+
+      // Then sign out
+      await wallet.signOut();
+
+      // Verify account is cleared
+      const accounts = await wallet.getAccounts();
+      expect(accounts).toHaveLength(0);
+    });
+  });
+
+  describe("getAccounts", () => {
+    it("should return empty array when not signed in", async () => {
+      const { wallet } = await createWebAuthnWallet();
+
+      const accounts = await wallet.getAccounts();
+
+      expect(accounts).toEqual([]);
+    });
+
+    it("should return account array when signed in", async () => {
+      const mockProvider = mock<ProviderService>();
+      mockProvider.query.mockResolvedValue({
+        keys: [{ public_key: publicKey }],
+      } as any);
+
+      const { wallet } = await createWebAuthnWallet({
+        provider: mockProvider,
+      });
+
+      await wallet.signIn({ contractId: "test.testnet" });
+      const accounts = await wallet.getAccounts();
+
+      expect(accounts).toHaveLength(1);
+      expect(accounts[0].accountId).toBe(accountId);
+    });
+  });
+
+  describe("signAndSendTransaction", () => {
+    it("should throw error when not signed in", async () => {
+      const { wallet } = await createWebAuthnWallet();
+
+      await expect(
+        wallet.signAndSendTransaction({
+          signerId: accountId,
+          receiverId: "test.testnet",
+          actions: [],
+        })
+      ).rejects.toThrow("No account signed in");
+    });
+  });
+
+  describe("signAndSendTransactions", () => {
+    it("should throw error when not signed in", async () => {
+      const { wallet } = await createWebAuthnWallet();
+
+      await expect(
+        wallet.signAndSendTransactions({
+          transactions: [
+            {
+              signerId: accountId,
+              receiverId: "test.testnet",
+              actions: [],
+            },
+          ],
+        })
+      ).rejects.toThrow("No account signed in");
+    });
+  });
+
+  describe("signMessage", () => {
+    it("should throw error when not signed in", async () => {
+      const { wallet } = await createWebAuthnWallet();
+
+      // Create a proper 32-byte nonce buffer
+      const nonce = Buffer.alloc(32);
+
+      await expect(
+        wallet.signMessage!({
+          message: "test message",
+          nonce: nonce,
+          recipient: "test.app",
+        })
+      ).rejects.toThrow("No account signed in");
+    });
+  });
+
+  describe("getPublicKey", () => {
+    it("should throw error when not signed in", async () => {
+      const { wallet } = await createWebAuthnWallet();
+
+      await expect(wallet.getPublicKey()).rejects.toThrow(
+        "No account signed in"
+      );
+    });
+
+    it("should return public key when signed in", async () => {
+      const mockProvider = mock<ProviderService>();
+      mockProvider.query.mockResolvedValue({
+        keys: [{ public_key: publicKey }],
+      } as any);
+
+      const { wallet } = await createWebAuthnWallet({
+        provider: mockProvider,
+      });
+
+      await wallet.signIn({ contractId: "test.testnet" });
+      const pk = await wallet.getPublicKey();
+
+      expect(pk.toString()).toBe(publicKey);
+    });
+  });
+
+  describe("WebAuthn support check", () => {
+    it("should throw error when WebAuthn is not supported", async () => {
+      (webauthnUtils.isPassKeyAvailable as jest.Mock).mockResolvedValue(false);
+
+      await expect(createWebAuthnWallet()).rejects.toThrow(
+        "WebAuthn is not supported in this browser"
+      );
+    });
+  });
+});


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to NEAR JavaScript API here: https://github.com/near/wallet-selector/blob/main/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/near/wallet-selector/blob/main/CONTRIBUTING.md).
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [x] **If this is a code change**: I have written unit tests.
- [ ] **If this changes code in a published package**: I have run `pnpm changeset` to create a `changeset` JSON document appropriate for this change.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation
This PR adds comprehensive unit test coverage for wallet packages

### Unit Tests
- Added unit tests for `hot-wallet` package
- Added unit tests for `webauthn-wallet` package
  - Tests for `webauthn-wallet.spec.ts`
  - Tests for `webauthn-utils.spec.ts`
  - Tests for `utils.spec.ts`
- Added Babel configuration for `webauthn-wallet` to support Jest testing
- Added Jest setup file for `webauthn-wallet`